### PR TITLE
feat(pty): truecolor support for terminals

### DIFF
--- a/src/main/pty/PtyManager.ts
+++ b/src/main/pty/PtyManager.ts
@@ -48,6 +48,8 @@ export class PtyManager {
     const baseEnv = {
       ...(getLoginEnv() ?? process.env),
       TERM_PROGRAM: 'canopy',
+      COLORTERM: 'truecolor',
+      TERM: 'xterm-256color',
     } as Record<string, string>
     const env = options?.env ? { ...baseEnv, ...options.env } : baseEnv
 


### PR DESCRIPTION
## Summary
- Set `COLORTERM=truecolor` and `TERM=xterm-256color` env vars in PTY base environment so programs detect 24-bit color support

## Test plan
- [ ] Open a terminal tab and verify `echo $COLORTERM` outputs `truecolor`
- [ ] Verify `echo $TERM` outputs `xterm-256color`
- [ ] Confirm programs like `bat`, `delta`, or `ls --color` render truecolor output