### PR TITLE
feat: add diff review panel with tabbed right sidebar

### DIFF
--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -1,6 +1,8 @@
 import { ok, err, okAsync, type Result, type ResultAsync } from 'neverthrow'
 import simpleGit from 'simple-git'
 import type { GitError } from './errors'
+import type { ParsedDiff } from './types'
+import { parseDiff } from './diffParser'
 import { fromExternalCall, errorMessage } from '../errors'
 
 function validateRef(name: string): Result<string, GitError> {
@@ -317,6 +319,40 @@ export class GitRepository {
       if (staged.trim()) return okAsync<string, GitError>(staged)
       return gitCall('diff', git.diff())
     })
+  }
+
+  static getDiffParsed(repoRoot: string): ResultAsync<ParsedDiff, GitError> {
+    const git = simpleGit(repoRoot)
+    return gitCall('diff', git.diff(['HEAD']))
+      .orElse((e) => {
+        if (e._tag === 'GitCommandFailed') {
+          return gitCall('diff', git.diff())
+        }
+        return okAsync<string, GitError>('')
+      })
+      .map((raw) => parseDiff(raw))
+  }
+
+  static getFileDiff(repoRoot: string, filePath: string): ResultAsync<ParsedDiff, GitError> {
+    const git = simpleGit(repoRoot)
+    return gitCall('diff', git.diff(['HEAD', '--', filePath]))
+      .orElse((e) => {
+        if (e._tag === 'GitCommandFailed') {
+          return gitCall('diff', git.diff(['--', filePath]))
+        }
+        return okAsync<string, GitError>('')
+      })
+      .map((raw) => parseDiff(raw))
+  }
+
+  static stageFile(repoRoot: string, filePath: string): ResultAsync<void, GitError> {
+    const git = simpleGit(repoRoot)
+    return gitCall('add', git.add(filePath)).map(() => undefined)
+  }
+
+  static revertFile(repoRoot: string, filePath: string): ResultAsync<void, GitError> {
+    const git = simpleGit(repoRoot)
+    return gitCall('checkout', git.checkout(['--', filePath])).map(() => undefined)
   }
 }
 

--- a/src/main/git/diffParser.ts
+++ b/src/main/git/diffParser.ts
@@ -1,0 +1,153 @@
+import type { ParsedDiff, DiffFile, DiffHunk, DiffChange } from './types'
+
+export function parseDiff(raw: string): ParsedDiff {
+  if (!raw.trim()) return { files: [] }
+
+  const files: DiffFile[] = []
+  const lines = raw.split('\n')
+  let i = 0
+
+  while (i < lines.length) {
+    // Look for "diff --git" header
+    if (!lines[i].startsWith('diff --git ')) {
+      i++
+      continue
+    }
+
+    const file = parseFile(lines, i)
+    files.push(file.result)
+    i = file.nextIndex
+  }
+
+  return { files }
+}
+
+function parseFile(lines: string[], start: number): { result: DiffFile; nextIndex: number } {
+  let i = start
+  const diffLine = lines[i]
+
+  // Extract paths from "diff --git a/path b/path"
+  const pathMatch = diffLine.match(/^diff --git a\/(.+) b\/(.+)$/)
+  const bPath = pathMatch ? pathMatch[2] : ''
+
+  i++
+
+  let status: DiffFile['status'] = 'modified'
+  let oldPath: string | undefined
+  let isBinary = false
+
+  // Parse extended headers
+  while (i < lines.length && !lines[i].startsWith('diff --git ')) {
+    const line = lines[i]
+
+    if (line.startsWith('new file mode')) {
+      status = 'added'
+    } else if (line.startsWith('deleted file mode')) {
+      status = 'deleted'
+    } else if (line.startsWith('rename from ')) {
+      status = 'renamed'
+      oldPath = line.slice('rename from '.length)
+    } else if (line.startsWith('Binary files')) {
+      isBinary = true
+    } else if (line.startsWith('@@') || line.startsWith('--- ')) {
+      break
+    }
+
+    i++
+  }
+
+  const hunks: DiffHunk[] = []
+  let additions = 0
+  let deletions = 0
+
+  if (!isBinary) {
+    // Skip "--- a/file" and "+++ b/file"
+    if (i < lines.length && lines[i].startsWith('--- ')) i++
+    if (i < lines.length && lines[i].startsWith('+++ ')) i++
+
+    // Parse hunks
+    while (i < lines.length && !lines[i].startsWith('diff --git ')) {
+      if (lines[i].startsWith('@@')) {
+        const hunk = parseHunk(lines, i)
+        hunks.push(hunk.result)
+        additions += hunk.additions
+        deletions += hunk.deletions
+        i = hunk.nextIndex
+      } else {
+        i++
+      }
+    }
+  }
+
+  const result: DiffFile = {
+    path: bPath,
+    status,
+    hunks,
+    additions,
+    deletions,
+  }
+  if (oldPath) result.oldPath = oldPath
+
+  return { result, nextIndex: i }
+}
+
+function parseHunk(
+  lines: string[],
+  start: number,
+): { result: DiffHunk; nextIndex: number; additions: number; deletions: number } {
+  const header = lines[start]
+  const match = header.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/)
+
+  const oldStart = match ? parseInt(match[1], 10) : 0
+  const oldLines = match ? parseInt(match[2] ?? '1', 10) : 0
+  const newStart = match ? parseInt(match[3], 10) : 0
+  const newLines = match ? parseInt(match[4] ?? '1', 10) : 0
+
+  const changes: DiffChange[] = []
+  let additions = 0
+  let deletions = 0
+  let oldLine = oldStart
+  let newLine = newStart
+  let i = start + 1
+
+  while (i < lines.length) {
+    const line = lines[i]
+
+    if (line.startsWith('diff --git ') || line.startsWith('@@')) {
+      break
+    }
+
+    if (line.startsWith('+')) {
+      changes.push({ type: 'add', content: line.slice(1), newLine })
+      newLine++
+      additions++
+    } else if (line.startsWith('-')) {
+      changes.push({ type: 'delete', content: line.slice(1), oldLine })
+      oldLine++
+      deletions++
+    } else if (line.startsWith(' ') || line === '') {
+      // Context line (or empty trailing line within a hunk)
+      const isTrailingEmpty = line === '' && i === lines.length - 1
+      if (!isTrailingEmpty) {
+        changes.push({ type: 'context', content: line.slice(1), oldLine, newLine })
+        oldLine++
+        newLine++
+      } else {
+        break
+      }
+    } else if (line.startsWith('\\')) {
+      // "\ No newline at end of file" — skip
+    } else {
+      break
+    }
+
+    i++
+  }
+
+  return {
+    result: { oldStart, oldLines, newStart, newLines, header, changes },
+    nextIndex: i,
+    additions,
+    deletions,
+  }
+}

--- a/src/main/git/types.ts
+++ b/src/main/git/types.ts
@@ -1,0 +1,28 @@
+export interface ParsedDiff {
+  files: DiffFile[]
+}
+
+export interface DiffFile {
+  path: string
+  oldPath?: string
+  status: 'added' | 'modified' | 'deleted' | 'renamed'
+  hunks: DiffHunk[]
+  additions: number
+  deletions: number
+}
+
+export interface DiffHunk {
+  oldStart: number
+  oldLines: number
+  newStart: number
+  newLines: number
+  header: string
+  changes: DiffChange[]
+}
+
+export interface DiffChange {
+  type: 'add' | 'delete' | 'context'
+  content: string
+  oldLine?: number
+  newLine?: number
+}

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -727,6 +727,35 @@ export function registerIpcHandlers(
     },
   )
 
