### PR TITLE
refactor: replace try/catch with neverthrow typed error handling

### DIFF
--- a/.github/prompts/code-review.md
+++ b/.github/prompts/code-review.md
@@ -105,6 +105,17 @@ This app targets macOS, Windows, and Linux. Platform-specific labels and behavio
 - Using `ipcRenderer.send`/`ipcMain.on` for request-response instead of `invoke`/`handle`.
 - IPC channels not following `feature:action` naming convention.
 
+### Error handling
+
+The codebase uses `neverthrow` for typed error handling. Business logic must not use `try/catch`.
+
+- `try/catch` in a service, manager, or domain module instead of returning `Result<T, E>` / `ResultAsync<T, E>`. Exception: process boundaries (PTY cleanup, HTTP body parsing, `JSON.parse` on untrusted input, `contextBridge` init, renderer event handlers).
+- Untyped errors: throwing `new Error(string)` from business logic instead of returning an error variant from a typed union.
+- Missing error type: new domain logic that can fail without a corresponding `errors.ts` defining a discriminated union with `_tag` fields.
+- Error message formatter not co-located with error type definition. Each `errors.ts` should export its own message formatter using `ts-pattern` `.exhaustive()`.
+- Swallowing errors silently (`catch {}` with no fallback value or logging) in non-boundary code.
+- Using `.unwrapOr()` where the caller needs to distinguish error cases (should use `.match()` or `isErr()` instead).
+
 ### Theming
 
 All UI colors must use CSS custom properties from the `--c-*` system defined in `base.css` and applied dynamically by `src/renderer/src/lib/theme/appTheme.ts`. The app theme syncs with the terminal theme.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,12 @@ npm run svelte-check     # renderer only
 - `tsconfig.web.json` — renderer (DOM types, strict mode OFF)
 - Use `verbatimModuleSyntax: true` — type-only imports must use `import type`
 
+## Error handling
+
+Use `neverthrow` (`Result<T, E>`, `ResultAsync<T, E>`) for all business logic error handling. Never use `try/catch` in services, managers, or domain logic. Define typed error unions with `_tag` discriminants per domain (e.g., `GitError`, `TaskTrackerError`) in dedicated `errors.ts` files. Use `fromExternalCall()` from `src/main/errors.ts` to wrap external promises. Co-locate error message formatters with error types, using `ts-pattern` `.exhaustive()` for formatting.
+
+`try/catch` is allowed only at process boundaries: PTY cleanup (EBADF), HTTP request parsing, `JSON.parse` on untrusted input, `contextBridge` initialization, file cleanup in `finally`, and renderer event handlers. IPC handlers unwrap Results with `unwrapOrThrow()` (write ops) or `.unwrapOr()` (read ops with safe defaults).
+
 ## Pattern matching
 
 Use `ts-pattern` (`match`/`with`) instead of `switch` or `if/else` chains when branching on discriminated unions, string literal types, or object shapes. Prefer `.exhaustive()` when all cases are handled (compile-time safety), `.otherwise()` when a default is needed. Use `P.union()` for grouped cases, `P.when()` for predicate guards. Do not use `ts-pattern` for simple 1-2 branch conditionals or numeric threshold checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,14 @@ Prettier handles formatting. Run `npm run format` before committing.
 - Use `import type` for type-only imports (`verbatimModuleSyntax` is enabled)
 - Avoid bare `any` without `// eslint-disable` and a justification comment
 
+### Error handling
+
+Business logic must use `neverthrow` (`Result<T, E>` / `ResultAsync<T, E>`) instead of `try/catch`. Each domain defines a typed error union with `_tag` discriminants in an `errors.ts` file (e.g., `src/main/git/errors.ts`). Wrap external calls with `fromExternalCall()` from `src/main/errors.ts`.
+
+`try/catch` is only acceptable at process boundaries: PTY resource cleanup, HTTP body parsing, `JSON.parse` on untrusted input, `contextBridge` initialization, and renderer event handlers.
+
+IPC handlers unwrap Results before returning to the renderer: `unwrapOrThrow()` for write operations (propagates typed error as IPC error), `.unwrapOr(defaultValue)` for read operations with safe fallbacks.
+
 ### Pattern matching
 
 Use `ts-pattern` for branching on discriminated unions, string literal types, or object shapes (3+ branches). Use `.exhaustive()` when all cases are handled, `.otherwise()` for defaults. Do not use it for simple 1-2 branch conditionals or numeric comparisons.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "electron-updater": "^6.3.9",
         "lucide-svelte": "^1.0.1",
         "marked": "^17.0.5",
+        "neverthrow": "^8.2.0",
         "node-pty": "^1.1.0",
         "semver": "^7.7.4",
         "simple-git": "^3.33.0",
@@ -3423,7 +3424,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8427,6 +8427,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/neverthrow": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-8.2.0.tgz",
+      "integrity": "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.24.0"
       }
     },
     "node_modules/node-abi": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "electron-updater": "^6.3.9",
     "lucide-svelte": "^1.0.1",
     "marked": "^17.0.5",
+    "neverthrow": "^8.2.0",
     "node-pty": "^1.1.0",
     "semver": "^7.7.4",
     "simple-git": "^3.33.0",

--- a/src/main/ai/commitMessageGenerator.ts
+++ b/src/main/ai/commitMessageGenerator.ts
@@ -4,6 +4,9 @@ import { query } from '@anthropic-ai/claude-agent-sdk'
 import type { PreferencesStore } from '../db/PreferencesStore'
 import { getLoginEnv } from '../shell/loginEnv'
 import { BLOCKED_ENV_VARS } from '../security/envBlocklist'
+import type { AiError } from './errors'
+import type { ResultAsyncType } from '../errors'
+import { fromExternalCall } from '../errors'
 
 let cachedClaudePath: string | undefined
 
@@ -49,11 +52,48 @@ const OUTPUT_SCHEMA = {
   required: ['subject', 'body'] as const,
 }
 
+function generateCommitMessageInner(diff: string): ResultAsyncType<string | null, AiError> {
+  const truncatedDiff = diff.length > MAX_DIFF_LENGTH ? diff.slice(0, MAX_DIFF_LENGTH) : diff
+  const prompt = PROMPT_TEMPLATE.replace('{diff}', truncatedDiff)
+
+  return fromExternalCall(
+    (async () => {
+      const claudePath = await resolveClaudeExecutable()
+
+      const q = query({
+        prompt,
+        options: {
+          model: 'haiku',
+          pathToClaudeCodeExecutable: claudePath,
+          outputFormat: { type: 'json_schema', schema: OUTPUT_SCHEMA },
+        },
+      })
+
+      let structuredOutput: CommitOutput | null = null
+      for await (const message of q) {
+        if (message.type === 'result' && (message as { subtype?: string }).subtype === 'success') {
+          structuredOutput = (message as Record<string, unknown>)
+            .structured_output as CommitOutput | null
+        }
+      }
+
+      return structuredOutput
+    })(),
+    (e): AiError => ({
+      _tag: 'AiRequestFailed',
+      message: e instanceof Error ? e.message : String(e),
+    }),
+  ).map((output) => {
+    if (!output?.subject) return null
+    const { subject, body } = output
+    return body ? `${subject}\n\n${body}` : subject
+  })
+}
+
 export async function generateCommitMessage(
   diff: string,
   preferencesStore: PreferencesStore,
 ): Promise<string | null> {
-  // Build env overrides from preferences (same pattern as handlers.ts for PTY sessions)
   const envOverrides: Record<string, string> = {}
 
   const claudeApiKey = preferencesStore.get('claude.apiKey')
@@ -79,9 +119,6 @@ export async function generateCommitMessage(
     }
   }
 
