### PR TITLE
fix(notch): eliminate first-hover FPS drop

### DIFF
--- a/src/main/notch/NotchOverlayManager.ts
+++ b/src/main/notch/NotchOverlayManager.ts
@@ -108,6 +108,7 @@ export class NotchOverlayManager {
       webPreferences: {
         preload: join(__dirname, '../preload/notch.js'),
         sandbox: true,
+        backgroundThrottling: false,
       },
     })
 

--- a/src/renderer/src/components/notch/NotchOverlay.svelte
+++ b/src/renderer/src/components/notch/NotchOverlay.svelte
@@ -185,6 +185,8 @@
     border-radius: 0 0 16px 16px;
     overflow: hidden;
     cursor: default;
+    contain: layout style;
+    will-change: width, height, box-shadow;
     transition:
       width 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.1),
       height 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.1),


### PR DESCRIPTION
## Summary
- Disable `backgroundThrottling` on the notch BrowserWindow so Chromium stops throttling the unfocusable renderer to ~1fps, eliminating the "wake up" stall on first hover
- Add `will-change: width, height, box-shadow` to pre-promote the GPU compositor layer and pre-compile the box-shadow blur shader
- Add `contain: layout style` to limit layout recalculation scope during expand/collapse transitions

## Test plan
- [ ] `npm run dev`, start a Claude session so the notch appears
- [ ] Hover the notch for the first time — should no longer have a visible FPS drop
- [ ] Hover/unhover repeatedly — animations remain smooth
- [ ] `npm run typecheck` and `npm run svelte-check` pass