### PR TITLE
fix(terminal): prevent WebGL crash on session restore

### DIFF
--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, untrack } from 'svelte'
   import { Terminal } from '@xterm/xterm'
   import { FitAddon } from '@xterm/addon-fit'
   import { WebglAddon } from '@xterm/addon-webgl'
@@ -34,7 +34,7 @@
   let termRef: Terminal | null = null
   let wsRef: WebSocket | null = null
   let webglAddonRef: WebglAddon | null = null
-  let webglAttached = $state(true)
+  let webglAttached = $state(false)
   let dragging = $state(false)
   let progressState = $state(0)
   let progressValue = $state(0)
@@ -89,9 +89,10 @@
     }
   })
 
-  // Re-attach WebGL addon when tab becomes active
+  // Re-attach WebGL addon when tab becomes active (untrack webglAttached
+  // so context-loss doesn't trigger an immediate retry loop)
   $effect(() => {
-    if (active && termRef && !webglAttached) {
+    if (active && termRef && !untrack(() => webglAttached)) {
       attachWebgl(termRef)
     }
   })
@@ -296,7 +297,7 @@
         progressValue = value
       })
 
-      attachWebgl(term)
+      if (active) attachWebgl(term)
 
       // Defer initial fit to after browser layout is complete
       requestAnimationFrame(() => fitAddon.fit())


### PR DESCRIPTION
## What

Defer WebGL context creation so only the active (visible) terminal gets a GPU context during mount. Inactive terminals get their context lazily when switched to.

## Why

On app startup, session restore recreates all terminals simultaneously. Each one created a WebGL context unconditionally, exceeding the browser's limit (~8-16 contexts). This caused the active terminal's context to be evicted, resulting in a crashed renderer (sad face icon, blank white terminal).

## How to test

1. Open 5+ tabs with different tools (Shell, Claude Code, etc.)
2. Quit the app
3. Relaunch — all terminals should render correctly
4. Switch between tabs — WebGL attaches/detaches on demand without crashes

## Checklist

- [x] Builds without errors (`npm run build`)
- [x] No new warnings introduced
- [ ] Tested on macOS
- [ ] Tested on Linux
- [ ] Tested on Windows