### PR TITLE
fix(terminal): restore focus after file drop and screenshot delivery

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -296,6 +296,13 @@ export function registerIpcHandlers(
     return false
   })
 
+  ipcMain.handle('app:focusRendererWebContents', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (win && !win.isDestroyed()) {
+      win.webContents.focus()
+    }
+  })
+
   // --- Dialog ---
 
   ipcMain.handle('dialog:openFolder', async (event) => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -275,6 +275,7 @@ interface CanopyAPI {
   setWorkspacePath: (path: string) => Promise<void>
   detachProject: (path: string) => Promise<void>
   focusWindowForPath: (path: string) => Promise<boolean>
+  focusRendererWebContents: () => Promise<void>
   setFocusedAgentSession: (ptySessionId: string | null) => Promise<void>
 
   // Dialog

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -160,6 +160,7 @@ const api = {
   detachProject: (path: string) => ipcRenderer.invoke('app:detachProject', { path }),
   focusWindowForPath: (path: string) =>
     ipcRenderer.invoke('app:focusWindowForPath', { path }) as Promise<boolean>,
+  focusRendererWebContents: () => ipcRenderer.invoke('app:focusRendererWebContents'),
 
   // Dialog
   openFolder: () => ipcRenderer.invoke('dialog:openFolder'),

--- a/src/renderer/src/components/browser/BrowserPane.svelte
+++ b/src/renderer/src/components/browser/BrowserPane.svelte
@@ -248,6 +248,9 @@
     window.dispatchEvent(new CustomEvent('canopy:unfreeze-browsers'))
     window.api.writePty(sessionId, payload)
     focusSessionByPtyId(sessionId)
+    window.api.focusRendererWebContents().then(() => {
+      window.dispatchEvent(new CustomEvent('canopy:focus-terminal', { detail: { sessionId } }))
+    })
   }
 
   function handlePickerSelect(sessionId: string): void {

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -65,6 +65,20 @@
     }
   })
 
+  // Listen for imperative focus requests (e.g. after browser screenshot delivery)
+  $effect(() => {
+    if (!termRef) return
+    const term = termRef
+    const handler = (e: Event): void => {
+      const detail = (e as CustomEvent<{ sessionId: string }>).detail
+      if (detail.sessionId === sessionId) {
+        requestAnimationFrame(() => term.focus())
+      }
+    }
+    window.addEventListener('canopy:focus-terminal', handler)
+    return () => window.removeEventListener('canopy:focus-terminal', handler)
+  })
+
   // Dispose WebGL addon when tab becomes inactive to free GPU memory
   $effect(() => {
     if (!active && webglAddonRef) {
@@ -133,6 +147,7 @@
 
     if (paths.length > 0 && termRef) {
       termRef.paste(paths.join(' '))
+      termRef.focus()
     }
   }
 


### PR DESCRIPTION
## Summary
- Restore terminal keyboard focus after drag-and-drop file drop (`termRef.focus()` after paste)
- Reclaim OS-level focus from BrowserView after screenshot/element pick delivery via new `app:focusRendererWebContents` IPC
- Add `canopy:focus-terminal` custom event for imperative terminal focus when reactive `$effect` can't re-trigger

## Test plan
- [ ] Drag file onto terminal, verify typing works immediately without clicking
- [ ] Capture browser region, verify terminal is focused and typeable after delivery
- [ ] Pick browser element, verify same focus behavior
- [ ] Multi-session: pick session from picker, verify focus lands on selected terminal