-  const model = 'haiku'
-
-  // Save current env, apply overrides, restore in finally
   const savedEnv: Record<string, string | undefined> = {}
 
   try {
@@ -90,33 +127,7 @@ export async function generateCommitMessage(
       process.env[key] = val
     }
 
-    const truncatedDiff = diff.length > MAX_DIFF_LENGTH ? diff.slice(0, MAX_DIFF_LENGTH) : diff
-    const prompt = PROMPT_TEMPLATE.replace('{diff}', truncatedDiff)
-    const claudePath = await resolveClaudeExecutable()
-
-    const q = query({
-      prompt,
-      options: {
-        model,
-        pathToClaudeCodeExecutable: claudePath,
-        outputFormat: { type: 'json_schema', schema: OUTPUT_SCHEMA },
-      },
-    })
-
-    let structuredOutput: CommitOutput | null = null
-    for await (const message of q) {
-      if (message.type === 'result' && (message as { subtype?: string }).subtype === 'success') {
-        structuredOutput = (message as Record<string, unknown>)
-          .structured_output as CommitOutput | null
-      }
-    }
-
-    if (!structuredOutput?.subject) return null
-    const { subject, body } = structuredOutput
-    return body ? `${subject}\n\n${body}` : subject
-  } catch (err) {
-    console.error('[ai-commit] Error:', err)
-    return null
+    return await generateCommitMessageInner(diff).unwrapOr(null)
   } finally {
     for (const [key, val] of Object.entries(savedEnv)) {
       if (val !== undefined) {

--- a/src/main/ai/errors.ts
+++ b/src/main/ai/errors.ts
@@ -1,0 +1,1 @@
+export type AiError = { _tag: 'AiRequestFailed'; message: string } | { _tag: 'NoOutput' }

--- a/src/main/changelog/errors.ts
+++ b/src/main/changelog/errors.ts
@@ -1,0 +1,1 @@
+export type ChangelogError = { _tag: 'FetchFailed'; message: string }

--- a/src/main/changelog/fetchChangelog.ts
+++ b/src/main/changelog/fetchChangelog.ts
@@ -1,5 +1,7 @@
 import { net } from 'electron'
 import semver from 'semver'
+import type { ChangelogError } from './errors'
+import { fromExternalCall, errorMessage, type ResultAsyncType } from '../errors'
 
 export interface ChangelogEntry {
   version: string
@@ -18,26 +20,26 @@ interface GitHubRelease {
 const GITHUB_RELEASES_URL =
   'https://api.github.com/repos/itsoltech/canopy-desktop/releases?per_page=100'
 
-async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
-  const response = await net.fetch(GITHUB_RELEASES_URL, {
-    headers: {
-      Accept: 'application/vnd.github.v3+json',
-      'User-Agent': 'Canopy-Desktop',
-    },
-  })
-  if (!response.ok) throw new Error(`GitHub API ${response.status}`)
-  return (await response.json()) as GitHubRelease[]
+function fetchGitHubReleases(): ResultAsyncType<GitHubRelease[], ChangelogError> {
+  return fromExternalCall(
+    (async () => {
+      const response = await net.fetch(GITHUB_RELEASES_URL, {
+        headers: {
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'Canopy-Desktop',
+        },
+      })
+      if (!response.ok) throw new Error(`GitHub API ${response.status}`)
+      return (await response.json()) as GitHubRelease[]
+    })(),
+    (e): ChangelogError => ({ _tag: 'FetchFailed', message: errorMessage(e) }),
+  )
 }
 
-/**
- * For the "next" update channel, determine whether electron-updater should
- * look for `latest-mac.yml` (stable) or `next-mac.yml` (pre-release) by
- * finding whichever pool contains the newest version above `currentVersion`.
- */
-export async function resolveUpdateChannel(currentVersion: string): Promise<'latest' | 'next'> {
-  try {
-    const releases = await fetchGitHubReleases()
-
+export function resolveUpdateChannel(
+  currentVersion: string,
+): ResultAsyncType<'latest' | 'next', ChangelogError> {
+  return fetchGitHubReleases().map((releases) => {
     let latestStable: string | null = null
     let latestPrerelease: string | null = null
 
@@ -57,20 +59,16 @@ export async function resolveUpdateChannel(currentVersion: string): Promise<'lat
       return 'latest'
     }
     return 'next'
-  } catch {
-    return 'next'
-  }
+  })
 }
 
-export async function fetchChangelogRange(
+export function fetchChangelogRange(
   fromVersion: string,
   toVersion: string,
   channel: 'stable' | 'next',
-): Promise<ChangelogEntry[] | null> {
-  try {
-    const releases = await fetchGitHubReleases()
-
-    return releases
+): ResultAsyncType<ChangelogEntry[], ChangelogError> {
+  return fetchGitHubReleases().map((releases) =>
+    releases
       .filter((r) => {
         if (r.draft || !r.body) return false
         if (channel === 'stable' && r.prerelease) return false
@@ -89,8 +87,6 @@ export async function fetchChangelogRange(
         version: semver.clean(r.tag_name)!,
         date: r.published_at.split('T')[0],
         body: r.body!,
-      }))
-  } catch {
-    return null
-  }
+      })),
+  )
 }

--- a/src/main/errors.ts
+++ b/src/main/errors.ts
@@ -1,0 +1,15 @@
+import { ResultAsync } from 'neverthrow'
+
+export { ok, err, okAsync, errAsync, ResultAsync } from 'neverthrow'
+export type { Result, ResultAsync as ResultAsyncType } from 'neverthrow'
+
+export function fromExternalCall<T, E>(
+  promise: Promise<T>,
+  mapErr: (e: unknown) => E,
+): ResultAsync<T, E> {
+  return ResultAsync.fromPromise(promise, mapErr)
+}
+
+export function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e)
+}

--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -1,9 +1,19 @@
+import { ok, err, okAsync, type Result, type ResultAsync } from 'neverthrow'
 import simpleGit from 'simple-git'
+import type { GitError } from './errors'
+import { fromExternalCall, errorMessage } from '../errors'
 
-function assertSafeRef(name: string): void {
-  if (name.startsWith('-')) {
-    throw new Error(`Invalid git ref: must not start with a dash`)
-  }
+function validateRef(name: string): Result<string, GitError> {
+  if (name.startsWith('-')) return err({ _tag: 'InvalidRef', ref: name })
+  return ok(name)
+}
+
+function gitErr(command: string, e: unknown): GitError {
+  return { _tag: 'GitCommandFailed', command, message: errorMessage(e) }
+}
+
+function gitCall<T>(command: string, promise: Promise<T>): ResultAsync<T, GitError> {
+  return fromExternalCall(promise, (e) => gitErr(command, e))
 }
 
 export interface GitCommitResult {
@@ -41,257 +51,272 @@ export interface GitWorktreeInfo {
 }
 
 export class GitRepository {
-  static async detect(dirPath: string): Promise<GitInfo> {
+  static detect(dirPath: string): ResultAsync<GitInfo, GitError> {
     const git = simpleGit(dirPath)
-
-    try {
-      const repoRoot = (await git.revparse(['--show-toplevel'])).trim()
-      const [branch, worktrees, isDirty, aheadBehind] = await Promise.all([
-        GitRepository.getBranch(repoRoot),
-        GitRepository.listWorktrees(repoRoot),
-        GitRepository.isDirty(repoRoot),
-        GitRepository.getAheadBehind(repoRoot),
-      ])
-
-      return { isGitRepo: true, repoRoot, branch, worktrees, isDirty, aheadBehind }
-    } catch {
-      return {
-        isGitRepo: false,
-        repoRoot: null,
-        branch: null,
-        worktrees: [],
-        isDirty: false,
-        aheadBehind: null,
-      }
-    }
+    return fromExternalCall(git.revparse(['--show-toplevel']), () => ({
+      _tag: 'NotAGitRepo' as const,
+      path: dirPath,
+    })).andThen((raw) => {
+      const repoRoot = raw.trim()
+      return GitRepository.getBranch(repoRoot).andThen((branch) =>
+        GitRepository.listWorktrees(repoRoot).andThen((worktrees) =>
+          GitRepository.isDirty(repoRoot).andThen((isDirty) =>
+            GitRepository.getAheadBehind(repoRoot).map((aheadBehind) => ({
+              isGitRepo: true as const,
+              repoRoot,
+              branch,
+              worktrees,
+              isDirty,
+              aheadBehind,
+            })),
+          ),
+        ),
+      )
+    })
   }
 
-  static async getBranch(repoRoot: string): Promise<string | null> {
+  static getBranch(repoRoot: string): ResultAsync<string | null, GitError> {
     const git = simpleGit(repoRoot)
-    try {
-      const branch = (await git.revparse(['--abbrev-ref', 'HEAD'])).trim()
+    return gitCall('rev-parse', git.revparse(['--abbrev-ref', 'HEAD'])).map((raw) => {
+      const branch = raw.trim()
       return branch === 'HEAD' ? null : branch
-    } catch {
-      return null
-    }
+    })
   }
 
-  static async listWorktrees(repoRoot: string): Promise<GitWorktreeInfo[]> {
+  static listWorktrees(repoRoot: string): ResultAsync<GitWorktreeInfo[], GitError> {
     const git = simpleGit(repoRoot)
-    try {
-      const raw = await git.raw(['worktree', 'list', '--porcelain'])
-      return parseWorktreeOutput(raw)
-    } catch {
-      return []
-    }
+    return gitCall('worktree list', git.raw(['worktree', 'list', '--porcelain'])).map(
+      parseWorktreeOutput,
+    )
   }
 
-  static async isDirty(repoRoot: string): Promise<boolean> {
+  static isDirty(repoRoot: string): ResultAsync<boolean, GitError> {
     const git = simpleGit(repoRoot)
-    try {
-      const status = await git.status()
-      return status.files.length > 0
-    } catch {
-      return false
-    }
+    return gitCall('status', git.status()).map((status) => status.files.length > 0)
   }
 
-  static async getAheadBehind(repoRoot: string): Promise<{ ahead: number; behind: number } | null> {
+  static getAheadBehind(
+    repoRoot: string,
+  ): ResultAsync<{ ahead: number; behind: number } | null, GitError> {
     const git = simpleGit(repoRoot)
-    try {
-      const raw = await git.raw(['rev-list', '--left-right', '--count', 'HEAD...@{upstream}'])
+    return gitCall(
+      'rev-list',
+      git.raw(['rev-list', '--left-right', '--count', 'HEAD...@{upstream}']),
+    ).map((raw) => {
       const parts = raw.trim().split(/\s+/)
       if (parts.length === 2) {
         return { ahead: parseInt(parts[0], 10), behind: parseInt(parts[1], 10) }
       }
       return null
-    } catch {
-      return null
-    }
+    })
   }
 
   // --- Write operations ---
 
-  static async commit(
+  static commit(
     repoRoot: string,
     message: string,
     stageAll?: boolean,
-  ): Promise<GitCommitResult> {
+  ): ResultAsync<GitCommitResult, GitError> {
     const git = simpleGit(repoRoot)
-    if (stageAll) {
-      await git.add('-A')
-    }
-    const result = await git.commit(message)
-    return {
-      hash: result.commit || '',
-      summary: result.summary
-        ? `${result.summary.changes} changed, ${result.summary.insertions} insertions, ${result.summary.deletions} deletions`
-        : 'Committed',
-    }
+    const doStage = stageAll ? gitCall('add', git.add('-A')) : okAsync<unknown, GitError>(undefined)
+    return doStage.andThen(() =>
+      gitCall('commit', git.commit(message)).map((result) => ({
+        hash: result.commit || '',
+        summary: result.summary
+          ? `${result.summary.changes} changed, ${result.summary.insertions} insertions, ${result.summary.deletions} deletions`
+          : 'Committed',
+      })),
+    )
   }
 
-  static async push(repoRoot: string): Promise<{ branch: string; remote: string }> {
+  static push(repoRoot: string): ResultAsync<{ branch: string; remote: string }, GitError> {
     const git = simpleGit(repoRoot)
-    const result = await git.push()
-    return {
+    return gitCall('push', git.push()).map((result) => ({
       branch: result.pushed?.[0]?.local || '',
       remote: result.remoteMessages?.all?.[0] || '',
-    }
+    }))
   }
 
-  static async pull(repoRoot: string, rebase: boolean): Promise<{ summary: string }> {
+  static pull(repoRoot: string, rebase: boolean): ResultAsync<{ summary: string }, GitError> {
     const git = simpleGit(repoRoot)
-    const result = await git.pull(undefined, undefined, rebase ? { '--rebase': null } : {})
-    const files = result.files?.length ?? 0
-    return { summary: `${files} file(s) updated` }
+    return gitCall('pull', git.pull(undefined, undefined, rebase ? { '--rebase': null } : {})).map(
+      (result) => {
+        const files = result.files?.length ?? 0
+        return { summary: `${files} file(s) updated` }
+      },
+    )
   }
 
-  static async fetch(repoRoot: string): Promise<void> {
+  static fetch(repoRoot: string): ResultAsync<void, GitError> {
     const git = simpleGit(repoRoot)
-    await git.fetch()
+    return gitCall('fetch', git.fetch()).map(() => undefined)
   }
 
-  static async fetchAll(repoRoot: string): Promise<void> {
+  static fetchAll(repoRoot: string): ResultAsync<void, GitError> {
     const git = simpleGit(repoRoot)
-    await git.fetch(['--all'])
+    return gitCall('fetch', git.fetch(['--all'])).map(() => undefined)
   }
 
-  static async stash(repoRoot: string): Promise<void> {
+  static stash(repoRoot: string): ResultAsync<void, GitError> {
     const git = simpleGit(repoRoot)
-    await git.stash()
+    return gitCall('stash', git.stash()).map(() => undefined)
   }
 
-  static async stashPop(repoRoot: string): Promise<void> {
+  static stashPop(repoRoot: string): ResultAsync<void, GitError> {
     const git = simpleGit(repoRoot)
-    await git.stash(['pop'])
+    return gitCall('stash pop', git.stash(['pop'])).map(() => undefined)
   }
 
-  static async listBranches(repoRoot: string): Promise<GitBranchList> {
+  static listBranches(repoRoot: string): ResultAsync<GitBranchList, GitError> {
     const git = simpleGit(repoRoot)
-    const result = await git.branch(['-a'])
-    const local: string[] = []
-    const remote: string[] = []
+    return gitCall('branch', git.branch(['-a'])).map((result) => {
+      const local: string[] = []
+      const remote: string[] = []
 
-    for (const [name, info] of Object.entries(result.branches)) {
-      if (name.startsWith('remotes/')) {
-        // Skip HEAD pointers like remotes/origin/HEAD
-        if (!name.endsWith('/HEAD')) {
-          remote.push(name.replace('remotes/', ''))
+      for (const [name, info] of Object.entries(result.branches)) {
+        if (name.startsWith('remotes/')) {
+          if (!name.endsWith('/HEAD')) {
+            remote.push(name.replace('remotes/', ''))
+          }
+        } else {
+          local.push(info.name)
         }
-      } else {
-        local.push(info.name)
       }
-    }
 
-    return { local, remote, current: result.current || null }
+      return { local, remote, current: result.current || null }
+    })
   }
 
-  static async createBranch(repoRoot: string, name: string, baseBranch: string): Promise<void> {
-    assertSafeRef(name)
-    assertSafeRef(baseBranch)
-    const git = simpleGit(repoRoot)
-    await git.raw(['branch', name, baseBranch])
+  static createBranch(
+    repoRoot: string,
+    name: string,
+    baseBranch: string,
+  ): ResultAsync<void, GitError> {
+    return validateRef(name)
+      .andThen(() => validateRef(baseBranch))
+      .asyncAndThen(() => {
+        const git = simpleGit(repoRoot)
+        return gitCall('branch', git.raw(['branch', name, baseBranch]))
+      })
+      .map(() => undefined)
   }
 
-  static async checkout(repoRoot: string, branch: string): Promise<void> {
-    assertSafeRef(branch)
-    const git = simpleGit(repoRoot)
-    await git.checkout(branch)
+  static checkout(repoRoot: string, branch: string): ResultAsync<void, GitError> {
+    return validateRef(branch)
+      .asyncAndThen(() => {
+        const git = simpleGit(repoRoot)
+        return gitCall('checkout', git.checkout(branch))
+      })
+      .map(() => undefined)
   }
 
-  static async deleteBranch(repoRoot: string, name: string, force: boolean): Promise<void> {
-    assertSafeRef(name)
-    const git = simpleGit(repoRoot)
-    await git.branch([force ? '-D' : '-d', name])
+  static deleteBranch(repoRoot: string, name: string, force: boolean): ResultAsync<void, GitError> {
+    return validateRef(name)
+      .asyncAndThen(() => {
+        const git = simpleGit(repoRoot)
+        return gitCall('branch -d', git.branch([force ? '-D' : '-d', name]))
+      })
+      .map(() => undefined)
   }
 
-  static async deleteRemoteBranch(repoRoot: string, remote: string, name: string): Promise<void> {
-    assertSafeRef(remote)
-    assertSafeRef(name)
-    const git = simpleGit(repoRoot)
-    await git.push(remote, name, { '--delete': null })
+  static deleteRemoteBranch(
+    repoRoot: string,
+    remote: string,
+    name: string,
+  ): ResultAsync<void, GitError> {
+    return validateRef(remote)
+      .andThen(() => validateRef(name))
+      .asyncAndThen(() => {
+        const git = simpleGit(repoRoot)
+        return gitCall('push --delete', git.push(remote, name, { '--delete': null }))
+      })
+      .map(() => undefined)
   }
 
-  static async getPushInfo(repoRoot: string): Promise<GitPushInfo | null> {
+  static getPushInfo(repoRoot: string): ResultAsync<GitPushInfo | null, GitError> {
     const git = simpleGit(repoRoot)
-    try {
-      const branch = (await git.revparse(['--abbrev-ref', 'HEAD'])).trim()
-      if (branch === 'HEAD') return null
+    return gitCall('rev-parse', git.revparse(['--abbrev-ref', 'HEAD'])).andThen((raw) => {
+      const branch = raw.trim()
+      if (branch === 'HEAD') return okAsync<GitPushInfo | null, GitError>(null)
 
-      const remote = (await git.raw(['config', `branch.${branch}.remote`])).trim()
-      if (!remote) return null
+      return gitCall('config', git.raw(['config', `branch.${branch}.remote`])).andThen(
+        (remoteRaw) => {
+          const remote = remoteRaw.trim()
+          if (!remote) return okAsync<GitPushInfo | null, GitError>(null)
 
-      const countRaw = await git.raw(['rev-list', '--count', `${remote}/${branch}..HEAD`])
-      const commitCount = parseInt(countRaw.trim(), 10) || 0
-
-      return { branch, remote, commitCount }
-    } catch {
-      return null
-    }
+          return gitCall(
+            'rev-list',
+            git.raw(['rev-list', '--count', `${remote}/${branch}..HEAD`]),
+          ).map((countRaw) => {
+            const commitCount = parseInt(countRaw.trim(), 10) || 0
+            return { branch, remote, commitCount }
+          })
+        },
+      )
+    })
   }
 
-  static async isBranchMerged(repoRoot: string, branch: string): Promise<boolean> {
+  static isBranchMerged(repoRoot: string, branch: string): ResultAsync<boolean, GitError> {
     const git = simpleGit(repoRoot)
-    try {
-      const raw = await git.raw(['branch', '--merged'])
+    return gitCall('branch --merged', git.raw(['branch', '--merged'])).map((raw) => {
       const merged = raw
         .split('\n')
         .map((line) => line.replace(/^\*?\s+/, '').trim())
         .filter(Boolean)
       return merged.includes(branch)
-    } catch {
-      return false
-    }
+    })
   }
 
-  static async worktreeAdd(
+  static worktreeAdd(
     repoRoot: string,
     path: string,
     branch: string,
     baseBranch: string,
-  ): Promise<void> {
-    assertSafeRef(branch)
-    assertSafeRef(baseBranch)
-    const git = simpleGit(repoRoot)
-    await git.raw(['worktree', 'add', '-b', branch, path, baseBranch])
+  ): ResultAsync<void, GitError> {
+    return validateRef(branch)
+      .andThen(() => validateRef(baseBranch))
+      .asyncAndThen(() => {
+        const git = simpleGit(repoRoot)
+        return gitCall('worktree add', git.raw(['worktree', 'add', '-b', branch, path, baseBranch]))
+      })
+      .map(() => undefined)
   }
 
-  static async worktreeRemove(repoRoot: string, path: string, force: boolean): Promise<void> {
+  static worktreeRemove(
+    repoRoot: string,
+    path: string,
+    force: boolean,
+  ): ResultAsync<void, GitError> {
     const git = simpleGit(repoRoot)
     const args = ['worktree', 'remove', path]
     if (force) args.push('--force')
-    await git.raw(args)
+    return gitCall('worktree remove', git.raw(args)).map(() => undefined)
   }
 
-  static async getUnmergedCommits(repoRoot: string, branch: string): Promise<string[]> {
-    assertSafeRef(branch)
-    const git = simpleGit(repoRoot)
-    try {
-      const raw = await git.raw(['log', branch, '--not', '--remotes', '--oneline'])
-      return raw.trim().split('\n').filter(Boolean)
-    } catch {
-      return []
-    }
+  static getUnmergedCommits(repoRoot: string, branch: string): ResultAsync<string[], GitError> {
+    return validateRef(branch).asyncAndThen(() => {
+      const git = simpleGit(repoRoot)
+      return gitCall('log', git.raw(['log', branch, '--not', '--remotes', '--oneline'])).map(
+        (raw) => raw.trim().split('\n').filter(Boolean),
+      )
+    })
   }
 
-  static async getStatusPorcelain(repoRoot: string, worktreePath?: string): Promise<string> {
+  static getStatusPorcelain(
+    repoRoot: string,
+    worktreePath?: string,
+  ): ResultAsync<string, GitError> {
     const git = simpleGit(worktreePath ?? repoRoot)
-    try {
-      return await git.raw(['status', '--porcelain'])
-    } catch {
-      return ''
-    }
+    return gitCall('status', git.raw(['status', '--porcelain']))
   }
 
-  static async getDiff(repoRoot: string): Promise<string> {
+  static getDiff(repoRoot: string): ResultAsync<string, GitError> {
     const git = simpleGit(repoRoot)
-    try {
-      const staged = await git.diff(['--cached'])
-      if (staged.trim()) return staged
-      return await git.diff()
-    } catch {
-      return ''
-    }
+    return gitCall('diff', git.diff(['--cached'])).andThen((staged) => {
+      if (staged.trim()) return okAsync<string, GitError>(staged)
+      return gitCall('diff', git.diff())
+    })
   }
 }
 

--- a/src/main/git/GitWatcher.ts
+++ b/src/main/git/GitWatcher.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import type { FSWatcher } from 'chokidar'
 import { GitRepository } from './GitRepository'
 import type { GitInfo } from './GitRepository'
+import { gitErrorMessage } from './errors'
 
 export interface GitRefreshFlags {
   branch: boolean
@@ -132,21 +133,24 @@ export class GitWatcher {
 
   private async refreshInfo(changes: GitRefreshFlags): Promise<GitInfo> {
     if (!this.lastInfo) {
-      const info = await GitRepository.detect(this.repoRoot)
-      this.lastInfo = info
-      return info
+      const result = await GitRepository.detect(this.repoRoot)
+      if (result.isErr()) throw new Error(gitErrorMessage(result.error))
+      this.lastInfo = result.value
+      return result.value
     }
 
     const [branch, worktrees, isDirty, aheadBehind] = await Promise.all([
       changes.branch
-        ? GitRepository.getBranch(this.repoRoot)
+        ? GitRepository.getBranch(this.repoRoot).unwrapOr(this.lastInfo.branch)
         : Promise.resolve(this.lastInfo.branch),
       changes.worktrees
-        ? GitRepository.listWorktrees(this.repoRoot)
+        ? GitRepository.listWorktrees(this.repoRoot).unwrapOr(this.lastInfo.worktrees)
         : Promise.resolve(this.lastInfo.worktrees),
-      changes.dirty ? GitRepository.isDirty(this.repoRoot) : Promise.resolve(this.lastInfo.isDirty),
+      changes.dirty
+        ? GitRepository.isDirty(this.repoRoot).unwrapOr(this.lastInfo.isDirty)
+        : Promise.resolve(this.lastInfo.isDirty),
       changes.aheadBehind
-        ? GitRepository.getAheadBehind(this.repoRoot)
+        ? GitRepository.getAheadBehind(this.repoRoot).unwrapOr(this.lastInfo.aheadBehind)
         : Promise.resolve(this.lastInfo.aheadBehind),
     ])
 

--- a/src/main/git/errors.ts
+++ b/src/main/git/errors.ts
@@ -1,0 +1,14 @@
+import { match } from 'ts-pattern'
+
+export type GitError =
+  | { _tag: 'NotAGitRepo'; path: string }
+  | { _tag: 'GitCommandFailed'; command: string; message: string }
+  | { _tag: 'InvalidRef'; ref: string }
+
+export function gitErrorMessage(error: GitError): string {
+  return match(error)
+    .with({ _tag: 'NotAGitRepo' }, (e) => `Not a git repository: ${e.path}`)
+    .with({ _tag: 'GitCommandFailed' }, (e) => `Git ${e.command} failed: ${e.message}`)
+    .with({ _tag: 'InvalidRef' }, (e) => `Invalid git ref: ${e.ref}`)
+    .exhaustive()
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,7 +56,7 @@ const checkWithChannelResolution = async (): Promise<void> => {
   try {
     const ch = preferencesStore.get('update.channel') ?? 'stable'
     if (ch === 'next') {
-      const effective = await resolveUpdateChannel(app.getVersion())
+      const effective = await resolveUpdateChannel(app.getVersion()).unwrapOr('next' as const)
       autoUpdater.channel = effective
       autoUpdater.allowPrerelease = true
     } else {
@@ -484,7 +484,7 @@ app.whenReady().then(async () => {
     async (_e, { fromVersion }: { fromVersion: string }) => {
       if (typeof fromVersion !== 'string' || !semver.valid(fromVersion)) return null
       const channel = (preferencesStore.get('update.channel') ?? 'stable') as 'stable' | 'next'
-      return fetchChangelogRange(fromVersion, app.getVersion(), channel)
+      return fetchChangelogRange(fromVersion, app.getVersion(), channel).unwrapOr(null)
     },
   )
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -3,6 +3,7 @@ import { ipcMain, dialog, shell, BrowserWindow, systemPreferences } from 'electr
 import os from 'os'
 import fs from 'fs'
 import path from 'path'
+import type { Result } from 'neverthrow'
 import type { PtyManager } from '../pty/PtyManager'
 import type { WsBridge } from '../pty/WsBridge'
 import type { WorkspaceStore } from '../db/WorkspaceStore'
@@ -27,6 +28,13 @@ import type { WorktreeSetupAction } from '../db/types'
 import { generateCommitMessage } from '../ai/commitMessageGenerator'
 import type { TaskTrackerManager } from '../taskTracker/TaskTrackerManager'
 import type { TaskTrackerProvider, TrackerTask } from '../taskTracker/types'
+import { taskTrackerErrorMessage } from '../taskTracker/errors'
+import { gitErrorMessage } from '../git/errors'
+
+function unwrapOrThrow<T, E>(result: Result<T, E>, toMessage: (e: E) => string): T {
+  if (result.isErr()) throw new Error(toMessage(result.error))
+  return result.value
+}
 import {
   buildVariables,
   renderBranchName,
@@ -494,20 +502,27 @@ export function registerIpcHandlers(
 
   // --- Git ---
 
+  const defaultGitInfo: GitInfo = {
+    isGitRepo: false,
+    repoRoot: null,
+    branch: null,
+    worktrees: [],
+    isDirty: false,
+    aheadBehind: null,
+  }
+
   ipcMain.handle('git:detect', async (_event, payload: { path: string }) => {
-    return GitRepository.detect(payload.path)
+    return GitRepository.detect(payload.path).unwrapOr(defaultGitInfo)
   })
 
   ipcMain.handle('git:worktrees', async (_event, payload: { repoRoot: string }) => {
-    return GitRepository.listWorktrees(payload.repoRoot)
+    return GitRepository.listWorktrees(payload.repoRoot).unwrapOr([])
   })
 
   ipcMain.handle('git:status', async (_event, payload: { path: string }) => {
-    const [branch, isDirty, aheadBehind] = await Promise.all([
-      GitRepository.getBranch(payload.path),
-      GitRepository.isDirty(payload.path),
-      GitRepository.getAheadBehind(payload.path),
-    ])
+    const branch = await GitRepository.getBranch(payload.path).unwrapOr(null)
+    const isDirty = await GitRepository.isDirty(payload.path).unwrapOr(false)
+    const aheadBehind = await GitRepository.getAheadBehind(payload.path).unwrapOr(null)
     return { branch, isDirty, aheadBehind }
   })
 
@@ -554,7 +569,7 @@ export function registerIpcHandlers(
 
   ipcMain.handle('git:init', async (_event, payload: { path: string }) => {
     await execFileAsync('git', ['init'], { cwd: payload.path })
-    return GitRepository.detect(payload.path)
+    return GitRepository.detect(payload.path).unwrapOr(defaultGitInfo)
   })
 
   // --- Workspace Git Status Refresh ---
@@ -562,7 +577,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'db:workspace:refreshGitStatus',
     async (_event, payload: { id: string; path: string }) => {
-      const info = await GitRepository.detect(payload.path)
+      const info = await GitRepository.detect(payload.path).unwrapOr(defaultGitInfo)
       const aheadBehind = info.aheadBehind ? JSON.stringify(info.aheadBehind) : null
       workspaceStore.updateGitCache(payload.id, {
         branch: info.branch,
@@ -579,71 +594,91 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'git:commit',
     async (_event, payload: { repoRoot: string; message: string; stageAll?: boolean }) => {
-      return GitRepository.commit(payload.repoRoot, payload.message, payload.stageAll)
+      const result = await GitRepository.commit(payload.repoRoot, payload.message, payload.stageAll)
+      return unwrapOrThrow(result, gitErrorMessage)
     },
   )
 
   ipcMain.handle('git:push', async (_event, payload: { repoRoot: string }) => {
-    return GitRepository.push(payload.repoRoot)
+    const result = await GitRepository.push(payload.repoRoot)
+    return unwrapOrThrow(result, gitErrorMessage)
   })
 
   ipcMain.handle('git:pull', async (_event, payload: { repoRoot: string; rebase: boolean }) => {
-    return GitRepository.pull(payload.repoRoot, payload.rebase)
+    const result = await GitRepository.pull(payload.repoRoot, payload.rebase)
+    return unwrapOrThrow(result, gitErrorMessage)
   })
 
   ipcMain.handle('git:fetch', async (_event, payload: { repoRoot: string }) => {
-    return GitRepository.fetch(payload.repoRoot)
+    const result = await GitRepository.fetch(payload.repoRoot)
+    return unwrapOrThrow(result, gitErrorMessage)
   })
 
   ipcMain.handle('git:fetchAll', async (_event, payload: { repoRoot: string }) => {
-    return GitRepository.fetchAll(payload.repoRoot)
+    const result = await GitRepository.fetchAll(payload.repoRoot)
+    return unwrapOrThrow(result, gitErrorMessage)
   })
 
   ipcMain.handle('git:stash', async (_event, payload: { repoRoot: string }) => {
-    return GitRepository.stash(payload.repoRoot)
+    const result = await GitRepository.stash(payload.repoRoot)
+    return unwrapOrThrow(result, gitErrorMessage)
   })
 
   ipcMain.handle('git:stashPop', async (_event, payload: { repoRoot: string }) => {
-    return GitRepository.stashPop(payload.repoRoot)
+    const result = await GitRepository.stashPop(payload.repoRoot)
+    return unwrapOrThrow(result, gitErrorMessage)
   })
 
   ipcMain.handle('git:branches', async (_event, payload: { repoRoot: string }) => {
-    return GitRepository.listBranches(payload.repoRoot)
+    const result = await GitRepository.listBranches(payload.repoRoot)
+    return unwrapOrThrow(result, gitErrorMessage)
   })
 
   ipcMain.handle(
     'git:branchCreate',
     async (_event, payload: { repoRoot: string; name: string; baseBranch: string }) => {
-      return GitRepository.createBranch(payload.repoRoot, payload.name, payload.baseBranch)
+      const result = await GitRepository.createBranch(
+        payload.repoRoot,
+        payload.name,
+        payload.baseBranch,
+      )
+      return unwrapOrThrow(result, gitErrorMessage)
     },
   )
 
   ipcMain.handle('git:checkout', async (_event, payload: { repoRoot: string; branch: string }) => {
-    return GitRepository.checkout(payload.repoRoot, payload.branch)
+    const result = await GitRepository.checkout(payload.repoRoot, payload.branch)
+    return unwrapOrThrow(result, gitErrorMessage)
   })
 
   ipcMain.handle(
     'git:branchDelete',
     async (_event, payload: { repoRoot: string; name: string; force: boolean }) => {
-      return GitRepository.deleteBranch(payload.repoRoot, payload.name, payload.force)
+      const result = await GitRepository.deleteBranch(payload.repoRoot, payload.name, payload.force)
+      return unwrapOrThrow(result, gitErrorMessage)
     },
   )
 
   ipcMain.handle(
     'git:branchDeleteRemote',
     async (_event, payload: { repoRoot: string; remote: string; name: string }) => {
-      return GitRepository.deleteRemoteBranch(payload.repoRoot, payload.remote, payload.name)
+      const result = await GitRepository.deleteRemoteBranch(
+        payload.repoRoot,
+        payload.remote,
+        payload.name,
+      )
+      return unwrapOrThrow(result, gitErrorMessage)
     },
   )
 
   ipcMain.handle('git:pushInfo', async (_event, payload: { repoRoot: string }) => {
-    return GitRepository.getPushInfo(payload.repoRoot)
+    return GitRepository.getPushInfo(payload.repoRoot).unwrapOr(null)
   })
 
   ipcMain.handle(
     'git:branchMerged',
     async (_event, payload: { repoRoot: string; branch: string }) => {
-      return GitRepository.isBranchMerged(payload.repoRoot, payload.branch)
+      return GitRepository.isBranchMerged(payload.repoRoot, payload.branch).unwrapOr(false)
     },
   )
 
@@ -656,38 +691,44 @@ export function registerIpcHandlers(
       const resolvedPath = payload.path.startsWith('~/')
         ? os.homedir() + payload.path.slice(1)
         : payload.path
-      return GitRepository.worktreeAdd(
+      const result = await GitRepository.worktreeAdd(
         payload.repoRoot,
         resolvedPath,
         payload.branch,
         payload.baseBranch,
       )
+      return unwrapOrThrow(result, gitErrorMessage)
     },
   )
 
   ipcMain.handle(
     'git:worktreeRemove',
     async (_event, payload: { repoRoot: string; path: string; force: boolean }) => {
-      return GitRepository.worktreeRemove(payload.repoRoot, payload.path, payload.force)
+      const result = await GitRepository.worktreeRemove(
+        payload.repoRoot,
+        payload.path,
+        payload.force,
+      )
+      return unwrapOrThrow(result, gitErrorMessage)
     },
   )
 
   ipcMain.handle(
     'git:unmergedCommits',
     async (_event, payload: { repoRoot: string; branch: string }) => {
-      return GitRepository.getUnmergedCommits(payload.repoRoot, payload.branch)
+      return GitRepository.getUnmergedCommits(payload.repoRoot, payload.branch).unwrapOr([])
     },
   )
 
   ipcMain.handle(
     'git:statusPorcelain',
     async (_event, payload: { repoRoot: string; worktreePath?: string }) => {
-      return GitRepository.getStatusPorcelain(payload.repoRoot, payload.worktreePath)
+      return GitRepository.getStatusPorcelain(payload.repoRoot, payload.worktreePath).unwrapOr('')
     },
   )
 
   ipcMain.handle('git:generateCommitMessage', async (_event, payload: { repoRoot: string }) => {
-    const diff = await GitRepository.getDiff(payload.repoRoot)
+    const diff = await GitRepository.getDiff(payload.repoRoot).unwrapOr('')
     if (!diff.trim()) return null
     return generateCommitMessage(diff, preferencesStore)
   })
@@ -1107,7 +1148,8 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'taskTracker:testConnection',
     async (_event, payload: { connectionId: string }) => {
-      return taskTrackerManager.testConnection(payload.connectionId)
+      const result = await taskTrackerManager.testConnection(payload.connectionId)
+      return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 
@@ -1130,12 +1172,14 @@ export function registerIpcHandlers(
         throw new Error('Base URL must use http:// or https://')
       }
       const { token, ...connectionData } = payload
-      return taskTrackerManager.testNewConnection(connectionData, token)
+      const result = await taskTrackerManager.testNewConnection(connectionData, token)
+      return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 
   ipcMain.handle('taskTracker:fetchBoards', async (_event, payload: { connectionId: string }) => {
-    return taskTrackerManager.fetchBoards(payload.connectionId)
+    const result = await taskTrackerManager.fetchBoards(payload.connectionId)
+    return unwrapOrThrow(result, taskTrackerErrorMessage)
   })
 
   ipcMain.handle(
@@ -1156,17 +1200,19 @@ export function registerIpcHandlers(
         throw new Error('Base URL must use http:// or https://')
       }
       const { token, ...connectionData } = payload
-      return taskTrackerManager.fetchBoardsForNew(
+      const result = await taskTrackerManager.fetchBoardsForNew(
         { ...connectionData, projectKey: connectionData.projectKey ?? '' },
         token,
       )
+      return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 
   ipcMain.handle(
     'taskTracker:fetchStatuses',
     async (_event, payload: { connectionId: string; boardId?: string }) => {
-      return taskTrackerManager.fetchStatuses(payload.connectionId, payload.boardId)
+      const result = await taskTrackerManager.fetchStatuses(payload.connectionId, payload.boardId)
+      return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 
@@ -1182,21 +1228,27 @@ export function registerIpcHandlers(
       },
     ) => {
       const { connectionId, ...params } = payload
-      return taskTrackerManager.fetchTasks(connectionId, params)
+      const result = await taskTrackerManager.fetchTasks(connectionId, params)
+      return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 
   ipcMain.handle(
     'taskTracker:getCurrentUser',
     async (_event, payload: { connectionId: string }) => {
-      return taskTrackerManager.getCurrentUserDisplayName(payload.connectionId)
+      const result = await taskTrackerManager.getCurrentUserDisplayName(payload.connectionId)
+      return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 
   ipcMain.handle(
     'taskTracker:getCurrentSprint',
     async (_event, payload: { connectionId: string; boardId?: string }) => {
-      return taskTrackerManager.getCurrentSprint(payload.connectionId, payload.boardId)
+      const result = await taskTrackerManager.getCurrentSprint(
+        payload.connectionId,
+        payload.boardId,
+      )
+      return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 
@@ -1240,7 +1292,7 @@ export function registerIpcHandlers(
       // Get sprint: from task data or from API
       const sprint = await taskTrackerManager
         .getCurrentSprint(payload.connectionId, payload.boardId)
-        .catch(() => null)
+        .unwrapOr(null)
 
       const variables = buildVariables(payload.task, sprint, customVars, payload.branchType)
       return renderBranchName(template, variables)
@@ -1416,7 +1468,8 @@ export function registerIpcHandlers(
         defaultBranch = preferencesStore.get('taskTracker.prDefaultBranch') || defaultBranch
       }
 
-      const branches = await GitRepository.listBranches(payload.repoRoot)
+      const branchResult = await GitRepository.listBranches(payload.repoRoot)
+      const branches = unwrapOrThrow(branchResult, gitErrorMessage)
       const existingBranches = [...branches.local, ...branches.remote]
 
       const prConfig = buildPRConfig(titleTemplate, bodyTemplate, defaultBranch, targetRules)
@@ -1449,7 +1502,7 @@ export function registerIpcHandlers(
 
       if (actions.length === 0) return { success: true, errors: [] }
 
-      const worktrees = await GitRepository.listWorktrees(payload.repoRoot)
+      const worktrees = await GitRepository.listWorktrees(payload.repoRoot).unwrapOr([])
       const mainWorktree = worktrees.find((wt) => wt.isMain)
       const mainWorktreePath = mainWorktree?.path ?? payload.repoRoot
 

--- a/src/main/taskTracker/TaskTrackerManager.ts
+++ b/src/main/taskTracker/TaskTrackerManager.ts
@@ -1,4 +1,6 @@
+import { ok, err, type Result, type ResultAsync } from 'neverthrow'
 import type { PreferencesStore } from '../db/PreferencesStore'
+import type { TaskTrackerError } from './errors'
 import { createProviderClient } from './providers'
 import type {
   TaskTrackerConnection,
@@ -27,16 +29,16 @@ export class TaskTrackerManager {
     this.preferencesStore.set(CONNECTIONS_PREF_KEY, JSON.stringify(connections))
   }
 
-  private getConnection(connectionId: string): TaskTrackerConnection {
+  private getConnection(connectionId: string): Result<TaskTrackerConnection, TaskTrackerError> {
     const conn = this.getConnections().find((c) => c.id === connectionId)
-    if (!conn) throw new Error(`Connection not found: ${connectionId}`)
-    return conn
+    if (!conn) return err({ _tag: 'ConnectionNotFound', connectionId })
+    return ok(conn)
   }
 
-  private getToken(connection: TaskTrackerConnection): string {
+  private getToken(connection: TaskTrackerConnection): Result<string, TaskTrackerError> {
     const token = this.preferencesStore.get(connection.authPrefKey)
-    if (!token) throw new Error(`No auth token for connection: ${connection.name}`)
-    return token
+    if (!token) return err({ _tag: 'AuthTokenMissing', connectionName: connection.name })
+    return ok(token)
   }
 
   addConnection(
@@ -90,17 +92,19 @@ export class TaskTrackerManager {
     this.saveConnections(connections.filter((c) => c.id !== connectionId))
   }
 
-  async testConnection(connectionId: string): Promise<boolean> {
-    const conn = this.getConnection(connectionId)
-    const token = this.getToken(conn)
-    const client = createProviderClient(conn.provider)
-    return client.testConnection(conn, token)
+  testConnection(connectionId: string): ResultAsync<boolean, TaskTrackerError> {
+    return this.getConnection(connectionId)
+      .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
+      .asyncAndThen(({ conn, token }) => {
+        const client = createProviderClient(conn.provider)
+        return client.testConnection(conn, token)
+      })
   }
 
-  async testNewConnection(
+  testNewConnection(
     connection: Omit<TaskTrackerConnection, 'id' | 'authPrefKey'>,
     token: string,
-  ): Promise<boolean> {
+  ): ResultAsync<boolean, TaskTrackerError> {
     const tempConn: TaskTrackerConnection = {
       ...connection,
       id: 'temp',
@@ -110,10 +114,10 @@ export class TaskTrackerManager {
     return client.testConnection(tempConn, token)
   }
 
-  async fetchBoardsForNew(
+  fetchBoardsForNew(
     connection: Omit<TaskTrackerConnection, 'id' | 'authPrefKey'>,
     token: string,
-  ): Promise<TrackerBoard[]> {
+  ): ResultAsync<TrackerBoard[], TaskTrackerError> {
     const tempConn: TaskTrackerConnection = {
       ...connection,
       id: 'temp',
@@ -126,53 +130,66 @@ export class TaskTrackerManager {
   async findTaskByKey(taskKey: string): Promise<TrackerTask | null> {
     const connections = this.getConnections()
     for (const conn of connections) {
-      try {
-        const token = this.getToken(conn)
-        const client = createProviderClient(conn.provider)
-        const found = await client.fetchTaskByKey(conn, token, taskKey)
-        if (found) return found
-      } catch {
-        // try next connection
-      }
+      const tokenResult = this.getToken(conn)
+      if (tokenResult.isErr()) continue
+      const client = createProviderClient(conn.provider)
+      const result = await client.fetchTaskByKey(conn, tokenResult.value, taskKey)
+      if (result.isOk() && result.value) return result.value
     }
     return null
   }
 
-  async getCurrentUserDisplayName(connectionId: string): Promise<string> {
-    const conn = this.getConnection(connectionId)
-    const token = this.getToken(conn)
-    const client = createProviderClient(conn.provider)
-    return client.getCurrentUserDisplayName(conn, token)
+  getCurrentUserDisplayName(connectionId: string): ResultAsync<string, TaskTrackerError> {
+    return this.getConnection(connectionId)
+      .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
+      .asyncAndThen(({ conn, token }) => {
+        const client = createProviderClient(conn.provider)
+        return client.getCurrentUserDisplayName(conn, token)
+      })
   }
 
-  async fetchBoards(connectionId: string): Promise<TrackerBoard[]> {
-    const conn = this.getConnection(connectionId)
-    const token = this.getToken(conn)
-    const client = createProviderClient(conn.provider)
-    return client.fetchBoards(conn, token)
+  fetchBoards(connectionId: string): ResultAsync<TrackerBoard[], TaskTrackerError> {
+    return this.getConnection(connectionId)
+      .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
+      .asyncAndThen(({ conn, token }) => {
+        const client = createProviderClient(conn.provider)
+        return client.fetchBoards(conn, token)
+      })
   }
 
-  async fetchStatuses(connectionId: string, boardId?: string): Promise<TrackerStatus[]> {
-    const conn = this.getConnection(connectionId)
-    const token = this.getToken(conn)
-    const client = createProviderClient(conn.provider)
-    return client.fetchStatuses(conn, token, boardId)
+  fetchStatuses(
+    connectionId: string,
+    boardId?: string,
+  ): ResultAsync<TrackerStatus[], TaskTrackerError> {
+    return this.getConnection(connectionId)
+      .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
+      .asyncAndThen(({ conn, token }) => {
+        const client = createProviderClient(conn.provider)
+        return client.fetchStatuses(conn, token, boardId)
+      })
   }
 
-  async fetchTasks(
+  fetchTasks(
     connectionId: string,
     params: { statuses?: string[]; assignedToMe?: boolean; boardId?: string },
-  ): Promise<TrackerTask[]> {
-    const conn = this.getConnection(connectionId)
-    const token = this.getToken(conn)
-    const client = createProviderClient(conn.provider)
-    return client.fetchTasks(conn, token, params)
+  ): ResultAsync<TrackerTask[], TaskTrackerError> {
+    return this.getConnection(connectionId)
+      .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
+      .asyncAndThen(({ conn, token }) => {
+        const client = createProviderClient(conn.provider)
+        return client.fetchTasks(conn, token, params)
+      })
   }
 
-  async getCurrentSprint(connectionId: string, boardId?: string): Promise<TrackerSprint | null> {
-    const conn = this.getConnection(connectionId)
-    const token = this.getToken(conn)
-    const client = createProviderClient(conn.provider)
-    return client.getCurrentSprint(conn, token, boardId)
+  getCurrentSprint(
+    connectionId: string,
+    boardId?: string,
+  ): ResultAsync<TrackerSprint | null, TaskTrackerError> {
+    return this.getConnection(connectionId)
+      .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
+      .asyncAndThen(({ conn, token }) => {
+        const client = createProviderClient(conn.provider)
+        return client.getCurrentSprint(conn, token, boardId)
+      })
   }
 }

--- a/src/main/taskTracker/errors.ts
+++ b/src/main/taskTracker/errors.ts
@@ -1,0 +1,15 @@
+import { match } from 'ts-pattern'
+import type { TaskTrackerProvider } from './types'
+
+export type TaskTrackerError =
+  | { _tag: 'ConnectionNotFound'; connectionId: string }
+  | { _tag: 'AuthTokenMissing'; connectionName: string }
+  | { _tag: 'ProviderApiError'; status: number; message: string; provider: TaskTrackerProvider }
+
+export function taskTrackerErrorMessage(error: TaskTrackerError): string {
+  return match(error)
+    .with({ _tag: 'ConnectionNotFound' }, (e) => `Connection not found: ${e.connectionId}`)
+    .with({ _tag: 'AuthTokenMissing' }, (e) => `No auth token for ${e.connectionName}`)
+    .with({ _tag: 'ProviderApiError' }, (e) => `${e.provider} API error ${e.status}: ${e.message}`)
+    .exhaustive()
+}

--- a/src/main/taskTracker/prCreation.ts
+++ b/src/main/taskTracker/prCreation.ts
@@ -41,12 +41,8 @@ export async function createPullRequest(params: CreatePRParams): Promise<CreateP
     existingBranches,
   )
 
-  // Ensure branch is pushed
-  try {
-    await GitRepository.push(repoRoot)
-  } catch {
-    // May already be pushed or upstream set
-  }
+  // Ensure branch is pushed (ignore errors -- may already be pushed or upstream set)
+  await GitRepository.push(repoRoot).unwrapOr({ branch: '', remote: '' })
 
   const hasGh = await detectGhCli()
   if (!hasGh) {

--- a/src/main/taskTracker/providers/jira.ts
+++ b/src/main/taskTracker/providers/jira.ts
@@ -1,3 +1,6 @@
+import { okAsync, errAsync, type ResultAsync } from 'neverthrow'
+import type { TaskTrackerError } from '../errors'
+import { fromExternalCall, errorMessage } from '../../errors'
 import type {
   TaskTrackerConnection,
   TaskTrackerProviderClient,
@@ -40,21 +43,31 @@ function buildAuthHeaders(connection: TaskTrackerConnection, token: string): Hea
   }
 }
 
-async function jiraFetch<T>(
+function apiError(status: number, message: string): TaskTrackerError {
+  return { _tag: 'ProviderApiError', status, message, provider: 'jira' }
+}
+
+function jiraFetch<T>(
   connection: TaskTrackerConnection,
   token: string,
   path: string,
-): Promise<T> {
+): ResultAsync<T, TaskTrackerError> {
   const url = `${connection.baseUrl.replace(/\/$/, '')}${path}`
-  const res = await fetch(url, {
-    headers: buildAuthHeaders(connection, token),
-    signal: AbortSignal.timeout(15_000),
+  return fromExternalCall(
+    fetch(url, {
+      headers: buildAuthHeaders(connection, token),
+      signal: AbortSignal.timeout(15_000),
+    }),
+    (e) => apiError(0, errorMessage(e)),
+  ).andThen((res) => {
+    if (!res.ok) {
+      return fromExternalCall(
+        res.text().catch(() => ''),
+        (e) => apiError(res.status, errorMessage(e)),
+      ).andThen((body) => errAsync(apiError(res.status, body || res.statusText)))
+    }
+    return fromExternalCall(res.json() as Promise<T>, (e) => apiError(0, errorMessage(e)))
   })
-  if (!res.ok) {
-    const body = await res.text().catch(() => '')
-    throw new Error(`Jira API error ${res.status}: ${body || res.statusText}`)
-  }
-  return res.json() as Promise<T>
 }
 
 function mapTaskType(fields: JiraTaskFields): string {
@@ -103,110 +116,102 @@ function mapJiraTask(task: JiraTask, baseUrl: string): TrackerTask {
 }
 
 export const jiraClient: TaskTrackerProviderClient = {
-  async testConnection(connection, token) {
-    await jiraFetch(connection, token, '/rest/api/3/myself')
-    return true
+  testConnection(connection, token) {
+    return jiraFetch(connection, token, '/rest/api/3/myself').map(() => true)
   },
 
-  async getCurrentUserDisplayName(connection, token) {
-    const data = await jiraFetch<{ displayName?: string }>(connection, token, '/rest/api/3/myself')
-    return data.displayName ?? ''
+  getCurrentUserDisplayName(connection, token) {
+    return jiraFetch<{ displayName?: string }>(connection, token, '/rest/api/3/myself').map(
+      (data) => data.displayName ?? '',
+    )
   },
 
-  async fetchTaskByKey(connection, token, taskKey) {
-    try {
-      const fields = 'summary,description,status,priority,issuetype,parent,assignee,sprint'
-      const data = await jiraFetch<JiraTask>(
-        connection,
-        token,
-        `/rest/api/3/issue/${encodeURIComponent(taskKey)}?fields=${fields}`,
-      )
-      return mapJiraTask(data, connection.baseUrl)
-    } catch {
-      return null
-    }
+  fetchTaskByKey(connection, token, taskKey) {
+    const fields = 'summary,description,status,priority,issuetype,parent,assignee,sprint'
+    return jiraFetch<JiraTask>(
+      connection,
+      token,
+      `/rest/api/3/issue/${encodeURIComponent(taskKey)}?fields=${fields}`,
+    ).map((data) => mapJiraTask(data, connection.baseUrl) as TrackerTask | null)
   },
 
-  async fetchBoards(connection, token) {
+  fetchBoards(connection, token) {
     const params = connection.projectKey
       ? `?projectKeyOrId=${encodeURIComponent(connection.projectKey)}`
       : '?maxResults=50'
-    const data = await jiraFetch<{
+    return jiraFetch<{
       values: Array<{
         id: number
         name: string
         location?: { projectKey?: string }
       }>
-    }>(connection, token, `/rest/agile/1.0/board${params}`)
-    return data.values.map(
-      (b): TrackerBoard => ({
-        id: String(b.id),
-        name: b.name,
-        projectKey: b.location?.projectKey,
-      }),
+    }>(connection, token, `/rest/agile/1.0/board${params}`).map((data) =>
+      data.values.map(
+        (b): TrackerBoard => ({
+          id: String(b.id),
+          name: b.name,
+          projectKey: b.location?.projectKey,
+        }),
+      ),
     )
   },
 
-  async fetchStatuses(connection, token) {
-    // Use /rest/api/3/statuses to get all actual task statuses
-    try {
-      const data = await jiraFetch<
-        Array<{ id: string; name: string; statusCategory?: { key?: string } }>
-      >(connection, token, '/rest/api/3/statuses')
-      const seen = new Set<string>()
-      const statuses: TrackerStatus[] = []
-      for (const s of data) {
-        if (!seen.has(s.name)) {
-          seen.add(s.name)
-          statuses.push({ id: s.id, name: s.name })
-        }
-      }
-      return statuses
-    } catch {
-      // Fallback: try project statuses if available
-      if (connection.projectKey) {
-        const data = await jiraFetch<Array<{ statuses?: Array<{ id: string; name: string }> }>>(
-          connection,
-          token,
-          `/rest/api/3/project/${encodeURIComponent(connection.projectKey)}/statuses`,
-        )
+  fetchStatuses(connection, token) {
+    return jiraFetch<Array<{ id: string; name: string; statusCategory?: { key?: string } }>>(
+      connection,
+      token,
+      '/rest/api/3/statuses',
+    )
+      .map((data) => {
         const seen = new Set<string>()
         const statuses: TrackerStatus[] = []
-        for (const category of data) {
-          for (const s of category.statuses ?? []) {
-            if (!seen.has(s.name)) {
-              seen.add(s.name)
-              statuses.push({ id: s.id, name: s.name })
-            }
+        for (const s of data) {
+          if (!seen.has(s.name)) {
+            seen.add(s.name)
+            statuses.push({ id: s.id, name: s.name })
           }
         }
         return statuses
-      }
-      return []
-    }
+      })
+      .orElse(() => {
+        if (connection.projectKey) {
+          return jiraFetch<Array<{ statuses?: Array<{ id: string; name: string }> }>>(
+            connection,
+            token,
+            `/rest/api/3/project/${encodeURIComponent(connection.projectKey)}/statuses`,
+          ).map((data) => {
+            const seen = new Set<string>()
+            const statuses: TrackerStatus[] = []
+            for (const category of data) {
+              for (const s of category.statuses ?? []) {
+                if (!seen.has(s.name)) {
+                  seen.add(s.name)
+                  statuses.push({ id: s.id, name: s.name })
+                }
+              }
+            }
+            return statuses
+          })
+        }
+        return errAsync(apiError(0, 'No statuses available'))
+      })
   },
 
-  async fetchTasks(connection, token, params) {
+  fetchTasks(connection, token, params) {
     const resolvedBoardId = params.boardId || connection.boardId
     const fields = 'summary,status,priority,issuetype,parent,assignee,sprint'
 
-    // Board endpoint returns ONLY tasks belonging to this board's filter
     if (resolvedBoardId) {
-      // Exclude done tasks, sort by recent, single request
       const jql = 'statusCategory != Done ORDER BY updated DESC'
       const jqlParam = `&jql=${encodeURIComponent(jql)}`
 
-      const data = await jiraFetch<{ issues: JiraTask[] }>(
+      return jiraFetch<{ issues: JiraTask[] }>(
         connection,
         token,
         `/rest/agile/1.0/board/${encodeURIComponent(resolvedBoardId)}/issue?fields=${fields}&maxResults=200${jqlParam}`,
-      )
-      const allTasks = data.issues
-
-      return allTasks.map((i) => mapJiraTask(i, connection.baseUrl))
+      ).map((data) => data.issues.map((i) => mapJiraTask(i, connection.baseUrl)))
     }
 
-    // No board — fallback to JQL search for assigned tasks
     const jqlParts: string[] = []
     if (connection.projectKey && /^[A-Za-z0-9_-]+$/.test(connection.projectKey)) {
       jqlParts.push(`project = "${connection.projectKey}"`)
@@ -214,38 +219,39 @@ export const jiraClient: TaskTrackerProviderClient = {
     jqlParts.push('assignee = currentUser()')
 
     const jql = jqlParts.join(' AND ') + ' ORDER BY updated DESC'
-    const data = await jiraFetch<{ issues: JiraTask[] }>(
+    return jiraFetch<{ issues: JiraTask[] }>(
       connection,
       token,
       `/rest/api/3/search/jql?jql=${encodeURIComponent(jql)}&fields=${encodeURIComponent(fields)}&maxResults=200`,
-    )
-
-    return data.issues.map((i) => mapJiraTask(i, connection.baseUrl))
+    ).map((data) => data.issues.map((i) => mapJiraTask(i, connection.baseUrl)))
   },
 
-  async getCurrentSprint(connection, token, boardId) {
-    if (!boardId) {
-      const boards = await jiraClient.fetchBoards(connection, token)
-      if (boards.length === 0) return null
-      boardId = boards[0].id
-    }
+  getCurrentSprint(connection, token, boardId) {
+    const getBoardId: ResultAsync<string, TaskTrackerError> = boardId
+      ? okAsync(boardId)
+      : jiraClient.fetchBoards(connection, token).andThen((boards) => {
+          if (boards.length === 0) return errAsync(apiError(0, 'No boards found'))
+          return okAsync(boards[0].id)
+        })
 
-    const data = await jiraFetch<{
-      values: Array<{ id: number; name: string; state: string }>
-    }>(
-      connection,
-      token,
-      `/rest/agile/1.0/board/${encodeURIComponent(boardId)}/sprint?state=active&maxResults=1`,
+    return getBoardId.andThen((resolvedBoardId) =>
+      jiraFetch<{
+        values: Array<{ id: number; name: string; state: string }>
+      }>(
+        connection,
+        token,
+        `/rest/agile/1.0/board/${encodeURIComponent(resolvedBoardId)}/sprint?state=active&maxResults=1`,
+      ).map((data) => {
+        const sprint = data.values[0]
+        if (!sprint) return null
+
+        return {
+          id: String(sprint.id),
+          name: sprint.name,
+          number: parseSprintNumber(sprint.name),
+          state: sprint.state as TrackerSprint['state'],
+        }
+      }),
     )
-
-    const sprint = data.values[0]
-    if (!sprint) return null
-
-    return {
-      id: String(sprint.id),
-      name: sprint.name,
-      number: parseSprintNumber(sprint.name),
-      state: sprint.state as TrackerSprint['state'],
-    }
   },
 }

--- a/src/main/taskTracker/providers/youtrack.ts
+++ b/src/main/taskTracker/providers/youtrack.ts
@@ -1,3 +1,6 @@
+import { okAsync, errAsync, type ResultAsync } from 'neverthrow'
+import type { TaskTrackerError } from '../errors'
+import { fromExternalCall, errorMessage } from '../../errors'
 import type {
   TaskTrackerConnection,
   TaskTrackerProviderClient,
@@ -30,21 +33,31 @@ function buildHeaders(token: string): HeadersInit {
   }
 }
 
-async function ytFetch<T>(
+function apiError(status: number, message: string): TaskTrackerError {
+  return { _tag: 'ProviderApiError', status, message, provider: 'youtrack' }
+}
+
+function ytFetch<T>(
   connection: TaskTrackerConnection,
   token: string,
   path: string,
-): Promise<T> {
+): ResultAsync<T, TaskTrackerError> {
   const url = `${connection.baseUrl.replace(/\/$/, '')}${path}`
-  const res = await fetch(url, {
-    headers: buildHeaders(token),
-    signal: AbortSignal.timeout(15_000),
+  return fromExternalCall(
+    fetch(url, {
+      headers: buildHeaders(token),
+      signal: AbortSignal.timeout(15_000),
+    }),
+    (e) => apiError(0, errorMessage(e)),
+  ).andThen((res) => {
+    if (!res.ok) {
+      return fromExternalCall(
+        res.text().catch(() => ''),
+        (e) => apiError(res.status, errorMessage(e)),
+      ).andThen((body) => errAsync(apiError(res.status, body || res.statusText)))
+    }
+    return fromExternalCall(res.json() as Promise<T>, (e) => apiError(0, errorMessage(e)))
   })
-  if (!res.ok) {
-    const body = await res.text().catch(() => '')
-    throw new Error(`YouTrack API error ${res.status}: ${body || res.statusText}`)
-  }
-  return res.json() as Promise<T>
 }
 
 function extractField(task: YTTask, fieldName: string): string {
@@ -94,57 +107,51 @@ function mapYTTask(task: YTTask, baseUrl: string): TrackerTask {
 }
 
 export const youtrackClient: TaskTrackerProviderClient = {
-  async testConnection(connection, token) {
-    await ytFetch(connection, token, '/api/users/me?fields=id,login')
-    return true
+  testConnection(connection, token) {
+    return ytFetch(connection, token, '/api/users/me?fields=id,login').map(() => true)
   },
 
-  async getCurrentUserDisplayName(connection, token) {
-    const data = await ytFetch<{ name?: string; fullName?: string }>(
+  getCurrentUserDisplayName(connection, token) {
+    return ytFetch<{ name?: string; fullName?: string }>(
       connection,
       token,
       '/api/users/me?fields=name,fullName',
-    )
-    return data.fullName ?? data.name ?? ''
+    ).map((data) => data.fullName ?? data.name ?? '')
   },
 
-  async fetchTaskByKey(connection, token, taskKey) {
-    try {
-      const fields =
-        'id,idReadable,summary,description,fields(name,projectCustomField(field(name)),value(name,login)),parent(issues(idReadable))'
-      const data = await ytFetch<YTTask>(
-        connection,
-        token,
-        `/api/issues/${encodeURIComponent(taskKey)}?fields=${encodeURIComponent(fields)}`,
-      )
-      return mapYTTask(data, connection.baseUrl)
-    } catch {
-      return null
-    }
+  fetchTaskByKey(connection, token, taskKey) {
+    const fields =
+      'id,idReadable,summary,description,fields(name,projectCustomField(field(name)),value(name,login)),parent(issues(idReadable))'
+    return ytFetch<YTTask>(
+      connection,
+      token,
+      `/api/issues/${encodeURIComponent(taskKey)}?fields=${encodeURIComponent(fields)}`,
+    ).map((data) => mapYTTask(data, connection.baseUrl) as TrackerTask | null)
   },
 
-  async fetchBoards(connection, token) {
-    const data = await ytFetch<
+  fetchBoards(connection, token) {
+    return ytFetch<
       Array<{
         id: string
         name: string
         projects?: Array<{ shortName?: string }>
       }>
-    >(connection, token, `/api/agiles?fields=id,name,projects(shortName)&$top=50`)
-    return data.map(
-      (b): TrackerBoard => ({
-        id: b.id,
-        name: b.name,
-        projectKey: b.projects?.[0]?.shortName,
-      }),
+    >(connection, token, `/api/agiles?fields=id,name,projects(shortName)&$top=50`).map((data) =>
+      data.map(
+        (b): TrackerBoard => ({
+          id: b.id,
+          name: b.name,
+          projectKey: b.projects?.[0]?.shortName,
+        }),
+      ),
     )
   },
 
-  async fetchStatuses(connection, token) {
+  fetchStatuses(connection, token) {
     const projectKey = connection.projectKey
-    if (!projectKey) return []
+    if (!projectKey) return okAsync([])
 
-    const data = await ytFetch<
+    return ytFetch<
       Array<{
         id: string
         name: string
@@ -154,94 +161,98 @@ export const youtrackClient: TaskTrackerProviderClient = {
       connection,
       token,
       `/api/admin/projects/${encodeURIComponent(projectKey)}/customFields?fields=id,name,bundle(values(name))&$top=50`,
-    )
+    ).map((data) => {
+      const stateField = data.find(
+        (f) => f.name === 'State' || f.name.toLowerCase().includes('state'),
+      )
+      if (!stateField?.values) return []
 
-    const stateField = data.find(
-      (f) => f.name === 'State' || f.name.toLowerCase().includes('state'),
-    )
-    if (!stateField?.values) return []
-
-    return stateField.values.map(
-      (v): TrackerStatus => ({
-        id: v.name,
-        name: v.name,
-      }),
-    )
+      return stateField.values.map(
+        (v): TrackerStatus => ({
+          id: v.name,
+          name: v.name,
+        }),
+      )
+    })
   },
 
-  async fetchTasks(connection, token, params) {
-    const queryParts: string[] = []
-
-    // Get project from connection or resolve from board
-    let projectKey = connection.projectKey
-    if (!projectKey && params.boardId) {
-      try {
-        const board = await ytFetch<{ projects?: Array<{ shortName?: string }> }>(
+  fetchTasks(connection, token, params) {
+    const projectFromBoard = params.boardId
+      ? ytFetch<{ projects?: Array<{ shortName?: string }> }>(
           connection,
           token,
           `/api/agiles/${encodeURIComponent(params.boardId)}?fields=projects(shortName)`,
         )
-        projectKey = board.projects?.[0]?.shortName ?? ''
-      } catch {
-        // can't determine project
-      }
-    }
+          .map((board) => board.projects?.[0]?.shortName ?? '')
+          .unwrapOr('')
+      : Promise.resolve('')
 
-    if (projectKey && /^[A-Za-z0-9_-]+$/.test(projectKey)) {
-      queryParts.push(`project: {${projectKey}}`)
-    }
+    const resolvedProject = connection.projectKey
+      ? Promise.resolve(connection.projectKey)
+      : projectFromBoard
 
-    if (params.assignedToMe) {
-      queryParts.push('for: me')
-    }
+    return fromExternalCall(resolvedProject, (e) => apiError(0, errorMessage(e))).andThen(
+      (projectKey) => {
+        const queryParts: string[] = []
 
-    const query = queryParts.join(' ') + ' sort by: updated desc'
-    const fields =
-      'id,idReadable,summary,fields(name,projectCustomField(field(name)),value(name,login)),parent(issues(idReadable))'
-    const data = await ytFetch<YTTask[]>(
-      connection,
-      token,
-      `/api/issues?query=${encodeURIComponent(query)}&fields=${encodeURIComponent(fields)}&$top=200`,
+        if (projectKey && /^[A-Za-z0-9_-]+$/.test(projectKey)) {
+          queryParts.push(`project: {${projectKey}}`)
+        }
+
+        if (params.assignedToMe) {
+          queryParts.push('for: me')
+        }
+
+        const query = queryParts.join(' ') + ' sort by: updated desc'
+        const fields =
+          'id,idReadable,summary,fields(name,projectCustomField(field(name)),value(name,login)),parent(issues(idReadable))'
+        return ytFetch<YTTask[]>(
+          connection,
+          token,
+          `/api/issues?query=${encodeURIComponent(query)}&fields=${encodeURIComponent(fields)}&$top=200`,
+        ).map((data) => data.map((i) => mapYTTask(i, connection.baseUrl)))
+      },
     )
-
-    return data.map((i) => mapYTTask(i, connection.baseUrl))
   },
 
-  async getCurrentSprint(connection, token, boardId) {
-    if (!boardId) {
-      const boards = await youtrackClient.fetchBoards(connection, token)
-      if (boards.length === 0) return null
-      boardId = boards[0].id
-    }
+  getCurrentSprint(connection, token, boardId) {
+    const getBoardId = boardId
+      ? okAsync<string, TaskTrackerError>(boardId)
+      : youtrackClient.fetchBoards(connection, token).andThen((boards) => {
+          if (boards.length === 0) return errAsync(apiError(0, 'No boards found'))
+          return okAsync<string, TaskTrackerError>(boards[0].id)
+        })
 
-    const data = await ytFetch<
-      Array<{ id: string; name: string; isResolved?: boolean; start?: number; finish?: number }>
-    >(
-      connection,
-      token,
-      `/api/agiles/${encodeURIComponent(boardId)}/sprints?fields=id,name,isResolved,start,finish&$top=10`,
+    return getBoardId.andThen((resolvedBoardId) =>
+      ytFetch<
+        Array<{ id: string; name: string; isResolved?: boolean; start?: number; finish?: number }>
+      >(
+        connection,
+        token,
+        `/api/agiles/${encodeURIComponent(resolvedBoardId)}/sprints?fields=id,name,isResolved,start,finish&$top=10`,
+      ).map((data) => {
+        const now = Date.now()
+        const active = data.find(
+          (s) => !s.isResolved && s.start && s.finish && s.start <= now && s.finish >= now,
+        )
+        if (!active) {
+          const unresolved = data.find((s) => !s.isResolved)
+          if (!unresolved) return null
+          return {
+            id: unresolved.id,
+            name: unresolved.name,
+            number: parseSprintNumber(unresolved.name),
+            state: 'active' as const,
+          }
+        }
+
+        return {
+          id: active.id,
+          name: active.name,
+          number: parseSprintNumber(active.name),
+          state: 'active' as const,
+        }
+      }),
     )
-
-    const now = Date.now()
-    const active = data.find(
-      (s) => !s.isResolved && s.start && s.finish && s.start <= now && s.finish >= now,
-    )
-    if (!active) {
-      const unresolved = data.find((s) => !s.isResolved)
-      if (!unresolved) return null
-      return {
-        id: unresolved.id,
-        name: unresolved.name,
-        number: parseSprintNumber(unresolved.name),
-        state: 'active' as const,
-      }
-    }
-
-    return {
-      id: active.id,
-      name: active.name,
-      number: parseSprintNumber(active.name),
-      state: 'active' as const,
-    }
   },
 }

--- a/src/main/taskTracker/types.ts
+++ b/src/main/taskTracker/types.ts
@@ -1,3 +1,6 @@
+import type { ResultAsync } from 'neverthrow'
+import type { TaskTrackerError } from './errors'
+
 export type TaskTrackerProvider = 'jira' | 'youtrack'
 
 export interface TaskTrackerConnection {
@@ -89,27 +92,36 @@ export interface FetchTasksParams {
 }
 
 export interface TaskTrackerProviderClient {
-  testConnection(connection: TaskTrackerConnection, token: string): Promise<boolean>
-  getCurrentUserDisplayName(connection: TaskTrackerConnection, token: string): Promise<string>
+  testConnection(
+    connection: TaskTrackerConnection,
+    token: string,
+  ): ResultAsync<boolean, TaskTrackerError>
+  getCurrentUserDisplayName(
+    connection: TaskTrackerConnection,
+    token: string,
+  ): ResultAsync<string, TaskTrackerError>
   fetchTaskByKey(
     connection: TaskTrackerConnection,
     token: string,
     taskKey: string,
-  ): Promise<TrackerTask | null>
-  fetchBoards(connection: TaskTrackerConnection, token: string): Promise<TrackerBoard[]>
+  ): ResultAsync<TrackerTask | null, TaskTrackerError>
+  fetchBoards(
+    connection: TaskTrackerConnection,
+    token: string,
+  ): ResultAsync<TrackerBoard[], TaskTrackerError>
   fetchStatuses(
     connection: TaskTrackerConnection,
     token: string,
     boardId?: string,
-  ): Promise<TrackerStatus[]>
+  ): ResultAsync<TrackerStatus[], TaskTrackerError>
   fetchTasks(
     connection: TaskTrackerConnection,
     token: string,
     params: { statuses?: string[]; assignedToMe?: boolean; boardId?: string },
-  ): Promise<TrackerTask[]>
+  ): ResultAsync<TrackerTask[], TaskTrackerError>
   getCurrentSprint(
     connection: TaskTrackerConnection,
     token: string,
     boardId?: string,
-  ): Promise<TrackerSprint | null>
+  ): ResultAsync<TrackerSprint | null, TaskTrackerError>
 }


### PR DESCRIPTION
## What

Replace try/catch blocks in business logic with neverthrow Result/ResultAsync types. Each domain (git, task tracker, AI, changelog) gets typed error unions with `_tag` discriminants and co-located error message formatters.

## Why

Untyped try/catch blocks made error handling implicit and error-prone — callers couldn't distinguish failure modes, errors were silently swallowed, and the compiler couldn't enforce exhaustive handling. neverthrow makes errors part of the type signature so they're visible, composable, and compiler-checked.

## How to test

1. `npm run typecheck` and `npm run lint` pass clean
2. `npm run build` succeeds
3. Test task tracker: add/test a Jira or YouTrack connection, fetch boards, search tasks, create a branch from a task
4. Test git operations: detect repo, commit, push, pull, branch create/delete, worktree add/remove
5. Test AI commit message generation (requires Claude API key configured)
6. Test update check (triggers changelog fetch)
7. Verify errors surface correctly in the UI (e.g., invalid connection, git command failure)

## Checklist

- [x] Code follows project conventions (`CLAUDE.md`)
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] No new `any` types without justification
- [x] Cross-platform compatible (no hardcoded paths or OS-specific code)
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] No secrets or credentials in code
- [x] Documentation updated (CLAUDE.md, CONTRIBUTING.md, code-review.md)
- [ ] Screenshots/recordings (N/A — no UI changes)