### PR TITLE
fix(terminal): pass agent env vars to tmux sessions

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -272,6 +272,7 @@ export function registerIpcHandlers(
           cols: payload.cols,
           rows: payload.rows,
           mouse: tmuxMouse,
+          env,
         })
         const attach = tmuxManager.attachArgs(tmuxSessionName)
         command = attach.command

--- a/src/main/pty/TmuxManager.ts
+++ b/src/main/pty/TmuxManager.ts
@@ -83,6 +83,7 @@ export class TmuxManager {
     cols?: number
     rows?: number
     mouse?: boolean
+    env?: Record<string, string>
   }): Promise<void> {
     if (!/^[\w-]+$/.test(opts.name)) {
       throw new Error('Invalid tmux session name')
@@ -91,6 +92,7 @@ export class TmuxManager {
     // Config file is only read on server start; explicitly set mouse
     // on the running server so preference changes take effect immediately.
     await this.exec(['set-option', '-g', 'mouse', opts.mouse ? 'on' : 'off']).catch(() => {})
+    const envArgs = Object.entries(opts.env ?? {}).flatMap(([k, v]) => ['-e', `${k}=${v}`])
     const args = [
       '-f',
       this.configPath,
@@ -104,6 +106,7 @@ export class TmuxManager {
       String(opts.cols ?? 80),
       '-y',
       String(opts.rows ?? 30),
+      ...envArgs,
       opts.shell,
       ...(opts.shellArgs ?? []),
     ]


### PR DESCRIPTION
## What

Forward agent environment variables (`CANOPY_HOOK_PORT`, `CANOPY_HOOK_TOKEN`, settings env) to `tmux new-session` via `-e` flags so the process running inside tmux receives them.

## Why

When tmux integration is enabled, `TmuxManager.newSession()` spawns the agent (e.g. Claude Code) inside a detached tmux session using only the base login environment. The hook port and auth token env vars were set on the `tmux attach` PTY instead, never reaching the actual agent process. This broke inspector hook event delivery, leaving the inspector panel empty.

## How to test

1. Enable tmux in preferences (`tmux.enabled = true`)
2. Open a Claude Code session
3. Verify the inspector panel shows live session state (status, context window, cost, tasks)
4. Compare with tmux disabled — behavior should be identical

## Checklist

- [x] Follows conventional commit format
- [x] TypeScript compiles without errors
- [ ] Tested on macOS
- [ ] Tested on Linux
- [ ] Tested on Windows (N/A — tmux disabled on Windows)