### PR TITLE
feat(terminal): add typing speed (WPM) tracker

### DIFF
--- a/src/renderer/src/components/preferences/GeneralPrefs.svelte
+++ b/src/renderer/src/components/preferences/GeneralPrefs.svelte
@@ -4,7 +4,7 @@
 
   let reopenLast = $derived(prefs.reopenLastWorkspace !== 'false')
   let notchEnabled = $derived(prefs['notch.enabled'] === 'true')
-  let wpmEnabled = $derived(prefs['wpm.enabled'] !== 'false')
+  let wpmEnabled = $derived(prefs['wpm.enabled'] === 'true')
   let urlOpenMode = $derived(prefs.urlOpenMode || 'ask')
 
   function toggleReopen(): void {

--- a/src/renderer/src/components/preferences/GeneralPrefs.svelte
+++ b/src/renderer/src/components/preferences/GeneralPrefs.svelte
@@ -4,6 +4,7 @@
 
   let reopenLast = $derived(prefs.reopenLastWorkspace !== 'false')
   let notchEnabled = $derived(prefs['notch.enabled'] === 'true')
+  let wpmEnabled = $derived(prefs['wpm.enabled'] !== 'false')
   let urlOpenMode = $derived(prefs.urlOpenMode || 'ask')
 
   function toggleReopen(): void {
@@ -14,6 +15,10 @@
     const next = !notchEnabled
     setPref('notch.enabled', next ? 'true' : 'false')
     window.api.setNotchEnabled(next)
+  }
+
+  function toggleWpm(): void {
+    setPref('wpm.enabled', wpmEnabled ? 'false' : 'true')
   }
 </script>
 
@@ -29,6 +34,17 @@
     <input type="checkbox" checked={notchEnabled} onchange={toggleNotch} />
     <span>Show session status in notch overlay</span>
   </label>
+
+  <label class="checkbox-row">
+    <input type="checkbox" checked={wpmEnabled} onchange={toggleWpm} />
+    <span>Show typing speed (WPM) in terminals</span>
+  </label>
+  {#if wpmEnabled}
+    <div class="hint-row">
+      Tracks printable keystrokes in a 10-second sliding window. Control keys, arrows, and escape
+      sequences are excluded. Displays current WPM, peak speed, and total characters.
+    </div>
+  {/if}
 
   <div class="select-row">
     <span class="select-label">Open URLs from terminal in</span>
@@ -105,5 +121,13 @@
     color: rgba(255, 255, 255, 0.7);
     font-family: monospace;
     font-size: 12px;
+  }
+
+  .hint-row {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.4);
+    line-height: 1.5;
+    padding-left: 24px;
+    margin-top: -8px;
   }
 </style>

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -32,7 +32,7 @@
 
   let agentState = $derived(agentSessions[pane.sessionId] ?? null)
   let showInspector = $derived(pane.inspectorOpen !== false && agentState !== null)
