### PR TITLE
fix(menu): add Preferences item to macOS app menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -144,6 +144,12 @@ function buildAppMenu(): void {
             submenu: [
               { label: 'About Canopy', click: showAboutClick },
               { type: 'separator' as const },
+              {
+                label: 'Preferences…',
+                accelerator: 'CmdOrCtrl+,',
+                click: showPreferencesClick,
+              },
+              { type: 'separator' as const },
               { role: 'hide' as const },
               { role: 'hideOthers' as const },
               { role: 'unhide' as const },


### PR DESCRIPTION
## Summary
- Add "Preferences..." menu item with `Cmd+,` to the macOS app submenu, between "About Canopy" and "Hide"
- Reuses existing `showPreferencesClick` handler that was only wired to the File menu on non-macOS platforms

## Test plan
- [ ] Open the Canopy app menu on macOS, confirm "Preferences..." appears with ⌘, shortcut
- [ ] Click it or press Cmd+, to confirm the preferences modal opens
- [ ] Verify non-macOS menu is unchanged