### PR TITLE
fix(terminal): preserve scroll position when new content arrives

### DIFF
--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -140,6 +140,7 @@
     // Write batching: coalesce rapid WebSocket messages into one term.write() per frame
     let pendingData = ''
     let writeScheduled = false
+    let writeRafId: number | null = null
 
     function scrollPreservingWrite(term: Terminal, data: string): void {
       const buffer = term.buffer.active
@@ -173,7 +174,8 @@
         pendingData += e.data
         if (!writeScheduled) {
           writeScheduled = true
-          requestAnimationFrame(() => {
+          writeRafId = requestAnimationFrame(() => {
+            writeRafId = null
             const chunk = pendingData
             pendingData = ''
             writeScheduled = false
@@ -336,6 +338,7 @@
     return () => {
       disposed = true
       clearConnectionStatus(sessionId)
+      if (writeRafId !== null) cancelAnimationFrame(writeRafId)
       if (reconnectTimer) clearTimeout(reconnectTimer)
       if (dataDisposable) dataDisposable.dispose()
       const term = termRef


### PR DESCRIPTION
## Summary

- Fixes scroll jumping to top when user is scrolled up and new terminal output arrives (xterm.js v6 `DomScrollableElement` regression)
- Preserves `viewportY` before `term.write()` and restores it in the write callback when user is scrolled up
- Coalesces rapid WebSocket messages into a single `term.write()` per animation frame to reduce viewport churn during streaming output (e.g. Claude Code)
- Applies the same scroll preservation around `fitAddon.fit()` during resize

## Test plan

- [ ] `npm run dev` — start the app
- [ ] Open a terminal, run a command with streaming output (e.g. Claude Code or `cat` a large file)
- [ ] Scroll up slightly while output is streaming — position should stay stable
- [ ] Scroll back to bottom — auto-follow should resume
- [ ] Resize the window while scrolled up — position should be preserved