-  let wpmEnabled = $derived(prefs['wpm.enabled'] !== 'false')
+  let wpmEnabled = $derived(prefs['wpm.enabled'] === 'true')
 
   // Whether this pane is a valid drop target
   let isValidTarget = $derived(

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -8,6 +8,8 @@
   import EditorPane from '../editor/EditorPane.svelte'
   import AgentInspector from '../agents/AgentInspector.svelte'
   import ExitBanner from './ExitBanner.svelte'
+  import WpmIndicator from './WpmIndicator.svelte'
+  import { prefs } from '../../lib/stores/preferences.svelte'
 
   let {
     pane,
@@ -30,6 +32,7 @@
 
   let agentState = $derived(agentSessions[pane.sessionId] ?? null)
   let showInspector = $derived(pane.inspectorOpen !== false && agentState !== null)
+  let wpmEnabled = $derived(prefs['wpm.enabled'] !== 'false')
 
   // Whether this pane is a valid drop target
   let isValidTarget = $derived(
@@ -108,6 +111,9 @@
             onTitleChange={(title) => updatePaneTitle(pane.sessionId, title)}
           />
         {/key}
+        {#if wpmEnabled}
+          <WpmIndicator sessionId={pane.sessionId} />
+        {/if}
         {#if !pane.isRunning}
           <ExitBanner
             exitCode={pane.exitCode}

--- a/src/renderer/src/components/terminal/WpmIndicator.svelte
+++ b/src/renderer/src/components/terminal/WpmIndicator.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import {
+    getWpm,
+    getLastActivity,
+    getSessionStats,
+    isSessionActive,
+  } from '../../lib/stores/wpmTracker.svelte'
+
+  let { sessionId }: { sessionId: string } = $props()
+
+  let visible = $state(false)
+  let fadeTimer: ReturnType<typeof setTimeout> | undefined
+  let pollTimer: ReturnType<typeof setInterval> | undefined
+  let currentWpm = $state(0)
+  let peakWpm = $state(0)
+  let active = $state(false)
+
+  $effect(() => {
+    pollTimer = setInterval(() => {
+      const wpm = getWpm(sessionId)
+      const lastActivity = getLastActivity(sessionId)
+      const stats = getSessionStats(sessionId)
+      const now = Date.now()
+      const recentlyTyped = now - lastActivity < 2500
+
+      currentWpm = wpm
+      peakWpm = stats.peakWpm
+      active = isSessionActive(sessionId)
+
+      if (active && recentlyTyped && wpm > 0) {
+        visible = true
+        clearTimeout(fadeTimer)
+        fadeTimer = setTimeout(() => {
+          visible = false
+        }, 3000)
+      }
+    }, 400)
+
+    return () => {
+      clearInterval(pollTimer)
+      clearTimeout(fadeTimer)
+    }
+  })
+</script>
+
+{#if active}
+  <div class="wpm-badge" class:visible>
+    <span class="wpm-number">{currentWpm}</span>
+    <span class="wpm-label">wpm</span>
+    {#if peakWpm > 0}
+      <span class="wpm-sep"></span>
+      <span class="wpm-peak">{peakWpm} peak</span>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .wpm-badge {
+    position: absolute;
+    bottom: 6px;
+    right: 10px;
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    padding: 4px 10px;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+    z-index: 5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wpm-badge.visible {
+    opacity: 1;
+  }
+
+  .wpm-number {
+    font-size: 13px;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    color: rgba(255, 255, 255, 0.7);
+    letter-spacing: -0.01em;
+  }
+
+  .wpm-label {
+    font-size: 10px;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.3);
+    letter-spacing: 0.02em;
+  }
+
+  .wpm-sep {
+    width: 1px;
+    height: 10px;
+    background: rgba(255, 255, 255, 0.1);
+    margin: 0 2px;
+    align-self: center;
+  }
+
+  .wpm-peak {
+    font-size: 10px;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.25);
+    letter-spacing: 0.02em;
+  }
+</style>

--- a/src/renderer/src/components/terminal/WpmIndicator.svelte
+++ b/src/renderer/src/components/terminal/WpmIndicator.svelte
@@ -1,45 +1,25 @@
 <script lang="ts">
-  import {
-    getWpm,
-    getLastActivity,
-    getSessionStats,
-    isSessionActive,
-  } from '../../lib/stores/wpmTracker.svelte'
+  import { getWpm, getSessionStats, isSessionActive } from '../../lib/stores/wpmTracker.svelte'
 
   let { sessionId }: { sessionId: string } = $props()
 
+  let currentWpm = $derived(getWpm(sessionId))
+  let stats = $derived(getSessionStats(sessionId))
+  let active = $derived(isSessionActive(sessionId))
+
   let visible = $state(false)
   let fadeTimer: ReturnType<typeof setTimeout> | undefined
-  let pollTimer: ReturnType<typeof setInterval> | undefined
-  let currentWpm = $state(0)
-  let peakWpm = $state(0)
-  let active = $state(false)
 
   $effect(() => {
-    pollTimer = setInterval(() => {
-      const wpm = getWpm(sessionId)
-      const lastActivity = getLastActivity(sessionId)
-      const stats = getSessionStats(sessionId)
-      const now = Date.now()
-      const recentlyTyped = now - lastActivity < 2500
-
-      currentWpm = wpm
-      peakWpm = stats.peakWpm
-      active = isSessionActive(sessionId)
-
-      if (active && recentlyTyped && wpm > 0) {
-        visible = true
-        clearTimeout(fadeTimer)
-        fadeTimer = setTimeout(() => {
-          visible = false
-        }, 3000)
-      }
-    }, 400)
-
-    return () => {
-      clearInterval(pollTimer)
+    if (currentWpm > 0 && active) {
+      visible = true
       clearTimeout(fadeTimer)
+      fadeTimer = setTimeout(() => {
+        visible = false
+      }, 3000)
     }
+
+    return () => clearTimeout(fadeTimer)
   })
 </script>
 
@@ -47,9 +27,9 @@
   <div class="wpm-badge" class:visible>
     <span class="wpm-number">{currentWpm}</span>
     <span class="wpm-label">wpm</span>
-    {#if peakWpm > 0}
+    {#if stats.peakWpm > 0}
       <span class="wpm-sep"></span>
-      <span class="wpm-peak">{peakWpm} peak</span>
+      <span class="wpm-peak">{stats.peakWpm} peak</span>
     {/if}
   </div>
 {/if}
@@ -70,6 +50,12 @@
     transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1);
     z-index: 5;
     -webkit-font-smoothing: antialiased;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .wpm-badge {
+      transition: none;
+    }
   }
 
   .wpm-badge.visible {

--- a/src/renderer/src/lib/stores/wpmTracker.svelte.ts
+++ b/src/renderer/src/lib/stores/wpmTracker.svelte.ts
@@ -38,7 +38,7 @@ function countPrintable(data: string): number {
 }
 
 export function recordKeystroke(sessionId: string, data: string): void {
-  if (getPref('wpm.enabled') === 'false') return
+  if (getPref('wpm.enabled') !== 'true') return
 
   const printable = countPrintable(data)
   if (printable === 0) return

--- a/src/renderer/src/lib/stores/wpmTracker.svelte.ts
+++ b/src/renderer/src/lib/stores/wpmTracker.svelte.ts
@@ -1,0 +1,117 @@
+import { SvelteMap } from 'svelte/reactivity'
+import { getPref } from './preferences.svelte'
+
+const WINDOW_MS = 10_000
+const CLEANUP_INTERVAL_MS = 5_000
+const CHARS_PER_WORD = 5
+/** Minimum printable chars before we consider the session "active" */
+const MIN_CHARS_TO_ACTIVATE = 5
+/** Minimum keystrokes within the window to show WPM (filters startup noise) */
+const MIN_WINDOW_CHARS = 3
+
+interface SessionData {
+  timestamps: number[]
+  lastActivity: number
+  totalChars: number
+  sessionStart: number
+  peakWpm: number
+}
+
+const sessions = new SvelteMap<string, SessionData>()
+
+const wpmValues: Record<string, number> = $state({})
+
+/** Only count real keystrokes — skip escape sequences (mouse events, arrows, function keys) */
+function countPrintable(data: string): number {
+  // Escape sequences (mouse reports, arrow keys, function keys) start with \x1b
+  if (data.charCodeAt(0) === 0x1b) return 0
+  // Single control chars (Enter, Tab, Backspace, Ctrl+C, etc.)
+  if (data.length === 1 && data.charCodeAt(0) < 32) return 0
+
+  let count = 0
+  for (let i = 0; i < data.length; i++) {
+    const code = data.charCodeAt(i)
+    if (code >= 32 && code < 127) count++
+    else if (code > 127) count++
+  }
+  return count
+}
+
+export function recordKeystroke(sessionId: string, data: string): void {
+  if (getPref('wpm.enabled', 'true') !== 'true') return
+
+  const printable = countPrintable(data)
+  if (printable === 0) return
+
+  const now = Date.now()
+  let session = sessions.get(sessionId)
+  if (!session) {
+    session = { timestamps: [], lastActivity: now, totalChars: 0, sessionStart: now, peakWpm: 0 }
+    sessions.set(sessionId, session)
+  }
+
+  for (let i = 0; i < printable; i++) {
+    session.timestamps.push(now)
+  }
+  session.lastActivity = now
+  session.totalChars += printable
+
+  // Trim old timestamps outside window
+  const cutoff = now - WINDOW_MS
+  const idx = session.timestamps.findIndex((t) => t >= cutoff)
+  if (idx > 0) session.timestamps.splice(0, idx)
+
+  // Need enough data points for a meaningful WPM reading
+  if (session.timestamps.length < MIN_WINDOW_CHARS) {
+    wpmValues[sessionId] = 0
+    return
+  }
+
+  const chars = session.timestamps.length
+  const elapsed = Math.min(now - session.timestamps[0], WINDOW_MS)
+  const minutes = elapsed / 60_000
+  const wpm = minutes > 0 ? Math.round(chars / CHARS_PER_WORD / minutes) : 0
+  wpmValues[sessionId] = wpm
+
+  if (wpm > session.peakWpm) session.peakWpm = wpm
+}
+
+export function getWpm(sessionId: string): number {
+  return wpmValues[sessionId] ?? 0
+}
+
+export function getLastActivity(sessionId: string): number {
+  return sessions.get(sessionId)?.lastActivity ?? 0
+}
+
+export function isSessionActive(sessionId: string): boolean {
+  const session = sessions.get(sessionId)
+  return !!session && session.totalChars >= MIN_CHARS_TO_ACTIVATE
+}
+
+export function getSessionStats(sessionId: string): {
+  totalChars: number
+  peakWpm: number
+} {
+  const session = sessions.get(sessionId)
+  if (!session) return { totalChars: 0, peakWpm: 0 }
+  return {
+    totalChars: session.totalChars,
+    peakWpm: session.peakWpm,
+  }
+}
+
+export function cleanupSession(sessionId: string): void {
+  sessions.delete(sessionId)
+  delete wpmValues[sessionId]
+}
+
+setInterval(() => {
+  const now = Date.now()
+  for (const [id, session] of sessions) {
+    if (now - session.lastActivity > 30_000) {
+      sessions.delete(id)
+      delete wpmValues[id]
+    }
+  }
+}, CLEANUP_INTERVAL_MS)

--- a/src/renderer/src/lib/stores/wpmTracker.svelte.ts
+++ b/src/renderer/src/lib/stores/wpmTracker.svelte.ts
@@ -126,3 +126,7 @@ export function stopCleanupTimer(): void {
 }
 
 startCleanupTimer()
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => stopCleanupTimer())
+}

--- a/src/renderer/src/lib/stores/wpmTracker.svelte.ts
+++ b/src/renderer/src/lib/stores/wpmTracker.svelte.ts
@@ -38,7 +38,7 @@ function countPrintable(data: string): number {
 }
 
 export function recordKeystroke(sessionId: string, data: string): void {
-  if (getPref('wpm.enabled', 'true') !== 'true') return
+  if (getPref('wpm.enabled') === 'false') return
 
   const printable = countPrintable(data)
   if (printable === 0) return
@@ -106,12 +106,23 @@ export function cleanupSession(sessionId: string): void {
   delete wpmValues[sessionId]
 }
 
-setInterval(() => {
-  const now = Date.now()
-  for (const [id, session] of sessions) {
-    if (now - session.lastActivity > 30_000) {
-      sessions.delete(id)
-      delete wpmValues[id]
+let cleanupIntervalId: ReturnType<typeof setInterval> | undefined
+
+export function startCleanupTimer(): void {
+  stopCleanupTimer()
+  cleanupIntervalId = setInterval(() => {
+    const now = Date.now()
+    for (const [id, session] of sessions) {
+      if (now - session.lastActivity > 30_000) {
+        sessions.delete(id)
+        delete wpmValues[id]
+      }
     }
-  }
-}, CLEANUP_INTERVAL_MS)
+  }, CLEANUP_INTERVAL_MS)
+}
+
+export function stopCleanupTimer(): void {
+  clearInterval(cleanupIntervalId)
+}
+
+startCleanupTimer()

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -13,7 +13,7 @@
   import { openTool } from '../stores/tabs.svelte'
   import { workspaceState } from '../stores/workspace.svelte'
   import { setConnectionStatus, clearConnectionStatus } from './connectionState.svelte'
-  import { recordKeystroke } from '../stores/wpmTracker.svelte'
+  import { recordKeystroke, cleanupSession } from '../stores/wpmTracker.svelte'
 
   const DEFAULT_FONT_FAMILY =
     'JetBrains Mono, JetBrainsMono Nerd Font, JetBrainsMono NF, FiraCode Nerd Font, Fira Code, Menlo, monospace'
@@ -370,6 +370,7 @@
     return () => {
       disposed = true
       clearConnectionStatus(sessionId)
+      cleanupSession(sessionId)
       if (writeRafId !== null) cancelAnimationFrame(writeRafId)
       if (reconnectTimer) clearTimeout(reconnectTimer)
       if (dataDisposable) dataDisposable.dispose()

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -13,6 +13,7 @@
   import { openTool } from '../stores/tabs.svelte'
   import { workspaceState } from '../stores/workspace.svelte'
   import { setConnectionStatus, clearConnectionStatus } from './connectionState.svelte'
+  import { recordKeystroke } from '../stores/wpmTracker.svelte'
 
   const DEFAULT_FONT_FAMILY =
     'JetBrains Mono, JetBrainsMono Nerd Font, JetBrainsMono NF, FiraCode Nerd Font, Fira Code, Menlo, monospace'
@@ -228,6 +229,7 @@
         if (wsRef && wsRef.readyState === WebSocket.OPEN) {
           wsRef.send(data)
         }
+        recordKeystroke(sessionId, data)
       })
     }
 


### PR DESCRIPTION
Display a minimal, Apple-smooth WPM badge in the bottom-right corner of terminal panes. Tracks only printable keystrokes using a 10-second sliding window — escape sequences, mouse events, control chars, and shell startup noise are excluded.

- New store (wpmTracker.svelte.ts) with session-scoped tracking
- WpmIndicator component with subtle fade animation and peak WPM
- Preference toggle in Settings > General with explanation text
- Requires 5+ chars before activating (no false triggers on open)