### PR TITLE
feat(tasks): send task context to agent sessions

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1284,7 +1284,7 @@ export function registerIpcHandlers(
       if (!payload.url || typeof payload.url !== 'string' || !/^https?:\/\//.test(payload.url)) {
         throw new Error('Invalid URL')
       }
-      if (!payload.filename || /[\0]/.test(payload.filename)) {
+      if (!payload.filename || /[\0/\\]/.test(payload.filename)) {
         throw new Error('Invalid filename')
       }
       return taskTrackerManager.downloadAttachment(
@@ -1296,7 +1296,9 @@ export function registerIpcHandlers(
   )
 
   ipcMain.handle('taskTracker:cleanupAttachments', (_event, payload: { filePaths: string[] }) => {
+    if (!Array.isArray(payload.filePaths)) throw new Error('Invalid filePaths')
     for (const fp of payload.filePaths) {
+      if (typeof fp !== 'string') continue
       taskTrackerManager.cleanupAttachmentDir(fp)
     }
   })

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1200,6 +1200,47 @@ export function registerIpcHandlers(
     },
   )
 
+  const TASK_KEY_RE = /^[A-Za-z0-9_-]+-\d+$/
+
+  ipcMain.handle(
+    'taskTracker:fetchTaskComments',
+    async (_event, payload: { connectionId: string; taskKey: string }) => {
+      if (!TASK_KEY_RE.test(payload.taskKey)) throw new Error('Invalid task key')
+      return taskTrackerManager.fetchTaskComments(payload.connectionId, payload.taskKey)
+    },
+  )
+
+  ipcMain.handle(
+    'taskTracker:fetchTaskAttachments',
+    async (_event, payload: { connectionId: string; taskKey: string }) => {
+      if (!TASK_KEY_RE.test(payload.taskKey)) throw new Error('Invalid task key')
+      return taskTrackerManager.fetchTaskAttachments(payload.connectionId, payload.taskKey)
+    },
+  )
+
+  ipcMain.handle(
+    'taskTracker:downloadAttachment',
+    async (_event, payload: { connectionId: string; url: string; filename: string }) => {
+      if (!payload.url || typeof payload.url !== 'string' || !/^https?:\/\//.test(payload.url)) {
+        throw new Error('Invalid URL')
+      }
+      if (!payload.filename || /[\0]/.test(payload.filename)) {
+        throw new Error('Invalid filename')
+      }
+      return taskTrackerManager.downloadAttachment(
+        payload.connectionId,
+        payload.url,
+        payload.filename,
+      )
+    },
+  )
+
+  ipcMain.handle('taskTracker:cleanupAttachments', (_event, payload: { filePaths: string[] }) => {
+    for (const fp of payload.filePaths) {
+      taskTrackerManager.cleanupAttachmentDir(fp)
+    }
+  })
+
   ipcMain.handle(
     'taskTracker:resolveBranchName',
     async (

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1287,11 +1287,12 @@ export function registerIpcHandlers(
       if (!payload.filename || /[\0/\\]/.test(payload.filename)) {
         throw new Error('Invalid filename')
       }
-      return taskTrackerManager.downloadAttachment(
+      const result = await taskTrackerManager.downloadAttachment(
         payload.connectionId,
         payload.url,
         payload.filename,
       )
+      return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 

--- a/src/main/taskTracker/TaskTrackerManager.ts
+++ b/src/main/taskTracker/TaskTrackerManager.ts
@@ -259,11 +259,17 @@ export class TaskTrackerManager {
             : `Bearer ${token}`,
         }
 
+        const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024
+
         return fromExternalCall(fetch(url, { headers, signal: AbortSignal.timeout(60_000) }), (e) =>
           dlErr(errorMessage(e)),
         ).andThen((res) => {
           if (!res.ok) return errAsync(dlErr(`HTTP ${res.status}`))
           if (!res.body) return errAsync(dlErr('Empty response body'))
+          const contentLength = Number(res.headers.get('content-length') || 0)
+          if (contentLength > MAX_ATTACHMENT_BYTES) {
+            return errAsync(dlErr(`Attachment too large: ${contentLength} bytes`))
+          }
           const nodeStream = Readable.fromWeb(res.body as import('stream/web').ReadableStream)
           return fromExternalCall(pipeline(nodeStream, createWriteStream(filePath)), (e) =>
             dlErr(errorMessage(e)),

--- a/src/main/taskTracker/TaskTrackerManager.ts
+++ b/src/main/taskTracker/TaskTrackerManager.ts
@@ -1,8 +1,16 @@
+import { join, basename } from 'path'
+import { mkdirSync, createWriteStream, rmSync } from 'fs'
+import os from 'os'
+import { randomUUID } from 'crypto'
+import { pipeline } from 'stream/promises'
+import { Readable } from 'stream'
 import type { PreferencesStore } from '../db/PreferencesStore'
 import { createProviderClient } from './providers'
 import type {
   TaskTrackerConnection,
+  TrackerAttachment,
   TrackerBoard,
+  TrackerComment,
   TrackerTask,
   TrackerSprint,
   TrackerStatus,
@@ -174,5 +182,61 @@ export class TaskTrackerManager {
     const token = this.getToken(conn)
     const client = createProviderClient(conn.provider)
     return client.getCurrentSprint(conn, token, boardId)
+  }
+
+  async fetchTaskComments(connectionId: string, taskKey: string): Promise<TrackerComment[]> {
+    const conn = this.getConnection(connectionId)
+    const token = this.getToken(conn)
+    const client = createProviderClient(conn.provider)
+    return client.fetchTaskComments(conn, token, taskKey)
+  }
+
+  async fetchTaskAttachments(connectionId: string, taskKey: string): Promise<TrackerAttachment[]> {
+    const conn = this.getConnection(connectionId)
+    const token = this.getToken(conn)
+    const client = createProviderClient(conn.provider)
+    return client.fetchTaskAttachments(conn, token, taskKey)
+  }
+
+  async downloadAttachment(connectionId: string, url: string, filename: string): Promise<string> {
+    const conn = this.getConnection(connectionId)
+    const token = this.getToken(conn)
+
+    const connBase = conn.baseUrl.replace(/\/$/, '')
+    if (!url.startsWith(connBase)) {
+      throw new Error('Attachment URL does not match connection base URL')
+    }
+
+    const dir = join(os.tmpdir(), `canopy-attachments-${randomUUID()}`)
+    mkdirSync(dir, { recursive: true })
+
+    const safeName = basename(filename.replace(/[/\\]/g, '_'))
+    const filePath = join(dir, safeName)
+
+    const headers: Record<string, string> = {
+      Authorization: conn.username
+        ? `Basic ${Buffer.from(`${conn.username}:${token}`).toString('base64')}`
+        : `Bearer ${token}`,
+    }
+
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(60_000) })
+    if (!res.ok) throw new Error(`Download failed: ${res.status}`)
+    if (!res.body) throw new Error('Empty response body')
+
+    const nodeStream = Readable.fromWeb(res.body as import('stream/web').ReadableStream)
+    await pipeline(nodeStream, createWriteStream(filePath))
+
+    return filePath
+  }
+
+  cleanupAttachmentDir(filePath: string): void {
+    const tmpBase = os.tmpdir()
+    const dir = join(filePath, '..')
+    if (!dir.startsWith(tmpBase) || !basename(dir).startsWith('canopy-attachments-')) return
+    try {
+      rmSync(dir, { recursive: true, force: true })
+    } catch {
+      // Ignore cleanup errors
+    }
   }
 }

--- a/src/main/taskTracker/TaskTrackerManager.ts
+++ b/src/main/taskTracker/TaskTrackerManager.ts
@@ -4,9 +4,10 @@ import os from 'os'
 import { randomUUID } from 'crypto'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
-import { ok, err, type Result, type ResultAsync } from 'neverthrow'
+import { ok, err, errAsync, type Result, type ResultAsync } from 'neverthrow'
 import type { PreferencesStore } from '../db/PreferencesStore'
 import type { TaskTrackerError } from './errors'
+import { fromExternalCall, errorMessage } from '../errors'
 import { createProviderClient } from './providers'
 import type {
   TaskTrackerConnection,
@@ -225,37 +226,50 @@ export class TaskTrackerManager {
       })
   }
 
-  async downloadAttachment(connectionId: string, url: string, filename: string): Promise<string> {
-    const connResult = this.getConnection(connectionId)
-    const tokenResult = connResult.andThen((conn) => this.getToken(conn).map((t) => ({ conn, t })))
-    if (tokenResult.isErr()) throw new Error('Connection or auth error')
-    const { conn, t: token } = tokenResult.value
+  downloadAttachment(
+    connectionId: string,
+    url: string,
+    filename: string,
+  ): ResultAsync<string, TaskTrackerError> {
+    const dlErr = (reason: string): TaskTrackerError => ({
+      _tag: 'AttachmentDownloadFailed',
+      filename,
+      reason,
+    })
 
-    const connBase = conn.baseUrl.replace(/\/$/, '')
-    if (!url.startsWith(connBase)) {
-      throw new Error('Attachment URL does not match connection base URL')
-    }
+    return this.getConnection(connectionId)
+      .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
+      .andThen(({ conn, token }) => {
+        const connBase = conn.baseUrl.replace(/\/$/, '')
+        if (!url.startsWith(connBase)) {
+          return err(dlErr('URL does not match connection base URL'))
+        }
+        return ok({ conn, token })
+      })
+      .asyncAndThen(({ conn, token }) => {
+        const dir = join(os.tmpdir(), `canopy-attachments-${randomUUID()}`)
+        mkdirSync(dir, { recursive: true })
 
-    const dir = join(os.tmpdir(), `canopy-attachments-${randomUUID()}`)
-    mkdirSync(dir, { recursive: true })
+        const safeName = basename(filename.replace(/[/\\]/g, '_'))
+        const filePath = join(dir, safeName)
 
-    const safeName = basename(filename.replace(/[/\\]/g, '_'))
-    const filePath = join(dir, safeName)
+        const headers: Record<string, string> = {
+          Authorization: conn.username
+            ? `Basic ${Buffer.from(`${conn.username}:${token}`).toString('base64')}`
+            : `Bearer ${token}`,
+        }
 
-    const headers: Record<string, string> = {
-      Authorization: conn.username
-        ? `Basic ${Buffer.from(`${conn.username}:${token}`).toString('base64')}`
-        : `Bearer ${token}`,
-    }
-
-    const res = await fetch(url, { headers, signal: AbortSignal.timeout(60_000) })
-    if (!res.ok) throw new Error(`Download failed: ${res.status}`)
-    if (!res.body) throw new Error('Empty response body')
-
-    const nodeStream = Readable.fromWeb(res.body as import('stream/web').ReadableStream)
-    await pipeline(nodeStream, createWriteStream(filePath))
-
-    return filePath
+        return fromExternalCall(fetch(url, { headers, signal: AbortSignal.timeout(60_000) }), (e) =>
+          dlErr(errorMessage(e)),
+        ).andThen((res) => {
+          if (!res.ok) return errAsync(dlErr(`HTTP ${res.status}`))
+          if (!res.body) return errAsync(dlErr('Empty response body'))
+          const nodeStream = Readable.fromWeb(res.body as import('stream/web').ReadableStream)
+          return fromExternalCall(pipeline(nodeStream, createWriteStream(filePath)), (e) =>
+            dlErr(errorMessage(e)),
+          ).map(() => filePath)
+        })
+      })
   }
 
   cleanupAttachmentDir(filePath: string): void {

--- a/src/main/taskTracker/errors.ts
+++ b/src/main/taskTracker/errors.ts
@@ -5,11 +5,16 @@ export type TaskTrackerError =
   | { _tag: 'ConnectionNotFound'; connectionId: string }
   | { _tag: 'AuthTokenMissing'; connectionName: string }
   | { _tag: 'ProviderApiError'; status: number; message: string; provider: TaskTrackerProvider }
+  | { _tag: 'AttachmentDownloadFailed'; filename: string; reason: string }
 
 export function taskTrackerErrorMessage(error: TaskTrackerError): string {
   return match(error)
     .with({ _tag: 'ConnectionNotFound' }, (e) => `Connection not found: ${e.connectionId}`)
     .with({ _tag: 'AuthTokenMissing' }, (e) => `No auth token for ${e.connectionName}`)
     .with({ _tag: 'ProviderApiError' }, (e) => `${e.provider} API error ${e.status}: ${e.message}`)
+    .with(
+      { _tag: 'AttachmentDownloadFailed' },
+      (e) => `Failed to download ${e.filename}: ${e.reason}`,
+    )
     .exhaustive()
 }

--- a/src/main/taskTracker/providers/jira.ts
+++ b/src/main/taskTracker/providers/jira.ts
@@ -1,7 +1,9 @@
 import type {
   TaskTrackerConnection,
   TaskTrackerProviderClient,
+  TrackerAttachment,
   TrackerBoard,
+  TrackerComment,
   TrackerTask,
   TrackerSprint,
   TrackerStatus,
@@ -246,6 +248,60 @@ export const jiraClient: TaskTrackerProviderClient = {
       name: sprint.name,
       number: parseSprintNumber(sprint.name),
       state: sprint.state as TrackerSprint['state'],
+    }
+  },
+
+  async fetchTaskComments(connection, token, taskKey) {
+    try {
+      const data = await jiraFetch<{
+        comments: Array<{
+          id: string
+          body?: unknown
+          author?: { displayName?: string }
+          created?: string
+        }>
+      }>(
+        connection,
+        token,
+        `/rest/api/3/issue/${encodeURIComponent(taskKey)}/comment?maxResults=50`,
+      )
+      return (data.comments ?? []).map(
+        (c): TrackerComment => ({
+          id: c.id,
+          author: c.author?.displayName ?? '',
+          body: typeof c.body === 'string' ? c.body : adfToPlainText(c.body).trim(),
+          created: c.created ?? '',
+        }),
+      )
+    } catch {
+      return []
+    }
+  },
+
+  async fetchTaskAttachments(connection, token, taskKey) {
+    try {
+      const data = await jiraFetch<{
+        fields: {
+          attachment?: Array<{
+            id: string
+            filename?: string
+            mimeType?: string
+            size?: number
+            content?: string
+          }>
+        }
+      }>(connection, token, `/rest/api/3/issue/${encodeURIComponent(taskKey)}?fields=attachment`)
+      return (data.fields.attachment ?? []).map(
+        (a): TrackerAttachment => ({
+          id: a.id,
+          name: a.filename ?? '',
+          mimeType: a.mimeType ?? '',
+          size: a.size ?? 0,
+          url: a.content ?? '',
+        }),
+      )
+    } catch {
+      return []
     }
   },
 }

--- a/src/main/taskTracker/providers/youtrack.ts
+++ b/src/main/taskTracker/providers/youtrack.ts
@@ -1,7 +1,9 @@
 import type {
   TaskTrackerConnection,
   TaskTrackerProviderClient,
+  TrackerAttachment,
   TrackerBoard,
+  TrackerComment,
   TrackerTask,
   TrackerStatus,
 } from '../types'
@@ -242,6 +244,64 @@ export const youtrackClient: TaskTrackerProviderClient = {
       name: active.name,
       number: parseSprintNumber(active.name),
       state: 'active' as const,
+    }
+  },
+
+  async fetchTaskComments(connection, token, taskKey) {
+    try {
+      const fields = 'id,text,author(name,fullName),created'
+      const data = await ytFetch<
+        Array<{
+          id: string
+          text?: string
+          author?: { name?: string; fullName?: string }
+          created?: number
+        }>
+      >(
+        connection,
+        token,
+        `/api/issues/${encodeURIComponent(taskKey)}/comments?fields=${encodeURIComponent(fields)}`,
+      )
+      return data.map(
+        (c): TrackerComment => ({
+          id: c.id,
+          author: c.author?.fullName ?? c.author?.name ?? '',
+          body: c.text ?? '',
+          created: c.created ? new Date(c.created).toISOString() : '',
+        }),
+      )
+    } catch {
+      return []
+    }
+  },
+
+  async fetchTaskAttachments(connection, token, taskKey) {
+    try {
+      const fields = 'attachments(id,name,size,mimeType)'
+      const data = await ytFetch<{
+        attachments?: Array<{
+          id: string
+          name?: string
+          size?: number
+          mimeType?: string
+        }>
+      }>(
+        connection,
+        token,
+        `/api/issues/${encodeURIComponent(taskKey)}?fields=${encodeURIComponent(fields)}`,
+      )
+      const baseUrl = connection.baseUrl.replace(/\/$/, '')
+      return (data.attachments ?? []).map(
+        (a): TrackerAttachment => ({
+          id: a.id,
+          name: a.name ?? '',
+          mimeType: a.mimeType ?? '',
+          size: a.size ?? 0,
+          url: `${baseUrl}/api/issues/${encodeURIComponent(taskKey)}/attachments/${a.id}/file`,
+        }),
+      )
+    } catch {
+      return []
     }
   },
 }

--- a/src/main/taskTracker/types.ts
+++ b/src/main/taskTracker/types.ts
@@ -36,6 +36,21 @@ export interface TrackerStatus {
   name: string
 }
 
+export interface TrackerComment {
+  id: string
+  author: string
+  body: string
+  created: string
+}
+
+export interface TrackerAttachment {
+  id: string
+  name: string
+  mimeType: string
+  size: number
+  url: string
+}
+
 export interface TrackerSprint {
   id: string
   name: string
@@ -112,4 +127,14 @@ export interface TaskTrackerProviderClient {
     token: string,
     boardId?: string,
   ): Promise<TrackerSprint | null>
+  fetchTaskComments(
+    connection: TaskTrackerConnection,
+    token: string,
+    taskKey: string,
+  ): Promise<TrackerComment[]>
+  fetchTaskAttachments(
+    connection: TaskTrackerConnection,
+    token: string,
+    taskKey: string,
+  ): Promise<TrackerAttachment[]>
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -491,6 +491,20 @@ interface CanopyAPI {
     boardId?: string,
   ) => Promise<TrackerSprint | null>
   taskTrackerGetCurrentUser: (connectionId: string) => Promise<string>
+  taskTrackerFetchTaskComments: (
+    connectionId: string,
+    taskKey: string,
+  ) => Promise<Array<{ id: string; author: string; body: string; created: string }>>
+  taskTrackerFetchTaskAttachments: (
+    connectionId: string,
+    taskKey: string,
+  ) => Promise<Array<{ id: string; name: string; mimeType: string; size: number; url: string }>>
+  taskTrackerDownloadAttachment: (
+    connectionId: string,
+    url: string,
+    filename: string,
+  ) => Promise<string>
+  taskTrackerCleanupAttachments: (filePaths: string[]) => Promise<void>
   taskTrackerResolveBranchName: (
     connectionId: string,
     task: TrackerTask,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -558,6 +558,18 @@ const api = {
     ipcRenderer.invoke('taskTracker:getCurrentSprint', { connectionId, boardId }),
   taskTrackerGetCurrentUser: (connectionId: string) =>
     ipcRenderer.invoke('taskTracker:getCurrentUser', { connectionId }) as Promise<string>,
+  taskTrackerFetchTaskComments: (connectionId: string, taskKey: string) =>
+    ipcRenderer.invoke('taskTracker:fetchTaskComments', { connectionId, taskKey }),
+  taskTrackerFetchTaskAttachments: (connectionId: string, taskKey: string) =>
+    ipcRenderer.invoke('taskTracker:fetchTaskAttachments', { connectionId, taskKey }),
+  taskTrackerDownloadAttachment: (connectionId: string, url: string, filename: string) =>
+    ipcRenderer.invoke('taskTracker:downloadAttachment', {
+      connectionId,
+      url,
+      filename,
+    }) as Promise<string>,
+  taskTrackerCleanupAttachments: (filePaths: string[]) =>
+    ipcRenderer.invoke('taskTracker:cleanupAttachments', { filePaths }),
   taskTrackerResolveBranchName: (
     connectionId: string,
     task: { key: string; type: string; [k: string]: unknown },

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -3,8 +3,13 @@
   import { X, ExternalLink, ArrowLeft } from '@lucide/svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import { closeDialog, confirm } from '../../lib/stores/dialogs.svelte'
-  import { getPref } from '../../lib/stores/preferences.svelte'
+  import { getPref, setPref } from '../../lib/stores/preferences.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
   import { workspaceState, selectWorktree } from '../../lib/stores/workspace.svelte'
+  import { getTools, getToolAvailability } from '../../lib/stores/tools.svelte'
+  import { isAiToolId, openTool } from '../../lib/stores/tabs.svelte'
+  import { agentSessions } from '../../lib/agents/agentState.svelte'
+  import { fetchAndFormatTaskContext } from '../../lib/taskTracker/taskContext'
 
   interface Task {
     key: string
@@ -39,6 +44,13 @@
   let templateHasBranchType = $state(false)
   let initialized = $state(false)
   let fullTask = $state<Task>(task)
+  let selectedAgentId = $state(getPref('taskTracker.lastAgent', ''))
+
+  let availableAgents = $derived.by(() => {
+    const tools = getTools()
+    const avail = getToolAvailability()
+    return tools.filter((t) => isAiToolId(t.id) && avail[t.id])
+  })
 
   async function init(): Promise<void> {
     // Fetch full task data (with description) in parallel with branch type
@@ -96,10 +108,28 @@
     const worktreePath = worktreeDir.startsWith('~/') ? homedir + worktreeDir.slice(1) : worktreeDir
 
     creatingWorktree = true
+    setPref('taskTracker.lastAgent', selectedAgentId)
     try {
       await window.api.gitWorktreeAdd(repoRoot, worktreePath, resolvedBranchName, currentBranch)
       closeDialog()
       await selectWorktree(worktreePath)
+
+      if (selectedAgentId) {
+        try {
+          const tab = await openTool(selectedAgentId, worktreePath)
+          const pane = tab.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+          if (pane) {
+            const sessionId = pane.sessionId
+            const ready = await waitForAgentReady(sessionId)
+            if (ready) {
+              const context = await fetchAndFormatTaskContext(connectionId, fullTask)
+              await window.api.writePty(sessionId, context + '\n')
+            }
+          }
+        } catch {
+          addToast('Failed to send task context to agent')
+        }
+      }
     } catch (e) {
       creatingWorktree = false
       closeDialog()
@@ -110,6 +140,19 @@
         confirmLabel: 'OK',
       })
     }
+  }
+
+  async function waitForAgentReady(sessionId: string, timeoutMs = 30000): Promise<boolean> {
+    // Give the agent session time to register in the store
+    await new Promise((r) => setTimeout(r, 500))
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      const session = agentSessions[sessionId]
+      if (session?.status.type === 'idle') return true
+      if (session?.status.type === 'ended' || session?.status.type === 'error') return false
+      await new Promise((r) => setTimeout(r, 200))
+    }
+    return false
   }
 
   onMount(() => {
@@ -166,6 +209,22 @@
       <span class="field-label">Branch</span>
       <code class="branch-preview">{resolvedBranchName}</code>
     </div>
+    {#if availableAgents.length > 0}
+      <div class="field-row">
+        <span class="field-label">Agent</span>
+        <CustomSelect
+          value={selectedAgentId}
+          options={[
+            { value: '', label: 'None' },
+            ...availableAgents.map((t) => ({ value: t.id, label: t.name })),
+          ]}
+          onchange={(v) => {
+            selectedAgentId = v
+          }}
+          maxWidth="none"
+        />
+      </div>
+    {/if}
     <div class="branch-actions">
       <button class="btn-cancel" onclick={onBack}>Back</button>
       <button
@@ -173,7 +232,8 @@
         onclick={confirmBranchCreation}
         disabled={creatingWorktree || !resolvedBranchName}
       >
-        {#if creatingWorktree}Creating...{:else}Create & Switch{/if}
+        {#if creatingWorktree}Creating...{:else if selectedAgentId}Create & Start Agent{:else}Create
+          & Switch{/if}
       </button>
     </div>
   </div>

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, onDestroy } from 'svelte'
   import { X, ExternalLink, ArrowLeft } from '@lucide/svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import { closeDialog, confirm } from '../../lib/stores/dialogs.svelte'
@@ -142,11 +142,14 @@
     }
   }
 
+  const abortController = new AbortController()
+
   async function waitForAgentReady(sessionId: string, timeoutMs = 30000): Promise<boolean> {
-    // Give the agent session time to register in the store
+    const signal = abortController.signal
     await new Promise((r) => setTimeout(r, 500))
     const start = Date.now()
     while (Date.now() - start < timeoutMs) {
+      if (signal.aborted) return false
       const session = agentSessions[sessionId]
       if (session?.status.type === 'idle') return true
       if (session?.status.type === 'ended' || session?.status.type === 'error') return false
@@ -157,6 +160,10 @@
 
   onMount(() => {
     init()
+  })
+
+  onDestroy(() => {
+    abortController.abort()
   })
 </script>
 

--- a/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
@@ -394,6 +394,7 @@
                   class="send-btn"
                   onclick={(e) => sendTaskToAgent(task, e)}
                   title="Send to agent"
+                  aria-label="Send to agent"
                 >
                   <Send size={12} />
                 </button>

--- a/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
-  import { Search, X, Loader2, Copy, Filter } from '@lucide/svelte'
+  import { Search, X, Loader2, Copy, Filter, Send } from '@lucide/svelte'
   import { closeDialog } from '../../lib/stores/dialogs.svelte'
   import { setPref, getPref, prefs } from '../../lib/stores/preferences.svelte'
   import { addToast } from '../../lib/stores/toast.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
+  import { getActiveAgentPane } from '../../lib/stores/tabs.svelte'
+  import { fetchAndFormatTaskContext } from '../../lib/taskTracker/taskContext'
   import BranchCreateForm from './BranchCreateForm.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
@@ -244,6 +246,18 @@
     }
   }
 
+  let hasActiveAgent = $derived(!!getActiveAgentPane())
+
+  async function sendTaskToAgent(task: Task, e: MouseEvent): Promise<void> {
+    e.stopPropagation()
+    const pane = getActiveAgentPane()
+    if (!pane) return
+    const context = await fetchAndFormatTaskContext(connectionId, task)
+    await window.api.writePty(pane.sessionId, context + '\n')
+    addToast('Task sent to agent')
+    closeDialog()
+  }
+
   function priorityColor(priority: string): string {
     const p = priority.toLowerCase()
     if (p.includes('critical') || p.includes('highest')) return 'var(--c-danger)'
@@ -375,6 +389,15 @@
               >
                 ●
               </span>
+              {#if hasActiveAgent}
+                <button
+                  class="send-btn"
+                  onclick={(e) => sendTaskToAgent(task, e)}
+                  title="Send to agent"
+                >
+                  <Send size={12} />
+                </button>
+              {/if}
               <button
                 class="send-btn"
                 onclick={(e) => {

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -134,6 +134,17 @@ function computeDisplayName(toolName: string, worktreePath: string, toolId: stri
   return `${toolName} #${sameToolCount + 1}`
 }
 
+export function getActiveAgentPane(): PaneSession | null {
+  const path = workspaceState.selectedWorktreePath
+  if (!path) return null
+  const tabId = activeTabId[path]
+  const tab = tabsByWorktree[path]?.find((t) => t.id === tabId)
+  if (!tab) return null
+  const focused = findLeaf(tab.rootSplit, tab.focusedPaneId)
+  if (!focused || !isAiToolId(focused.toolId)) return null
+  return focused
+}
+
 export async function openTool(
   toolId: string,
   worktreePath: string,

--- a/src/renderer/src/lib/taskTracker/taskContext.ts
+++ b/src/renderer/src/lib/taskTracker/taskContext.ts
@@ -1,0 +1,118 @@
+interface TaskContextInput {
+  key: string
+  summary: string
+  description: string
+  status: string
+  priority: string
+  type: string
+  url?: string
+}
+
+interface TaskComment {
+  author: string
+  body: string
+  created: string
+}
+
+interface TaskAttachmentPath {
+  name: string
+  localPath: string
+}
+
+const MAX_DESCRIPTION_LENGTH = 3000
+const MAX_COMMENTS = 15
+const MAX_COMMENT_LENGTH = 1000
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  return text.slice(0, max) + '...'
+}
+
+export function formatTaskContext(
+  task: TaskContextInput,
+  comments?: TaskComment[],
+  attachments?: TaskAttachmentPath[],
+  failedAttachments?: string[],
+): string {
+  const lines: string[] = ['Work on the following task:', '']
+
+  lines.push(`# ${task.key}: ${task.summary}`)
+
+  const meta: string[] = []
+  if (task.status) meta.push(`Status: ${task.status}`)
+  if (task.priority) meta.push(`Priority: ${task.priority}`)
+  if (task.type) meta.push(`Type: ${task.type}`)
+  if (meta.length > 0) lines.push(meta.join(' | '))
+
+  if (task.url) lines.push(`URL: ${task.url}`)
+
+  if (task.description) {
+    lines.push('', '## Description', truncate(task.description.trim(), MAX_DESCRIPTION_LENGTH))
+  }
+
+  if (comments && comments.length > 0) {
+    const recent = comments.slice(-MAX_COMMENTS)
+    lines.push('', '## Comments')
+    for (const c of recent) {
+      const date = c.created ? c.created.slice(0, 10) : ''
+      const body = truncate(c.body.trim(), MAX_COMMENT_LENGTH)
+      lines.push(`[${date} ${c.author}]: ${body}`)
+    }
+  }
+
+  if (
+    (attachments && attachments.length > 0) ||
+    (failedAttachments && failedAttachments.length > 0)
+  ) {
+    lines.push('', '## Attachments')
+    if (attachments) {
+      for (const a of attachments) {
+        lines.push(`@${a.localPath}`)
+      }
+    }
+    if (failedAttachments && failedAttachments.length > 0) {
+      lines.push(`(failed to download: ${failedAttachments.join(', ')})`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export async function fetchAndFormatTaskContext(
+  connectionId: string,
+  task: TaskContextInput,
+): Promise<string> {
+  const [comments, rawAttachments] = await Promise.all([
+    window.api.taskTrackerFetchTaskComments(connectionId, task.key).catch(() => []),
+    window.api.taskTrackerFetchTaskAttachments(connectionId, task.key).catch(() => []),
+  ])
+
+  const attachments: TaskAttachmentPath[] = []
+  const failedAttachments: string[] = []
+  const downloadResults = await Promise.allSettled(
+    rawAttachments.map(async (a) => {
+      const localPath = await window.api.taskTrackerDownloadAttachment(connectionId, a.url, a.name)
+      return { name: a.name, localPath }
+    }),
+  )
+  for (let i = 0; i < downloadResults.length; i++) {
+    const result = downloadResults[i]
+    if (result.status === 'fulfilled') {
+      attachments.push(result.value)
+    } else {
+      failedAttachments.push(rawAttachments[i].name)
+    }
+  }
+
+  const context = formatTaskContext(task, comments, attachments, failedAttachments)
+
+  // Schedule cleanup of downloaded attachment files
+  if (attachments.length > 0) {
+    const paths = attachments.map((a) => a.localPath)
+    setTimeout(() => {
+      window.api.taskTrackerCleanupAttachments(paths).catch(() => {})
+    }, 60_000)
+  }
+
+  return context
+}


### PR DESCRIPTION
## What

Add ability to send task tracker data (title, description, comments, attachments) directly to AI agent sessions. Two new workflows:
1. Auto-start an agent with task context when creating a worktree from a task
2. Send task context to an already-running agent pane from the task picker

## Why

When starting work on a task, developers manually copy task details into their AI agent. This automates that workflow — pick a task, create a worktree, and the agent already has full context including comments and attachments.

## How to test

**Feature 1 — Agent auto-start from task:**
1. Open task picker (sidebar → Tasks)
2. Select a task → branch creation form appears
3. Verify "Agent" dropdown shows available AI tools (Claude, Gemini, etc.)
4. Select an agent, click "Create & Start Agent"
5. Worktree is created, agent launches, and task context (title, description, comments, downloaded attachments) is sent as the first prompt

**Feature 2 — Send to existing agent:**
1. Open a Claude Code (or other AI tool) pane
2. Open task picker
3. Verify a Send icon button appears next to the Copy button on each task row
4. Click Send — task context is written to the agent's terminal input
5. Verify the button only appears when an AI tool pane is focused

**Edge cases:**
- Verify attachment files are downloaded to `/tmp/canopy-attachments-*` and cleaned up after ~60s
- Verify failed attachment downloads are noted in the context text
- Verify last selected agent is persisted across sessions

## Screenshots / recordings

UI changes: new "Agent" dropdown in branch creation form, new Send button icon in task picker rows.

## Checklist

- [x] Code compiles (`npm run typecheck`)
- [x] Linter passes (`npm run lint`)
- [x] IPC input validation (task keys, URLs, filenames)
- [x] Security: attachment URL validated against connection base URL
- [x] Temp file cleanup after use
- [ ] Manual testing with Jira connection
- [ ] Manual testing with YouTrack connection