### PR TITLE
feat(sidebar): show loading indicator when removing worktree

### DIFF
--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -137,6 +137,8 @@
       }
     }
 
+    removingPaths.delete(wt.path)
+
     if (workspaceState.selectedWorktreePath === wt.path) {
       const main = project.worktrees.find((w) => w.isMain)
       if (main) selectWorktree(main.path)
@@ -689,7 +691,8 @@
   @media (prefers-reduced-motion: reduce) {
     .wt-status-dot.working,
     .wt-status-dot.waitingPermission,
-    .wt-notify-dot.permission {
+    .wt-notify-dot.permission,
+    .removing-label {
       animation: none;
     }
   }


### PR DESCRIPTION
## Summary
- After confirming worktree removal, the row dims (45% opacity) and shows a pulsing orange "removing..." label for immediate user feedback
- Row interaction is blocked during removal via `pointer-events: none`
- If both normal and force removal fail, the row reverts to its normal state
- Consolidated duplicated removal logic from `removeWorktree` and `ctxRemoveWorktree` into shared `doRemoveWorktree`

## Test plan
- [ ] Right-click a non-main worktree → Remove Worktree → confirm → verify row dims with "removing..." label
- [ ] Click inline trash icon on a merged worktree → confirm → same behavior
- [ ] Try clicking the dimmed row during removal — should be blocked
- [ ] Verify row disappears after GitWatcher fires (~2-5s)
- [ ] `npm run typecheck` and `npm run lint` pass