### PR TITLE
feat(sidebar): add "New Worktree from Branch" to context menu

### DIFF
--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -399,6 +399,7 @@
     onClose={closeDialog}
     repoRoot={dialogState.current.repoRoot}
     workspaceId={dialogState.current.workspaceId}
+    baseBranch={dialogState.current.baseBranch}
   />
 {:else if dialogState.current.type === 'preferences'}
   <PreferencesModal />

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -228,6 +228,17 @@
     closeCtxMenu()
   }
 
+  function ctxNewWorktree(): void {
+    if (!ctxMenu) return
+    const { project, wt } = ctxMenu
+    closeCtxMenu()
+    showCreateWorktree({
+      repoRoot: project.repoRoot!,
+      workspaceId: project.workspace.id,
+      baseBranch: wt.branch,
+    })
+  }
+
   async function ctxStopAll(): Promise<void> {
     if (!ctxMenu) return
     const tabs = getTabsForWorktree(ctxMenu.wt.path)
@@ -290,6 +301,8 @@
       <button class="ctx-item" onclick={ctxCopyPath}>Copy Path</button>
       {#if ctxMenu.wt.branch !== '(detached)'}
         <button class="ctx-item" onclick={ctxCopyBranch}>Copy Branch Name</button>
+        <div class="ctx-divider"></div>
+        <button class="ctx-item" onclick={ctxNewWorktree}>New Worktree from Branch</button>
       {/if}
       {#if isWorktreeActive(ctxMenu.wt.path)}
         <div class="ctx-divider"></div>

--- a/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
+++ b/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
@@ -7,10 +7,12 @@
     onClose,
     repoRoot: repoRootProp,
     workspaceId: workspaceIdProp,
+    baseBranch: baseBranchProp,
   }: {
     onClose: () => void
     repoRoot?: string
     workspaceId?: string
+    baseBranch?: string
   } = $props()
 
   type Step = 'loading' | 'pickBase' | 'creating' | 'setup' | 'done' | 'error'
@@ -54,6 +56,9 @@
     try {
       const list = await window.api.gitBranches(repoRoot)
       branches = { local: list.local, remote: list.remote }
+      if (baseBranchProp) {
+        selectedBase = baseBranchProp
+      }
       step = 'pickBase'
     } catch (e) {
       errorMessage = e instanceof Error ? e.message : String(e)

--- a/src/renderer/src/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/src/lib/stores/dialogs.svelte.ts
@@ -41,6 +41,7 @@ interface CreateWorktreeState {
   type: 'createWorktree'
   repoRoot?: string
   workspaceId?: string
+  baseBranch?: string
 }
 
 interface PreferencesState {
@@ -109,11 +110,16 @@ export function prompt(opts: PromptOptions): Promise<PromptResult | null> {
   })
 }
 
-export function showCreateWorktree(opts?: { repoRoot?: string; workspaceId?: string }): void {
+export function showCreateWorktree(opts?: {
+  repoRoot?: string
+  workspaceId?: string
+  baseBranch?: string
+}): void {
   dialogState.current = {
     type: 'createWorktree',
     repoRoot: opts?.repoRoot,
     workspaceId: opts?.workspaceId,
+    baseBranch: opts?.baseBranch,
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds "New Worktree from Branch" option to the worktree right-click context menu in the sidebar
- Clicking it opens the Create Worktree modal with the base branch pre-filled, skipping the branch picker step
- Threads a `baseBranch` parameter through dialog store, MainLayout, and CreateWorktreeModal

## Test plan
- [ ] Right-click a worktree in the sidebar, verify "New Worktree from Branch" appears after "Copy Branch Name"
- [ ] Click it, verify modal opens with base branch pre-selected (shows new branch name input directly)
- [ ] Verify the option does not appear for detached HEAD worktrees
- [ ] Verify existing "New Worktree" flows (command palette, `+ new` button) still work without pre-selection