### PR TITLE
Configure Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 15
+    labels:
+      - dependencies
+    commit-message:
+      prefix: 'chore(deps):'
+      prefix-development: 'chore(deps-dev):'
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: 'chore(deps):'
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly updates (Mondays) for npm and GitHub Actions ecosystems
- Minor/patch updates grouped into single PRs, major bumps stay individual for dedicated review
- Created `dependencies` repo label for dependabot PRs
- Commit messages follow conventional format (`chore(deps):` / `chore(deps-dev):`)

## Test plan
- [ ] Verify config is picked up in GitHub Settings > Code security > Dependabot
- [ ] Confirm first batch of PRs appears after next Monday