### PR TITLE
fix(hooks): use .sh scripts on Windows to fix hook and status line errors

### DIFF
--- a/src/main/claude/ClaudeSessionManager.ts
+++ b/src/main/claude/ClaudeSessionManager.ts
@@ -161,14 +161,16 @@ export class ClaudeSessionManager {
     this.busySessions.clear()
   }
 
-  private getHookScriptPath(): string {
-    const scriptName =
-      process.platform === 'win32' ? 'canopy-claude-hook.cmd' : 'canopy-claude-hook.sh'
+  /** Resolve a resource script path, using forward slashes on Windows for bash compatibility */
+  private getResourceScript(name: string): string {
+    const raw = is.dev
+      ? join(process.cwd(), 'resources', name)
+      : join(process.resourcesPath, 'app.asar.unpacked', 'resources', name)
+    return process.platform === 'win32' ? raw.replaceAll('\\', '/') : raw
+  }
 
-    if (is.dev) {
-      return join(process.cwd(), 'resources', scriptName)
-    }
-    return join(process.resourcesPath, 'app.asar.unpacked', 'resources', scriptName)
+  private getHookScriptPath(): string {
+    return this.getResourceScript('canopy-claude-hook.sh')
   }
 
   private buildSettingsJson(overrides?: Record<string, unknown>): string {
@@ -232,12 +234,7 @@ export class ClaudeSessionManager {
   }
 
   private getStatusLineScriptPath(): string {
-    const scriptName =
-      process.platform === 'win32' ? 'canopy-statusline.cmd' : 'canopy-statusline.sh'
-    if (is.dev) {
-      return join(process.cwd(), 'resources', scriptName)
-    }
-    return join(process.resourcesPath, 'app.asar.unpacked', 'resources', scriptName)
+    return this.getResourceScript('canopy-statusline.sh')
   }
 
   private buildSessionContext(


### PR DESCRIPTION
## Summary

- Use `.sh` hook/status scripts on all platforms (including Windows) since Claude Code runs hooks via bash
- Extract shared `getResourceScript()` helper for path resolution with forward-slash conversion on Windows
- Fixes JSON double-quote quoting issue in `.cmd` scripts that caused hook errors and broken status line