### PR TITLE
fix(terminal): forward process titles through tmux to tab names

### DIFF
--- a/src/main/pty/TmuxManager.ts
+++ b/src/main/pty/TmuxManager.ts
@@ -24,6 +24,8 @@ set -g escape-time 0
 set -g default-terminal xterm-256color
 set -g mouse ${mouse ? 'on' : 'off'}
 set -g history-limit 10000
+set -g set-titles-string "#T"
+set -g set-titles on
 `
 }
 
@@ -93,6 +95,8 @@ export class TmuxManager {
     // Config file is only read on server start; explicitly set mouse
     // on the running server so preference changes take effect immediately.
     await this.exec(['set-option', '-g', 'mouse', opts.mouse ? 'on' : 'off']).catch(() => {})
+    await this.exec(['set-option', '-g', 'set-titles-string', '#T']).catch(() => {})
+    await this.exec(['set-option', '-g', 'set-titles', 'on']).catch(() => {})
     const envArgs = Object.entries(opts.env ?? {}).flatMap(([k, v]) => ['-e', `${k}=${v}`])
     const args = [
       '-f',


### PR DESCRIPTION
## What
Enable tmux `set-titles` so that OSC 0/2 escape sequences emitted by shells are re-emitted to the outer PTY, allowing xterm.js to pick them up and update tab names.

## Why
When tmux is enabled, it intercepts terminal title escape sequences from the shell and stores them internally without forwarding them. This means tab names stay static ("Shell", "Claude") instead of showing the running process (e.g. "vim file.ts").

## How to test
1. `npm run dev` with tmux enabled
2. Open a shell tab
3. Run a command that sets a terminal title (e.g. `vim`, `htop`)
4. Tab name should update to reflect the running process
5. Exit the command — tab name should revert to the shell's default title

## Checklist
- [x] Self-reviewed
- [ ] Tests added/updated
- [ ] Docs updated
- [x] Tested locally