+  ipcMain.handle('git:diff', async (_event, payload: { repoRoot: string }) => {
+    const result = await GitRepository.getDiffParsed(payload.repoRoot)
+    return result.unwrapOr({ files: [] })
+  })
+
+  ipcMain.handle(
+    'git:diffFile',
+    async (_event, payload: { repoRoot: string; filePath: string }) => {
+      const result = await GitRepository.getFileDiff(payload.repoRoot, payload.filePath)
+      return result.unwrapOr({ files: [] })
+    },
+  )
+
+  ipcMain.handle(
+    'git:stageFile',
+    async (_event, payload: { repoRoot: string; filePath: string }) => {
+      const result = await GitRepository.stageFile(payload.repoRoot, payload.filePath)
+      return unwrapOrThrow(result, gitErrorMessage)
+    },
+  )
+
+  ipcMain.handle(
+    'git:revertFile',
+    async (_event, payload: { repoRoot: string; filePath: string }) => {
+      const result = await GitRepository.revertFile(payload.repoRoot, payload.filePath)
+      return unwrapOrThrow(result, gitErrorMessage)
+    },
+  )
+
   ipcMain.handle('git:generateCommitMessage', async (_event, payload: { repoRoot: string }) => {
     const diff = await GitRepository.getDiff(payload.repoRoot).unwrapOr('')
     if (!diff.trim()) return null

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -58,6 +58,7 @@ interface ToolDefinition {
 }
 
 type GitInfo = import('../main/git/GitRepository').GitInfo
+type ParsedDiff = import('../main/git/types').ParsedDiff
 type GitWorktreeInfo = import('../main/git/GitRepository').GitWorktreeInfo
 type GitRefreshFlags = import('../main/git/GitWatcher').GitRefreshFlags
 
@@ -349,6 +350,10 @@ interface CanopyAPI {
   gitWorktreeRemove: (repoRoot: string, path: string, force: boolean) => Promise<void>
   gitUnmergedCommits: (repoRoot: string, branch: string) => Promise<string[]>
   gitStatusPorcelain: (repoRoot: string, worktreePath?: string) => Promise<string>
+  gitDiff: (repoRoot: string) => Promise<ParsedDiff>
+  gitDiffFile: (repoRoot: string, filePath: string) => Promise<ParsedDiff>
+  gitStageFile: (repoRoot: string, filePath: string) => Promise<void>
+  gitRevertFile: (repoRoot: string, filePath: string) => Promise<void>
   gitGenerateCommitMessage: (repoRoot: string) => Promise<string | null>
 
   // Browser (<webview> management)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -266,6 +266,13 @@ const api = {
     ipcRenderer.invoke('git:unmergedCommits', { repoRoot, branch }),
   gitStatusPorcelain: (repoRoot: string, worktreePath?: string) =>
     ipcRenderer.invoke('git:statusPorcelain', { repoRoot, worktreePath }),
+  gitDiff: (repoRoot: string) => ipcRenderer.invoke('git:diff', { repoRoot }),
+  gitDiffFile: (repoRoot: string, filePath: string) =>
+    ipcRenderer.invoke('git:diffFile', { repoRoot, filePath }),
+  gitStageFile: (repoRoot: string, filePath: string) =>
+    ipcRenderer.invoke('git:stageFile', { repoRoot, filePath }),
+  gitRevertFile: (repoRoot: string, filePath: string) =>
+    ipcRenderer.invoke('git:revertFile', { repoRoot, filePath }),
   gitGenerateCommitMessage: (repoRoot: string) =>
     ipcRenderer.invoke('git:generateCommitMessage', { repoRoot }),
 

--- a/src/renderer/src/assets/base.css
+++ b/src/renderer/src/assets/base.css
@@ -60,6 +60,12 @@
 
   --c-scrim: rgba(0, 0, 0, 0.5);
 
+  --diff-add-bg: rgba(46, 160, 67, 0.15);
+  --diff-add-fg: #3fb950;
+  --diff-delete-bg: rgba(248, 81, 73, 0.15);
+  --diff-delete-fg: #f85149;
+  --diff-hunk-header-bg: rgba(56, 139, 253, 0.1);
+
   color-scheme: dark;
 }
 

--- a/src/renderer/src/components/agents/AgentInspector.svelte
+++ b/src/renderer/src/components/agents/AgentInspector.svelte
@@ -88,7 +88,7 @@
   }
 </script>
 
-<aside class="inspector">
+<div class="inspector">
   <h3 class="inspector-title">{inspectorTitle}</h3>
 
   <!-- Status -->
@@ -212,7 +212,7 @@
       </div>
     </div>
   {/if}
-</aside>
+</div>
 
 <style>
   /* Context bar */
@@ -267,18 +267,10 @@
   }
 
   .inspector {
-    width: 280px;
-    min-width: 280px;
-    height: 100%;
-    background: var(--c-bg-glass);
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-    border-left: 1px solid var(--c-border-subtle);
-    overflow-y: auto;
-    padding: 12px;
     display: flex;
     flex-direction: column;
     gap: 12px;
+    padding: 12px;
   }
 
   .inspector-title {

--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -1,0 +1,527 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { openDiffTab } from '../../lib/stores/tabs.svelte'
+
+  interface DiffChange {
+    type: 'add' | 'delete' | 'context'
+    content: string
+    oldLine?: number
+    newLine?: number
+  }
+
+  interface DiffHunk {
+    oldStart: number
+    oldLines: number
+    newStart: number
+    newLines: number
+    header: string
+    changes: DiffChange[]
+  }
+
+  interface DiffFile {
+    path: string
+    oldPath?: string
+    status: 'added' | 'modified' | 'deleted' | 'renamed'
+    hunks: DiffHunk[]
+    additions: number
+    deletions: number
+  }
+
+  interface ParsedDiff {
+    files: DiffFile[]
+  }
+
+  let { worktreePath }: { worktreePath: string } = $props()
+
+  let diff = $state<ParsedDiff | null>(null)
+  let loading = $state(false)
+  let hoveredPath = $state<string | null>(null)
+  let visibleFilePath = $state<string | null>(null)
+
+  // Filter state
+  let filterQuery = $state('')
+  let statusFilter = $state<'all' | 'added' | 'modified' | 'deleted'>('all')
+
+  async function refresh(): Promise<void> {
+    loading = true
+    try {
+      diff = await window.api.gitDiff(worktreePath)
+    } catch {
+      diff = null
+    } finally {
+      loading = false
+    }
+  }
+
+  // Re-fetch when worktreePath changes (branch switch, worktree switch)
+  $effect(() => {
+    void worktreePath
+    refresh()
+  })
+
+  onMount(() => {
+    const unsubGit = window.api.onGitChanged(() => {
+      refresh()
+    })
+
+    const handleVisibleFile = (e: Event): void => {
+      const detail = (e as CustomEvent<{ filePath: string }>).detail
+      visibleFilePath = detail.filePath
+    }
+    window.addEventListener('canopy:diff-visible-file', handleVisibleFile)
+
+    return () => {
+      unsubGit()
+      window.removeEventListener('canopy:diff-visible-file', handleVisibleFile)
+    }
+  })
+
+  // Derived filtered files
+  let allFiles = $derived(diff?.files ?? [])
+
+  let filteredFiles = $derived.by(() => {
+    let result = allFiles
+    if (filterQuery) {
+      const q = filterQuery.toLowerCase()
+      result = result.filter((f) => f.path.toLowerCase().includes(q))
+    }
+    if (statusFilter !== 'all') {
+      result = result.filter((f) => f.status === statusFilter)
+    }
+    return result
+  })
+
+  // Summary stats
+  let totalFiles = $derived(allFiles.length)
+  let totalAdditions = $derived(allFiles.reduce((sum, f) => sum + f.additions, 0))
+  let totalDeletions = $derived(allFiles.reduce((sum, f) => sum + f.deletions, 0))
+  let totalChanges = $derived(totalAdditions + totalDeletions)
+
+  let summaryBarAddWidth = $derived(
+    totalChanges > 0 ? Math.round((totalAdditions / totalChanges) * 60) : 0,
+  )
+  let summaryBarDelWidth = $derived(totalChanges > 0 ? 60 - summaryBarAddWidth : 0)
+
+  // Broadcast file count for badge in RightPanel
+  $effect(() => {
+    window.dispatchEvent(new CustomEvent('canopy:changes-count', { detail: { count: totalFiles } }))
+  })
+
+  function basename(filePath: string): string {
+    const parts = filePath.split('/')
+    return parts[parts.length - 1]
+  }
+
+  function dirname(filePath: string): string {
+    const parts = filePath.split('/')
+    if (parts.length <= 1) return ''
+    return parts.slice(0, -1).join('/') + '/'
+  }
+
+  function statusIcon(status: DiffFile['status']): string {
+    if (status === 'added') return '+'
+    if (status === 'modified') return 'M'
+    if (status === 'deleted') return '\u2212'
+    return '\u2192'
+  }
+
+  function statusClass(status: DiffFile['status']): string {
+    if (status === 'added') return 'status-added'
+    if (status === 'modified') return 'status-modified'
+    if (status === 'deleted') return 'status-deleted'
+    return 'status-renamed'
+  }
+
+  function handleClick(file: DiffFile): void {
+    openDiffTab(worktreePath, file.path)
+  }
+
+  async function handleStage(e: Event, path: string): Promise<void> {
+    e.stopPropagation()
+    await window.api.gitStageFile(worktreePath, path)
+    await refresh()
+  }
+
+  async function handleRevert(e: Event, path: string): Promise<void> {
+    e.stopPropagation()
+    const ok = window.confirm('Revert all changes to this file? This cannot be undone.')
+    if (!ok) return
+    await window.api.gitRevertFile(worktreePath, path)
+    await refresh()
+  }
+</script>
+
+<div class="changes-panel">
+  <div class="panel-header">
+    <span class="panel-title">Changes</span>
+    <button class="refresh-btn" onclick={refresh} title="Refresh" disabled={loading}>
+      {loading ? '...' : '\u21BB'}
+    </button>
+  </div>
+
+  {#if totalFiles > 0}
+    <div class="summary-line">
+      <span class="summary-text">
+        {totalFiles} file{totalFiles !== 1 ? 's' : ''} changed,
+        <span class="stat-add">+{totalAdditions}</span>
+        <span class="stat-del">&minus;{totalDeletions}</span>
+      </span>
+      <span class="summary-bar">
+        {#if totalAdditions > 0}
+          <span class="summary-bar-add" style="width: {summaryBarAddWidth}px"></span>
+        {/if}
+        {#if totalDeletions > 0}
+          <span class="summary-bar-del" style="width: {summaryBarDelWidth}px"></span>
+        {/if}
+      </span>
+    </div>
+  {/if}
+
+  <div class="filter-section">
+    <input
+      class="filter-input"
+      type="text"
+      placeholder="Filter files..."
+      bind:value={filterQuery}
+    />
+    <div class="status-filters">
+      <button
+        class="filter-btn"
+        class:filter-active={statusFilter === 'all'}
+        onclick={() => (statusFilter = 'all')}>All</button
+      >
+      <button
+        class="filter-btn"
+        class:filter-active={statusFilter === 'added'}
+        onclick={() => (statusFilter = statusFilter === 'added' ? 'all' : 'added')}>A</button
+      >
+      <button
+        class="filter-btn"
+        class:filter-active={statusFilter === 'modified'}
+        onclick={() => (statusFilter = statusFilter === 'modified' ? 'all' : 'modified')}>M</button
+      >
+      <button
+        class="filter-btn"
+        class:filter-active={statusFilter === 'deleted'}
+        onclick={() => (statusFilter = statusFilter === 'deleted' ? 'all' : 'deleted')}>D</button
+      >
+    </div>
+  </div>
+
+  {#if filteredFiles.length > 0}
+    <ul class="file-list">
+      {#each filteredFiles as file (file.path)}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <li
+          class="file-item"
+          class:file-visible={visibleFilePath === file.path}
+          onclick={() => handleClick(file)}
+          onpointerenter={() => (hoveredPath = file.path)}
+          onpointerleave={() => (hoveredPath = null)}
+        >
+          <span class="status-icon {statusClass(file.status)}">{statusIcon(file.status)}</span>
+          <span class="file-path">
+            <span class="dir">{dirname(file.path)}</span><span class="name"
+              >{basename(file.path)}</span
+            >
+          </span>
+          <span class="stats">
+            {#if file.additions > 0}<span class="stat-add">+{file.additions}</span>{/if}
+            {#if file.deletions > 0}<span class="stat-del">&minus;{file.deletions}</span>{/if}
+          </span>
+          {#if hoveredPath === file.path}
+            <span class="actions">
+              <button
+                class="action-btn stage"
+                onclick={(e) => handleStage(e, file.path)}
+                title="Stage">&#x2713;</button
+              >
+              <button
+                class="action-btn revert"
+                onclick={(e) => handleRevert(e, file.path)}
+                title="Revert">&#x2717;</button
+              >
+            </span>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {:else if !loading}
+    <div class="empty-state">
+      <span class="empty-text">
+        {#if filterQuery || statusFilter !== 'all'}
+          No matching files
+        {:else}
+          No uncommitted changes
+        {/if}
+      </span>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .changes-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 12px;
+    flex-shrink: 0;
+  }
+
+  .panel-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--c-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .refresh-btn {
+    background: none;
+    border: none;
+    color: var(--c-text-muted);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-family: inherit;
+  }
+
+  .refresh-btn:hover {
+    color: var(--c-text);
+    background: var(--c-hover);
+  }
+
+  .refresh-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .summary-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 2px 12px 6px;
+    flex-shrink: 0;
+  }
+
+  .summary-text {
+    font-size: 11px;
+    color: var(--c-text-muted);
+  }
+
+  .summary-bar {
+    display: flex;
+    align-items: center;
+    height: 6px;
+    border-radius: 2px;
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
+  .summary-bar-add {
+    height: 100%;
+    background: var(--diff-add-fg);
+    display: block;
+  }
+
+  .summary-bar-del {
+    height: 100%;
+    background: var(--diff-delete-fg);
+    display: block;
+  }
+
+  .filter-section {
+    padding: 0 12px 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  .filter-input {
+    background: var(--c-bg);
+    border: 1px solid var(--c-border-subtle);
+    border-radius: 4px;
+    color: var(--c-text);
+    font-size: 11px;
+    padding: 3px 8px;
+    width: 100%;
+    outline: none;
+    font-family: var(--font-mono, monospace);
+    box-sizing: border-box;
+  }
+
+  .filter-input:focus {
+    border-color: var(--c-accent);
+  }
+
+  .filter-input::placeholder {
+    color: var(--c-text-faint);
+  }
+
+  .status-filters {
+    display: flex;
+    gap: 2px;
+  }
+
+  .filter-btn {
+    background: none;
+    border: 1px solid var(--c-border-subtle);
+    color: var(--c-text-muted);
+    cursor: pointer;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 1px 8px;
+    border-radius: 3px;
+    font-family: var(--font-mono, monospace);
+  }
+
+  .filter-btn:hover {
+    color: var(--c-text);
+    background: var(--c-active);
+  }
+
+  .filter-btn.filter-active {
+    background: var(--c-accent);
+    color: #fff;
+    border-color: var(--c-accent);
+  }
+
+  .file-list {
+    padding: 0;
+    margin: 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .file-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 12px;
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1.4;
+    position: relative;
+  }
+
+  .file-item:hover {
+    background: var(--c-hover);
+  }
+
+  .file-item.file-visible {
+    background: rgba(255, 255, 255, 0.04);
+    border-left: 2px solid var(--c-accent);
+    padding-left: 10px;
+  }
+
+  .status-icon {
+    flex-shrink: 0;
+    width: 16px;
+    text-align: center;
+    font-weight: 600;
+    font-size: 11px;
+    font-family: var(--font-mono, monospace);
+  }
+
+  .status-added {
+    color: var(--c-success);
+  }
+
+  .status-modified {
+    color: var(--c-warning);
+  }
+
+  .status-deleted {
+    color: var(--c-danger);
+  }
+
+  .status-renamed {
+    color: var(--c-accent);
+  }
+
+  .file-path {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .dir {
+    color: var(--c-text-muted);
+  }
+
+  .name {
+    color: var(--c-text);
+  }
+
+  .stats {
+    flex-shrink: 0;
+    font-size: 11px;
+    font-family: var(--font-mono, monospace);
+    display: flex;
+    gap: 4px;
+  }
+
+  .stat-add {
+    color: var(--diff-add-fg);
+  }
+
+  .stat-del {
+    color: var(--diff-delete-fg);
+  }
+
+  .actions {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 0;
+  }
+
+  .action-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 12px;
+    padding: 0 3px;
+    border-radius: 3px;
+    font-family: inherit;
+  }
+
+  .action-btn.stage {
+    color: var(--c-success);
+  }
+
+  .action-btn.stage:hover {
+    background: rgba(105, 219, 124, 0.15);
+  }
+
+  .action-btn.revert {
+    color: var(--c-danger);
+  }
+
+  .action-btn.revert:hover {
+    background: rgba(255, 107, 107, 0.15);
+  }
+
+  .empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    padding: 16px;
+  }
+
+  .empty-text {
+    font-size: 12px;
+    color: var(--c-text-muted);
+  }
+</style>

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -1,0 +1,1082 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { SvelteSet } from 'svelte/reactivity'
+  import { getAiSessions, focusSessionByPtyId } from '../../lib/stores/tabs.svelte'
+  import { workspaceState } from '../../lib/stores/workspace.svelte'
+
+  interface DiffChange {
+    type: 'add' | 'delete' | 'context'
+    content: string
+    oldLine?: number
+    newLine?: number
+  }
+
+  interface DiffHunk {
+    oldStart: number
+    oldLines: number
+    newStart: number
+    newLines: number
+    header: string
+    changes: DiffChange[]
+  }
+
+  interface DiffFile {
+    path: string
+    oldPath?: string
+    status: 'added' | 'modified' | 'deleted' | 'renamed'
+    hunks: DiffHunk[]
+    additions: number
+    deletions: number
+  }
+
+  let {
+    worktreePath,
+    active,
+  }: {
+    worktreePath: string
+    active: boolean
+  } = $props()
+
+  let files = $state<DiffFile[]>([])
+  let loading = $state(false)
+  let bodyEl: HTMLDivElement | undefined = $state()
+  let paneEl: HTMLDivElement | undefined = $state()
+
+  // Collapse state
+  let collapsedFiles = new SvelteSet<string>()
+
+  // Search state
+  let searchQuery = $state('')
+  let showSearch = $state(false)
+
+  // Keyboard navigation state
+  let focusedFileIndex = $state(-1)
+
+  // Auto-refresh pulse state
+  let justRefreshed = $state(false)
+
+  // Hover state for copy button
+  let hoveredFilePath = $state<string | null>(null)
+
+  // Comment state
+  let commentKey = $state<string | null>(null)
+  let commentText = $state('')
+  let commentFilePath = $state('')
+  let commentLineNum = $state(0)
+
+  async function refresh(): Promise<void> {
+    loading = true
+    try {
+      const result = await window.api.gitDiff(worktreePath)
+      files = (result as { files: DiffFile[] }).files
+    } catch {
+      files = []
+    } finally {
+      loading = false
+    }
+  }
+
+  function triggerPulse(): void {
+    justRefreshed = true
+    setTimeout(() => {
+      justRefreshed = false
+    }, 1000)
+  }
+
+  // Re-fetch when worktreePath changes (branch/worktree switch)
+  $effect(() => {
+    void worktreePath
+    refresh()
+  })
+
+  // Scroll to file when diffScrollTarget changes
+  $effect(() => {
+    const target = workspaceState.diffScrollTarget
+    if (!target) return
+    const filePath = target.path
+    // Delay to ensure tab switch + DOM layout completes
+    setTimeout(() => {
+      const el = document.getElementById(`diff-file-${filePath}`)
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }
+    }, 150)
+  })
+
+  onMount(() => {
+    const unsubGit = window.api.onGitChanged(() => {
+      refresh().then(() => triggerPulse())
+    })
+
+    // Track which file is currently visible via IntersectionObserver
+    let observer: IntersectionObserver | null = null
+
+    function setupObserver(): void {
+      observer?.disconnect()
+      if (!bodyEl) return
+      observer = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              const path = (entry.target as HTMLElement).dataset.filepath
+              if (path) {
+                workspaceState.diffScrollTarget = null
+                window.dispatchEvent(
+                  new CustomEvent('canopy:diff-visible-file', { detail: { filePath: path } }),
+                )
+              }
+            }
+          }
+        },
+        { root: bodyEl, rootMargin: '0px 0px -70% 0px', threshold: 0 },
+      )
+      bodyEl.querySelectorAll('.file-section').forEach((el) => observer!.observe(el))
+    }
+
+    // Re-setup observer when files change
+    const unsubFiles = $effect.root(() => {
+      $effect(() => {
+        void files.length
+        setTimeout(setupObserver, 100)
+      })
+      return () => observer?.disconnect()
+    })
+
+    return () => {
+      unsubGit()
+      unsubFiles()
+      observer?.disconnect()
+    }
+  })
+
+  let totalAdditions = $derived(files.reduce((sum, f) => sum + f.additions, 0))
+  let totalDeletions = $derived(files.reduce((sum, f) => sum + f.deletions, 0))
+
+  // Search matching
+  let searchLower = $derived(searchQuery.toLowerCase())
+
+  let matchCount = $derived.by(() => {
+    if (!searchLower) return 0
+    let count = 0
+    for (const file of files) {
+      for (const hunk of file.hunks) {
+        for (const change of hunk.changes) {
+          if (change.content.toLowerCase().includes(searchLower)) {
+            count++
+          }
+        }
+      }
+    }
+    return count
+  })
+
+  function lineMatchesSearch(content: string): boolean {
+    if (!searchLower) return false
+    return content.toLowerCase().includes(searchLower)
+  }
+
+  function highlightMatch(text: string): string {
+    if (!searchLower) return escapeHtml(text)
+    const escaped = escapeHtml(text)
+    const queryEscaped = escapeHtml(searchLower)
+    const regex = new RegExp(`(${escapeRegex(queryEscaped)})`, 'gi')
+    return escaped.replace(regex, '<mark class="search-highlight">$1</mark>')
+  }
+
+  function escapeHtml(str: string): string {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+  }
+
+  function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  }
+
+  function statusLabel(status: DiffFile['status']): string {
+    if (status === 'added') return 'Added'
+    if (status === 'modified') return 'Modified'
+    if (status === 'deleted') return 'Deleted'
+    return 'Renamed'
+  }
+
+  function statusClass(status: DiffFile['status']): string {
+    if (status === 'added') return 'badge-added'
+    if (status === 'deleted') return 'badge-deleted'
+    return 'badge-modified'
+  }
+
+  function toggleCollapse(path: string): void {
+    if (collapsedFiles.has(path)) {
+      collapsedFiles.delete(path)
+    } else {
+      collapsedFiles.add(path)
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+
+    if (e.key === 'j' || e.key === 'J') {
+      e.preventDefault()
+      if (files.length > 0) {
+        focusedFileIndex = Math.min(focusedFileIndex + 1, files.length - 1)
+        scrollToFocusedFile()
+      }
+    } else if (e.key === 'k' || e.key === 'K') {
+      e.preventDefault()
+      if (files.length > 0) {
+        focusedFileIndex = Math.max(focusedFileIndex - 1, 0)
+        scrollToFocusedFile()
+      }
+    }
+  }
+
+  function scrollToFocusedFile(): void {
+    if (focusedFileIndex >= 0 && focusedFileIndex < files.length) {
+      const file = files[focusedFileIndex]
+      const el = document.getElementById(`diff-file-${CSS.escape(file.path)}`)
+      if (el && bodyEl) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    }
+  }
+
+  function openComment(filePath: string, line: number): void {
+    const key = `${filePath}:${line}`
+    if (commentKey === key) {
+      closeComment()
+      return
+    }
+    commentKey = key
+    commentFilePath = filePath
+    commentLineNum = line
+    commentText = ''
+  }
+
+  function closeComment(): void {
+    commentKey = null
+    commentText = ''
+  }
+
+  function gatherContext(filePath: string, lineNum: number): string {
+    const file = files.find((f) => f.path === filePath)
+    if (!file) return ''
+
+    for (const hunk of file.hunks) {
+      const changeIndex = hunk.changes.findIndex((c) => getLineNum(c) === lineNum)
+      if (changeIndex === -1) continue
+
+      const start = Math.max(0, changeIndex - 3)
+      const end = Math.min(hunk.changes.length - 1, changeIndex + 3)
+      const lines: string[] = []
+
+      for (let i = start; i <= end; i++) {
+        const c = hunk.changes[i]
+        const ln = getLineNum(c)
+        const prefix = i === changeIndex ? '>' : ' '
+        const marker = c.type === 'add' ? '+' : c.type === 'delete' ? '-' : ' '
+        lines.push(`${prefix} ${String(ln).padStart(4)} | ${marker}${c.content}`)
+      }
+
+      return lines.join('\n')
+    }
+    return ''
+  }
+
+  function sendComment(): void {
+    if (!commentText.trim()) return
+    const sessions = getAiSessions(worktreePath)
+    if (sessions.length === 0) return
+
+    const context = gatherContext(commentFilePath, commentLineNum)
+    const contextBlock = context ? `\nContext:\n${context}\n` : ''
+
+    const message = [
+      `In file ${commentFilePath}, around line ${commentLineNum}:`,
+      contextBlock,
+      `Comment: ${commentText.trim()}`,
+    ].join('\n')
+
+    window.api.writePty(sessions[0].sessionId, message + '\n')
+    focusSessionByPtyId(sessions[0].sessionId)
+    window.dispatchEvent(
+      new CustomEvent('canopy:focus-terminal', {
+        detail: { sessionId: sessions[0].sessionId },
+      }),
+    )
+    closeComment()
+  }
+
+  function getLineNum(change: DiffChange): number {
+    return change.newLine ?? change.oldLine ?? 0
+  }
+
+  function statsBarWidth(file: DiffFile): number {
+    const total = file.additions + file.deletions
+    return Math.min(total, 60)
+  }
+
+  function statsBarAddWidth(file: DiffFile): number {
+    const total = file.additions + file.deletions
+    if (total === 0) return 0
+    return Math.round((file.additions / total) * statsBarWidth(file))
+  }
+
+  function statsBarDelWidth(file: DiffFile): number {
+    return statsBarWidth(file) - statsBarAddWidth(file)
+  }
+
+  function buildUnifiedDiff(file: DiffFile): string {
+    const lines: string[] = []
+    lines.push(`--- a/${file.oldPath ?? file.path}`)
+    lines.push(`+++ b/${file.path}`)
+    for (const hunk of file.hunks) {
+      lines.push(hunk.header)
+      for (const change of hunk.changes) {
+        const prefix = change.type === 'add' ? '+' : change.type === 'delete' ? '-' : ' '
+        lines.push(`${prefix}${change.content}`)
+      }
+    }
+    return lines.join('\n')
+  }
+
+  async function copyDiff(file: DiffFile): Promise<void> {
+    const text = buildUnifiedDiff(file)
+    await navigator.clipboard.writeText(text)
+  }
+
+  function toggleSearch(): void {
+    showSearch = !showSearch
+    if (!showSearch) {
+      searchQuery = ''
+    }
+  }
+
+  let hasAgent = $derived(getAiSessions(worktreePath).length > 0)
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="diff-pane"
+  class:hidden={!active}
+  bind:this={paneEl}
+  tabindex="-1"
+  onkeydown={handleKeydown}
+>
+  <div class="diff-toolbar" class:toolbar-pulse={justRefreshed}>
+    <span class="toolbar-title">Diff</span>
+    <span class="toolbar-summary">
+      {files.length} file{files.length !== 1 ? 's' : ''}
+      <span class="stat-add">+{totalAdditions}</span>
+      <span class="stat-del">&minus;{totalDeletions}</span>
+    </span>
+    {#if showSearch}
+      <div class="search-bar">
+        <input
+          class="search-input"
+          type="text"
+          placeholder="Search in diff..."
+          bind:value={searchQuery}
+          onkeydown={(e) => {
+            if (e.key === 'Escape') toggleSearch()
+          }}
+        />
+        {#if searchQuery}
+          <span class="match-count">{matchCount} match{matchCount !== 1 ? 'es' : ''}</span>
+        {/if}
+      </div>
+    {/if}
+    <button class="toolbar-btn" onclick={toggleSearch} title="Search"> &#x1F50D; </button>
+    <button class="toolbar-btn" onclick={refresh} title="Refresh" disabled={loading}>
+      &#x21BB;
+    </button>
+  </div>
+
+  <div class="diff-body" bind:this={bodyEl}>
+    {#if loading && files.length === 0}
+      <div class="empty-state">Loading...</div>
+    {:else if files.length === 0}
+      <div class="empty-state">No uncommitted changes</div>
+    {:else}
+      {#each files as file, fileIndex (file.path)}
+        <div
+          class="file-section"
+          class:file-focused={focusedFileIndex === fileIndex}
+          id="diff-file-{file.path}"
+          data-filepath={file.path}
+          onpointerenter={() => (hoveredFilePath = file.path)}
+          onpointerleave={() => (hoveredFilePath = null)}
+        >
+          <div class="file-header" onclick={() => toggleCollapse(file.path)}>
+            <span class="chevron" class:chevron-open={!collapsedFiles.has(file.path)}>&#x25B8;</span
+            >
+            <span class="file-status {statusClass(file.status)}">{statusLabel(file.status)}</span>
+            <span class="file-path">{file.path}</span>
+            <span class="stats-bar">
+              {#if file.additions > 0}
+                <span class="stats-bar-add" style="width: {statsBarAddWidth(file)}px"></span>
+              {/if}
+              {#if file.deletions > 0}
+                <span class="stats-bar-del" style="width: {statsBarDelWidth(file)}px"></span>
+              {/if}
+            </span>
+            <span class="file-stats">
+              <span class="stat-add">+{file.additions}</span>
+              <span class="stat-del">&minus;{file.deletions}</span>
+            </span>
+            {#if hoveredFilePath === file.path}
+              <button
+                class="copy-diff-btn"
+                title="Copy diff"
+                onclick={(e) => {
+                  e.stopPropagation()
+                  copyDiff(file)
+                }}
+              >
+                &#x1F4CB;
+              </button>
+            {/if}
+          </div>
+
+          {#if !collapsedFiles.has(file.path)}
+            {#if file.hunks.length === 0}
+              <div class="no-hunks">Binary file or empty diff</div>
+            {:else}
+              {#each file.hunks as hunk (hunk.header)}
+                <div class="hunk">
+                  <div class="hunk-header">
+                    <span class="gutter old-gutter"></span>
+                    <span class="gutter new-gutter"></span>
+                    <span class="hunk-text">{hunk.header}</span>
+                  </div>
+                  {#each hunk.changes as change, i (i)}
+                    <div
+                      class="diff-line {change.type}"
+                      class:search-match={lineMatchesSearch(change.content)}
+                    >
+                      {#if hasAgent}
+                        <button
+                          class="comment-trigger"
+                          title="Add review comment"
+                          onclick={() => openComment(file.path, getLineNum(change))}>+</button
+                        >
+                      {/if}
+                      <span class="gutter old-gutter"
+                        >{change.type !== 'add' && change.oldLine != null
+                          ? change.oldLine
+                          : ''}</span
+                      >
+                      <span class="gutter new-gutter"
+                        >{change.type !== 'delete' && change.newLine != null
+                          ? change.newLine
+                          : ''}</span
+                      >
+                      <span class="line-prefix"
+                        >{change.type === 'add' ? '+' : change.type === 'delete' ? '-' : ' '}</span
+                      >
+                      {#if searchQuery && lineMatchesSearch(change.content)}
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                        <span class="line-content">{@html highlightMatch(change.content)}</span>
+                      {:else}
+                        <span class="line-content">{change.content}</span>
+                      {/if}
+                    </div>
+                    {#if commentKey === `${file.path}:${getLineNum(change)}`}
+                      <div class="comment-form">
+                        <div class="comment-card">
+                          <div class="comment-card-header">
+                            <svg
+                              class="comment-icon"
+                              width="14"
+                              height="14"
+                              viewBox="0 0 16 16"
+                              fill="currentColor"
+                            >
+                              <path
+                                d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"
+                              />
+                            </svg>
+                            <span class="comment-label">Review comment</span>
+                            <span class="comment-file-ref">{file.path}:{getLineNum(change)}</span>
+                          </div>
+                          <textarea
+                            class="comment-input"
+                            placeholder="Describe what should be changed..."
+                            bind:value={commentText}
+                            onkeydown={(e) => {
+                              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) sendComment()
+                              if (e.key === 'Escape') closeComment()
+                            }}
+                          ></textarea>
+                          <div class="comment-footer">
+                            <span class="comment-hint">
+                              {navigator.userAgent.includes('Mac') ? '\u2318' : 'Ctrl'}+Enter to
+                              send
+                            </span>
+                            <div class="comment-actions">
+                              <button class="comment-cancel" onclick={closeComment}>Cancel</button>
+                              <button
+                                class="comment-send"
+                                onclick={sendComment}
+                                disabled={!commentText.trim()}
+                              >
+                                <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                                  <path
+                                    d="M.989 8 .064 2.68a1.342 1.342 0 0 1 1.85-1.462l13.402 5.744a1.13 1.13 0 0 1 0 2.076L1.913 14.782a1.343 1.343 0 0 1-1.85-1.463Z"
+                                  />
+                                </svg>
+                                Send to Agent
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    {/if}
+                  {/each}
+                </div>
+              {/each}
+            {/if}
+          {/if}
+        </div>
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .diff-pane {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: var(--c-bg);
+    outline: none;
+  }
+
+  .diff-pane.hidden {
+    display: none;
+  }
+
+  .diff-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 16px;
+    background: var(--c-bg-elevated);
+    border-bottom: 1px solid var(--c-border-subtle);
+    flex-shrink: 0;
+    transition: box-shadow 0.3s ease;
+  }
+
+  .toolbar-pulse {
+    animation: pulse-glow 1s ease-out;
+  }
+
+  @keyframes pulse-glow {
+    0% {
+      box-shadow: inset 0 0 12px rgba(56, 139, 253, 0.4);
+    }
+    100% {
+      box-shadow: none;
+    }
+  }
+
+  .toolbar-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--c-text);
+  }
+
+  .toolbar-summary {
+    font-size: 12px;
+    color: var(--c-text-muted);
+    flex: 1;
+  }
+
+  .stat-add {
+    color: var(--diff-add-fg);
+  }
+
+  .stat-del {
+    color: var(--diff-delete-fg);
+  }
+
+  .toolbar-btn {
+    background: none;
+    border: none;
+    color: var(--c-text-muted);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+
+  .toolbar-btn:hover {
+    color: var(--c-text);
+    background: var(--c-active);
+  }
+
+  .toolbar-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  .search-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .search-input {
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    color: var(--c-text);
+    font-size: 12px;
+    padding: 3px 8px;
+    width: 180px;
+    outline: none;
+    font-family: var(--font-mono, monospace);
+  }
+
+  .search-input:focus {
+    border-color: var(--c-accent);
+  }
+
+  .match-count {
+    font-size: 11px;
+    color: var(--c-text-muted);
+    white-space: nowrap;
+  }
+
+  .diff-body {
+    flex: 1;
+    overflow: auto;
+    min-height: 0;
+    font-family: var(--font-mono, monospace);
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  .file-section {
+    border-bottom: 1px solid var(--c-border-subtle);
+    border-left: 2px solid transparent;
+  }
+
+  .file-section.file-focused {
+    border-left: 2px solid var(--c-accent);
+  }
+
+  .file-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: var(--c-bg-elevated);
+    border-bottom: 1px solid var(--c-border-subtle);
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .file-header:hover {
+    background: var(--c-active);
+  }
+
+  .chevron {
+    font-size: 10px;
+    color: var(--c-text-muted);
+    transition: transform 0.15s ease;
+    flex-shrink: 0;
+    display: inline-block;
+  }
+
+  .chevron.chevron-open {
+    transform: rotate(90deg);
+  }
+
+  .file-status {
+    font-size: 10px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    flex-shrink: 0;
+  }
+
+  .badge-added {
+    background: rgba(46, 160, 67, 0.2);
+    color: var(--diff-add-fg);
+  }
+
+  .badge-modified {
+    background: rgba(56, 139, 253, 0.2);
+    color: var(--c-accent);
+  }
+
+  .badge-deleted {
+    background: rgba(248, 81, 73, 0.2);
+    color: var(--diff-delete-fg);
+  }
+
+  .file-path {
+    font-size: 12px;
+    color: var(--c-text);
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--font-mono, monospace);
+  }
+
+  .stats-bar {
+    display: flex;
+    align-items: center;
+    height: 8px;
+    border-radius: 2px;
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
+  .stats-bar-add {
+    height: 100%;
+    background: var(--diff-add-fg);
+    display: block;
+  }
+
+  .stats-bar-del {
+    height: 100%;
+    background: var(--diff-delete-fg);
+    display: block;
+  }
+
+  .file-stats {
+    display: flex;
+    gap: 6px;
+    font-size: 11px;
+    flex-shrink: 0;
+  }
+
+  .copy-diff-btn {
+    background: none;
+    border: 1px solid var(--c-border);
+    color: var(--c-text-muted);
+    cursor: pointer;
+    font-size: 12px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  .copy-diff-btn:hover {
+    color: var(--c-text);
+    background: var(--c-active);
+  }
+
+  .no-hunks {
+    padding: 12px 16px;
+    color: var(--c-text-muted);
+    font-style: italic;
+  }
+
+  .hunk-header {
+    display: flex;
+    background: var(--diff-hunk-header-bg);
+    color: var(--c-text-muted);
+    padding: 2px 0;
+    font-size: 11px;
+  }
+
+  .hunk-text {
+    padding: 0 8px;
+    flex: 1;
+  }
+
+  .diff-line {
+    display: flex;
+    -webkit-user-select: text;
+    user-select: text;
+    position: relative;
+  }
+
+  .diff-line.search-match {
+    outline: 1px solid var(--c-warning);
+    outline-offset: -1px;
+  }
+
+  :global(.search-highlight) {
+    background: rgba(var(--c-warning), 0.3);
+    background: color-mix(in srgb, var(--c-warning) 30%, transparent);
+    border-radius: 2px;
+  }
+
+  .comment-trigger {
+    position: absolute;
+    left: 1px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    border: none;
+    background: #1f6feb;
+    color: #fff;
+    font-size: 15px;
+    font-weight: 700;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: opacity 0.1s ease;
+  }
+
+  .diff-line:hover .comment-trigger {
+    opacity: 1;
+  }
+
+  .comment-trigger:hover {
+    background: #388bfd;
+  }
+
+  .comment-trigger:active {
+    background: #1a5ccf;
+  }
+
+  .comment-form {
+    padding: 10px 16px 10px 24px;
+    animation: comment-slide-in 0.25s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  @keyframes comment-slide-in {
+    0% {
+      opacity: 0;
+      transform: translateY(-4px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .comment-card {
+    background: var(--c-bg-elevated);
+    border: 1px solid var(--c-border);
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow:
+      0 2px 8px rgba(0, 0, 0, 0.15),
+      0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+
+  .comment-card-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border-bottom: 1px solid var(--c-border-subtle);
+  }
+
+  .comment-icon {
+    color: var(--c-accent);
+    flex-shrink: 0;
+  }
+
+  .comment-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--c-text-secondary);
+    letter-spacing: 0.2px;
+  }
+
+  .comment-file-ref {
+    font-size: 10px;
+    color: var(--c-text-faint);
+    margin-left: auto;
+    font-family: var(--font-mono, monospace);
+  }
+
+  .comment-input {
+    width: 100%;
+    min-height: 72px;
+    padding: 10px 12px;
+    border: none;
+    background: transparent;
+    color: var(--c-text);
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
+    font-size: 13px;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+  }
+
+  .comment-input::placeholder {
+    color: var(--c-text-faint);
+  }
+
+  .comment-footer {
+    display: flex;
+    align-items: center;
+    padding: 6px 12px 8px;
+    border-top: 1px solid var(--c-border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .comment-hint {
+    font-size: 10px;
+    color: var(--c-text-faint);
+    flex: 1;
+  }
+
+  .comment-actions {
+    display: flex;
+    gap: 6px;
+  }
+
+  .comment-cancel {
+    padding: 5px 12px;
+    border: none;
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--c-text-muted);
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    transition:
+      background 0.15s,
+      color 0.15s;
+  }
+
+  .comment-cancel:hover {
+    color: var(--c-text);
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .comment-send {
+    padding: 5px 14px;
+    border: none;
+    background: var(--c-accent);
+    color: #fff;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: inherit;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    transition:
+      filter 0.15s,
+      transform 0.1s;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+
+  .comment-send:hover {
+    filter: brightness(1.15);
+  }
+
+  .comment-send:active {
+    transform: scale(0.97);
+  }
+
+  .comment-send:disabled {
+    opacity: 0.35;
+    cursor: default;
+    transform: none;
+    filter: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .comment-trigger {
+      transition: none;
+    }
+
+    .comment-form {
+      animation: none;
+    }
+
+    .comment-send {
+      transition: none;
+    }
+
+    .toolbar-pulse {
+      animation: none;
+    }
+
+    .chevron {
+      transition: none;
+    }
+  }
+
+  .diff-line.add {
+    background: var(--diff-add-bg);
+  }
+
+  .diff-line.delete {
+    background: var(--diff-delete-bg);
+  }
+
+  .gutter {
+    display: inline-block;
+    width: 4ch;
+    text-align: right;
+    padding-right: 4px;
+    color: var(--c-text-faint);
+    flex-shrink: 0;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  .line-prefix {
+    width: 1ch;
+    flex-shrink: 0;
+    -webkit-user-select: none;
+    user-select: none;
+    color: var(--c-text-faint);
+  }
+
+  .diff-line.add .line-prefix {
+    color: var(--diff-add-fg);
+  }
+
+  .diff-line.delete .line-prefix {
+    color: var(--diff-delete-fg);
+  }
+
+  .line-content {
+    flex: 1;
+    padding: 0 8px 0 4px;
+    white-space: pre;
+    min-width: 0;
+    color: var(--c-text);
+  }
+
+  .diff-line.add .line-content {
+    color: var(--diff-add-fg);
+  }
+
+  .diff-line.delete .line-content {
+    color: var(--diff-delete-fg);
+  }
+
+  .empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    font-size: 13px;
+    color: var(--c-text-muted);
+    font-family: inherit;
+  }
+</style>

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -16,6 +16,7 @@
   import FeatureOnboarding from '../onboarding/FeatureOnboarding.svelte'
   import TmuxSessionBrowser from '../terminal/TmuxSessionBrowser.svelte'
   import WelcomeDashboard from '../dashboard/WelcomeDashboard.svelte'
+  import RightPanel from './RightPanel.svelte'
   import Toast from '../shared/Toast.svelte'
   import { getPref, setPref } from '../../lib/stores/preferences.svelte'
   import {
@@ -34,7 +35,7 @@
     restoreProjects,
     updateGitInfoForProject,
     toggleSidebar,
-    toggleInspector,
+    toggleRightPanel,
   } from '../../lib/stores/workspace.svelte'
   import {
     activeTabId,
@@ -106,6 +107,37 @@
     if (sidebarDragging) {
       sidebarDragging = false
       setPref('sidebar.width', String(sidebarWidth))
+    }
+  }
+
+  // Right panel resize state
+  const RPANEL_MIN = 200
+  const RPANEL_MAX = 500
+  let rightPanelWidth = $state(parseInt(getPref('rightPanel.width', '280'), 10) || 280)
+  let rpDragging = $state(false)
+  let rpDragStart = 0
+
+  function handleRpPointerDown(e: PointerEvent): void {
+    e.preventDefault()
+    const target = e.currentTarget as HTMLElement
+    target.setPointerCapture(e.pointerId)
+    rpDragging = true
+    rpDragStart = e.clientX
+  }
+
+  function handleRpPointerMove(e: PointerEvent): void {
+    if (!rpDragging) return
+    const delta = rpDragStart - e.clientX
+    if (delta !== 0) {
+      rightPanelWidth = Math.min(RPANEL_MAX, Math.max(RPANEL_MIN, rightPanelWidth + delta))
+      rpDragStart = e.clientX
+    }
+  }
+
+  function handleRpPointerUp(): void {
+    if (rpDragging) {
+      rpDragging = false
+      setPref('rightPanel.width', String(rightPanelWidth))
     }
   }
 
@@ -277,6 +309,9 @@
   let activeAgentPtySessionId = $derived(
     focusedPane && agentSessions[focusedPane.sessionId] ? focusedPane.sessionId : null,
   )
+  let activeAgentState = $derived(
+    activeAgentPtySessionId ? agentSessions[activeAgentPtySessionId] : null,
+  )
 
   // Clear badge when agent pane is focused
   $effect(() => {
@@ -343,7 +378,7 @@
     // Cmd+Shift+I: toggle Agent Inspector on focused pane
     if ((e.key === 'I' || e.key === 'i') && e.shiftKey) {
       e.preventDefault()
-      toggleInspector()
+      toggleRightPanel()
     }
 
     // Cmd+L: focus browser URL bar (when active tab is browser)
@@ -505,6 +540,23 @@
           </div>
         {/if}
       </div>
+
+      {#if workspaceState.rightPanelOpen && workspaceState.selectedWorktreePath}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="right-resize-handle"
+          class:dragging={rpDragging}
+          onpointerdown={handleRpPointerDown}
+          onpointermove={handleRpPointerMove}
+          onpointerup={handleRpPointerUp}
+          onpointercancel={handleRpPointerUp}
+        ></div>
+        <RightPanel
+          agentState={activeAgentState}
+          width={rightPanelWidth}
+          worktreePath={workspaceState.selectedWorktreePath ?? ''}
+        />
+      {/if}
     </div>
   </div>
 </main>
@@ -528,6 +580,26 @@
 
   .sidebar-resize-handle:hover,
   .sidebar-resize-handle.dragging {
+    background: var(--c-accent-muted);
+  }
+
+  .right-resize-handle {
+    width: 1px;
+    cursor: col-resize;
+    background: var(--c-border-subtle);
+    flex-shrink: 0;
+    position: relative;
+  }
+
+  .right-resize-handle::after {
+    content: '';
+    position: absolute;
+    inset: 0 -3px;
+    cursor: col-resize;
+  }
+
+  .right-resize-handle:hover,
+  .right-resize-handle.dragging {
     background: var(--c-accent-muted);
   }
 

--- a/src/renderer/src/components/layout/RightPanel.svelte
+++ b/src/renderer/src/components/layout/RightPanel.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import type { AgentSessionState } from '../../lib/agents/agentState.svelte'
+  import { workspaceState } from '../../lib/stores/workspace.svelte'
+  import AgentInspector from '../agents/AgentInspector.svelte'
+  import ChangesPanel from '../diff/ChangesPanel.svelte'
+
+  let {
+    agentState = null,
+    width = 280,
+    worktreePath = '',
+  }: {
+    agentState?: AgentSessionState | null
+    width?: number
+    worktreePath?: string
+  } = $props()
+
+  onMount(() => {
+    const handler = (e: Event): void => {
+      workspaceState.changesCount = (e as CustomEvent<{ count: number }>).detail.count
+    }
+    window.addEventListener('canopy:changes-count', handler)
+    return () => window.removeEventListener('canopy:changes-count', handler)
+  })
+</script>
+
+<aside class="right-panel" style:width="{width}px">
+  <div class="tab-header">
+    <div class="segmented-control" role="tablist">
+      <button
+        class="segment"
+        class:active={workspaceState.rightPanelTab === 'session'}
+        role="tab"
+        aria-selected={workspaceState.rightPanelTab === 'session'}
+        onclick={() => (workspaceState.rightPanelTab = 'session')}
+      >
+        Session
+      </button>
+      <button
+        class="segment"
+        class:active={workspaceState.rightPanelTab === 'changes'}
+        role="tab"
+        aria-selected={workspaceState.rightPanelTab === 'changes'}
+        onclick={() => (workspaceState.rightPanelTab = 'changes')}
+      >
+        Changes
+        {#if workspaceState.changesCount > 0}
+          <span class="badge">{workspaceState.changesCount}</span>
+        {/if}
+      </button>
+    </div>
+  </div>
+
+  <div class="tab-content">
+    {#if workspaceState.rightPanelTab === 'session'}
+      {#if agentState}
+        <AgentInspector state={agentState} />
+      {:else}
+        <div class="empty-state">
+          <span class="empty-text">No active agent session</span>
+        </div>
+      {/if}
+    {:else if worktreePath}
+      <ChangesPanel {worktreePath} />
+    {:else}
+      <div class="empty-state">
+        <span class="empty-text">No changes yet</span>
+      </div>
+    {/if}
+  </div>
+</aside>
+
+<style>
+  .right-panel {
+    min-width: 200px;
+    max-width: 500px;
+    height: 100%;
+    background: var(--c-bg);
+    border-left: 1px solid var(--c-border-subtle);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  .tab-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 12px;
+    flex-shrink: 0;
+  }
+
+  .segmented-control {
+    display: flex;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 8px;
+    padding: 2px;
+    width: 100%;
+  }
+
+  .segment {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    height: 26px;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--c-text-faint);
+    cursor: pointer;
+    border: none;
+    background: none;
+    font-family: inherit;
+    border-radius: 6px;
+    transition:
+      background 0.2s cubic-bezier(0.25, 0.1, 0.25, 1),
+      color 0.15s,
+      box-shadow 0.2s cubic-bezier(0.25, 0.1, 0.25, 1);
+  }
+
+  .segment:hover:not(.active) {
+    color: var(--c-text-secondary);
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .segment.active {
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--c-text);
+    font-weight: 600;
+    box-shadow:
+      0 1px 4px rgba(0, 0, 0, 0.3),
+      0 0.5px 1px rgba(0, 0, 0, 0.2);
+  }
+
+  .badge {
+    font-size: 10px;
+    font-weight: 600;
+    min-width: 14px;
+    height: 14px;
+    border-radius: 7px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 4px;
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--c-text-secondary);
+    line-height: 1;
+  }
+
+  .segment.active .badge {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--c-text);
+  }
+
+  .tab-content {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  .empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    padding: 16px;
+  }
+
+  .empty-text {
+    font-size: 12px;
+    color: var(--c-text-muted);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .segment {
+      transition: none;
+    }
+  }
+</style>

--- a/src/renderer/src/components/layout/StatusBar.svelte
+++ b/src/renderer/src/components/layout/StatusBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { match } from 'ts-pattern'
-  import { workspaceState, projects, toggleInspector } from '../../lib/stores/workspace.svelte'
+  import { workspaceState, projects, toggleRightPanel } from '../../lib/stores/workspace.svelte'
   import { agentSessions, type AgentSessionState } from '../../lib/agents/agentState.svelte'
   import { getAllTabs, activeTabId, focusSessionByPtyId } from '../../lib/stores/tabs.svelte'
   import { findLeaf } from '../../lib/stores/splitTree'
@@ -319,7 +319,7 @@
         class="status-item inspector-toggle"
         aria-label="Toggle Inspector"
         title="Toggle Inspector"
-        onclick={() => toggleInspector()}
+        onclick={() => toggleRightPanel()}
       >
         <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
           <path

--- a/src/renderer/src/components/palette/CommandPalette.svelte
+++ b/src/renderer/src/components/palette/CommandPalette.svelte
@@ -4,7 +4,7 @@
   import {
     workspaceState,
     toggleSidebar,
-    toggleInspector,
+    toggleRightPanel,
     openWorkspace,
     selectWorktree,
   } from '../../lib/stores/workspace.svelte'
@@ -119,7 +119,7 @@
       label: 'Toggle Claude Inspector',
       category: 'App',
       shortcut: `${mod}+Shift+I`,
-      action: () => toggleInspector(),
+      action: () => toggleRightPanel(),
     })
 
     items.push({

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -2,11 +2,10 @@
   import type { PaneSession } from '../../lib/stores/splitTree'
   import { restartPane, updatePaneTitle, isAiToolId } from '../../lib/stores/tabs.svelte'
   import { dragState, setDropTarget, type DropZone } from '../../lib/stores/dragState.svelte'
-  import { agentSessions } from '../../lib/agents/agentState.svelte'
   import TerminalInstance from '../../lib/terminal/TerminalInstance.svelte'
   import BrowserPane from '../browser/BrowserPane.svelte'
   import EditorPane from '../editor/EditorPane.svelte'
-  import AgentInspector from '../agents/AgentInspector.svelte'
+  import DiffPane from '../diff/DiffPane.svelte'
   import ExitBanner from './ExitBanner.svelte'
   import DetachedOverlay from './DetachedOverlay.svelte'
   import WpmIndicator from './WpmIndicator.svelte'
@@ -33,8 +32,6 @@
   let wrapperEl: HTMLDivElement | undefined = $state()
   let hoveredZone: DropZone | null = $state(null)
 
-  let agentState = $derived(agentSessions[pane.sessionId] ?? null)
-  let showInspector = $derived(pane.inspectorOpen !== false && agentState !== null)
   let wpmEnabled = $derived(prefs['wpm.enabled'] === 'true')
   let keystrokeVisualizerEnabled = $derived(prefs['keystrokeVisualizer.enabled'] === 'true')
 
@@ -106,40 +103,37 @@
     />
   {:else if pane.paneType === 'editor'}
     <EditorPane filePath={pane.filePath!} {active} />
+  {:else if pane.paneType === 'diff'}
+    <DiffPane {worktreePath} {active} />
   {:else}
-    <div class="pane-with-inspector">
-      <div class="pane-content">
-        {#key pane.sessionId}
-          <TerminalInstance
-            sessionId={pane.sessionId}
-            wsUrl={pane.wsUrl}
-            active={active && focused}
-            visible={active}
-            isAiTool={isAiToolId(pane.toolId)}
-            onTitleChange={(title) => updatePaneTitle(pane.sessionId, title)}
-          />
-        {/key}
-        {#if wpmEnabled}
-          <WpmIndicator sessionId={pane.sessionId} />
-        {/if}
-        {#if keystrokeVisualizerEnabled}
-          <KeystrokeVisualizer sessionId={pane.sessionId} />
-        {/if}
-        {#if !pane.isRunning && pane.detached && pane.tmuxSessionName}
-          <DetachedOverlay
-            tmuxSessionName={pane.tmuxSessionName}
-            onReattach={() => reattachTmuxPane(worktreePath, tabId, pane.id)}
-            onKill={() => killTmuxPane(worktreePath, tabId, pane.id)}
-          />
-        {:else if !pane.isRunning}
-          <ExitBanner
-            exitCode={pane.exitCode}
-            onRestart={() => restartPane(worktreePath, tabId, pane.id)}
-          />
-        {/if}
-      </div>
-      {#if showInspector}
-        <AgentInspector state={agentState} />
+    <div class="pane-content">
+      {#key pane.sessionId}
+        <TerminalInstance
+          sessionId={pane.sessionId}
+          wsUrl={pane.wsUrl}
+          active={active && focused}
+          visible={active}
+          isAiTool={isAiToolId(pane.toolId)}
+          onTitleChange={(title) => updatePaneTitle(pane.sessionId, title)}
+        />
+      {/key}
+      {#if wpmEnabled}
+        <WpmIndicator sessionId={pane.sessionId} />
+      {/if}
+      {#if keystrokeVisualizerEnabled}
+        <KeystrokeVisualizer sessionId={pane.sessionId} />
+      {/if}
+      {#if !pane.isRunning && pane.detached && pane.tmuxSessionName}
+        <DetachedOverlay
+          tmuxSessionName={pane.tmuxSessionName}
+          onReattach={() => reattachTmuxPane(worktreePath, tabId, pane.id)}
+          onKill={() => killTmuxPane(worktreePath, tabId, pane.id)}
+        />
+      {:else if !pane.isRunning}
+        <ExitBanner
+          exitCode={pane.exitCode}
+          onRestart={() => restartPane(worktreePath, tabId, pane.id)}
+        />
       {/if}
     </div>
   {/if}
@@ -162,19 +156,11 @@
     outline-offset: -1px;
   }
 
-  .pane-with-inspector {
-    display: flex;
-    flex-direction: row;
+  .pane-content {
     width: 100%;
     height: 100%;
-    overflow: hidden;
-  }
-
-  .pane-content {
-    flex: 1;
-    min-width: 0;
     position: relative;
-    height: 100%;
+    overflow: hidden;
   }
 
   .drop-zone-overlay {

--- a/src/renderer/src/lib/stores/splitTree.ts
+++ b/src/renderer/src/lib/stores/splitTree.ts
@@ -9,7 +9,7 @@ export interface PaneSession {
   isRunning: boolean
   exitCode: number | null
   title: string | null
-  paneType?: 'terminal' | 'browser' | 'editor'
+  paneType?: 'terminal' | 'browser' | 'editor' | 'diff'
   filePath?: string
   url?: string
   isLoading?: boolean

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -492,6 +492,61 @@ export function openFile(filePath: string, worktreePath: string): void {
   scheduleSave(worktreePath)
 }
 
+export function openDiffTab(worktreePath: string, scrollToFile?: string): void {
+  // Check if a diff tab already exists — focus it
+  const tabs = (tabsByWorktree[worktreePath] ?? []).filter((t) => !t.suspended)
+  for (const tab of tabs) {
+    const panes = allPanes(tab.rootSplit)
+    const existing = panes.find((p) => p.paneType === 'diff')
+    if (existing) {
+      activeTabId[worktreePath] = tab.id
+      tab.focusedPaneId = existing.id
+      if (scrollToFile) {
+        workspaceState.diffScrollTarget = { path: scrollToFile, ts: Date.now() }
+      }
+      return
+    }
+  }
+
+  // Create single diff tab for all changes
+  const paneId = nextPaneId()
+  const pane: PaneSession = {
+    id: paneId,
+    sessionId: '',
+    wsUrl: '',
+    toolId: 'diff',
+    toolName: 'Diff',
+    isRunning: true,
+    exitCode: null,
+    title: null,
+    paneType: 'diff',
+  }
+
+  const id = nextTabId()
+  const name = computeDisplayName('Diff', worktreePath, 'diff')
+
+  const tab: TabInfo = {
+    id,
+    toolId: 'diff',
+    toolName: 'Diff',
+    name,
+    worktreePath,
+    rootSplit: createLeaf(pane),
+    focusedPaneId: paneId,
+  }
+
+  if (!tabsByWorktree[worktreePath]) {
+    tabsByWorktree[worktreePath] = []
+  }
+  tabsByWorktree[worktreePath].push(tab)
+  activeTabId[worktreePath] = id
+  scheduleSave(worktreePath)
+
+  if (scrollToFile) {
+    workspaceState.diffScrollTarget = { path: scrollToFile, ts: Date.now() }
+  }
+}
+
 export function getActiveTab(worktreePath: string): TabInfo | null {
   const tabs = tabsByWorktree[worktreePath]
   if (!tabs) return null

--- a/src/renderer/src/lib/stores/workspace.svelte.ts
+++ b/src/renderer/src/lib/stores/workspace.svelte.ts
@@ -63,6 +63,10 @@ interface WorkspaceState {
   isDirty: boolean
   aheadBehind: { ahead: number; behind: number } | null
   sidebarOpen: boolean
+  rightPanelOpen: boolean
+  rightPanelTab: 'session' | 'changes'
+  changesCount: number
+  diffScrollTarget: { path: string; ts: number } | null
 }
 
 // --- State ---
@@ -77,6 +81,10 @@ const initial: WorkspaceState = {
   isDirty: false,
   aheadBehind: null,
   sidebarOpen: true,
+  rightPanelOpen: true,
+  rightPanelTab: 'changes',
+  changesCount: 0,
+  diffScrollTarget: null,
 }
 
 /** Active selection — the currently focused project + worktree context */
@@ -413,7 +421,9 @@ export function toggleSidebar(): void {
   workspaceState.sidebarOpen = !workspaceState.sidebarOpen
 }
 
-export { toggleFocusedInspector as toggleInspector } from './tabs.svelte'
+export function toggleRightPanel(): void {
+  workspaceState.rightPanelOpen = !workspaceState.rightPanelOpen
+}
 
 export async function closeWorkspace(): Promise<void> {
   // Detach all projects


### PR DESCRIPTION
## Summary

- **Right panel with tabs** — app-level panel (replaces per-pane inspector) with Apple-style segmented control: Session tab for AgentInspector, Changes tab for diff review
- **Changes panel** — lists uncommitted files with status icons, +N/-M counts, file/status filters, stage/revert actions. Clicking a file navigates to its section in the Diff tab
- **Full-window Diff tab** — renders all file diffs in a single scrollable view (like GitHub PR diff) with collapsible files, search highlighting, keyboard navigation (J/K), and sticky file headers
- **Inline review comments** — GitHub-style `+` trigger on diff lines opens a comment card that sends context (3 surrounding lines) + comment to the active agent session via PTY
- **Backend diff pipeline** — unified diff parser, `git:diff`/`git:diffFile`/`git:stageFile`/`git:revertFile` IPC channels with neverthrow error handling
- **Auto-refresh** — diffs update on branch switch, worktree change, and git index changes. Visible file syncs between diff scroll position and changes list

## Test plan

- [ ] Open a project with uncommitted changes, verify Changes tab shows file list
- [ ] Click a file in Changes → Diff tab opens and scrolls to that file
- [ ] Test stage (✓) and revert (✗) buttons on file items
- [ ] Test J/K keyboard navigation between files in Diff tab
- [ ] Test search in diff (search icon in toolbar)
- [ ] Test collapse/expand file sections by clicking headers
- [ ] Test inline comment: hover line → click `+` → type comment → Send to Agent
- [ ] Switch branches → verify Changes tab auto-refreshes
- [ ] Toggle right panel with Cmd+Shift+I
- [ ] Resize right panel by dragging left edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)