### PR TITLE
fix(file-tree): include active worktree in path validation

### DIFF
--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -169,7 +169,10 @@ export class WindowManager {
 
   getWorkspacePaths(wcId: number): string[] {
     const paths = this.workspacePaths.get(wcId)
-    return paths ? [...paths] : []
+    const result = paths ? [...paths] : []
+    const active = this.activeWorktreePaths.get(wcId)
+    if (active && !result.includes(active)) result.push(active)
+    return result
   }
 
   /** Returns one entry per window, each containing all project paths for that window */

--- a/src/renderer/src/lib/stores/workspace.svelte.ts
+++ b/src/renderer/src/lib/stores/workspace.svelte.ts
@@ -286,8 +286,8 @@ export async function selectWorktree(path: string): Promise<void> {
     workspaceState.worktrees = project.worktrees
   }
 
-  workspaceState.selectedWorktreePath = path
   window.api.setActiveWorktree(path)
+  workspaceState.selectedWorktreePath = path
 
   if (project?.isGitRepo) {
     const wt = project.worktrees.find((w) => w.path === path)


### PR DESCRIPTION
## Summary

- Include active worktree path in `getWorkspacePaths()` so `validatePathAccess` allows `readDir` calls for the currently selected worktree
- Reorder IPC call before state assignment in `selectWorktree()` to ensure the path is registered before the file tree effect fires

Fixes empty file tree when creating or switching to a worktree whose path is outside the registered workspace root.

## Test plan

- [ ] Create new worktree — file tree should populate immediately
- [ ] Switch between existing worktrees — file tree updates correctly
- [ ] Restart app with active non-main worktree — file tree loads on restore