### PR TITLE
fix(notch): remove 5-item cap and fix height calculation in agent list

### DIFF
--- a/src/main/notch/NotchOverlayManager.ts
+++ b/src/main/notch/NotchOverlayManager.ts
@@ -8,7 +8,7 @@ import type { NotchSessionStatus, NotchOverlayState, SessionStatusType } from '.
 // Window is oversized so CSS animations can expand freely inside it.
 // Transparent pixels are click-through on macOS.
 const WINDOW_WIDTH = 560
-const WINDOW_HEIGHT = 500
+const WINDOW_HEIGHT = 650
 
 export class NotchOverlayManager {
   private overlayWindow: BrowserWindow | null = null

--- a/src/renderer/src/components/notch/NotchNotificationRow.svelte
+++ b/src/renderer/src/components/notch/NotchNotificationRow.svelte
@@ -80,6 +80,8 @@
     display: flex;
     align-items: center;
     gap: 10px;
+    height: 48px;
+    box-sizing: border-box;
     padding: 8px 12px;
     margin: 0 6px;
     width: calc(100% - 12px);

--- a/src/renderer/src/components/notch/NotchOverlay.svelte
+++ b/src/renderer/src/components/notch/NotchOverlay.svelte
@@ -85,8 +85,11 @@
       ? state.sessions.filter((s) => peekSessionIds.has(s.ptySessionId))
       : state.sessions,
   )
-  const itemCount = $derived(Math.min(visibleSessions.length, 5))
-  const expandedHeight = $derived(collapsedHeight + itemCount * 56 + 12)
+  const ROW_HEIGHT = 48
+  const CONTENT_PADDING = 6
+  const MAX_VISIBLE_ROWS = 12
+  const visibleItemCount = $derived(Math.min(visibleSessions.length, MAX_VISIBLE_ROWS))
+  const expandedHeight = $derived(collapsedHeight + visibleItemCount * ROW_HEIGHT + CONTENT_PADDING)
   const gapWidth = $derived(showExpanded ? 480 - 80 : state.notchWidth)
 
   function handleMouseEnter(): void {
@@ -157,7 +160,7 @@
     </div>
 
     <div class="content">
-      {#each visibleSessions.slice(0, 5) as session (session.ptySessionId)}
+      {#each visibleSessions as session (session.ptySessionId)}
         <NotchNotificationRow
           {session}
           highlight={peekSessionIds.has(session.ptySessionId)}
@@ -180,6 +183,8 @@
 
   .island {
     position: relative;
+    display: flex;
+    flex-direction: column;
     margin: 0 auto;
     background: #000;
     border-radius: 0 0 16px 16px;
@@ -261,6 +266,22 @@
 
   .content {
     padding: 0 0 6px;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .content::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  .content::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 2px;
+  }
+
+  .content::-webkit-scrollbar-track {
+    background: transparent;
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Removed hardcoded 5-session limit — all agents now render in the notch overlay
- Fixed expanded height formula: corrected row height (56→48px) and padding (12→6px) to eliminate growing gap at bottom
- Added scroll overflow with thin scrollbar for 12+ sessions
- Increased overlay window height from 500→650px to accommodate more items

## Test plan
- [ ] Open 5+ worktrees with Claude sessions — verify all appear in notch list
- [ ] Verify no gap between last item and bottom of the island
- [ ] Verify smooth expand/collapse animation
- [ ] Verify scrolling works when 13+ agents are running