### PR TITLE
feat(github): add GitHub integration with GraphQL API

### DIFF
--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -83,6 +83,13 @@ export class GitRepository {
     })
   }
 
+  static getRemoteUrl(repoRoot: string, remote = 'origin'): ResultAsync<string, GitError> {
+    const git = simpleGit(repoRoot)
+    return gitCall('remote get-url', git.raw(['remote', 'get-url', remote])).map((raw) =>
+      raw.trim(),
+    )
+  }
+
   static listWorktrees(repoRoot: string): ResultAsync<GitWorktreeInfo[], GitError> {
     const git = simpleGit(repoRoot)
     return gitCall('worktree list', git.raw(['worktree', 'list', '--porcelain'])).map(

--- a/src/main/github/GitHubService.ts
+++ b/src/main/github/GitHubService.ts
@@ -1,4 +1,4 @@
-import { ok, err, type ResultAsync } from 'neverthrow'
+import { ok, err, okAsync, type ResultAsync } from 'neverthrow'
 import type { PreferencesStore } from '../db/PreferencesStore'
 import type { TaskTrackerConnection } from '../taskTracker/types'
 import type { TaskTrackerManager } from '../taskTracker/TaskTrackerManager'
@@ -142,7 +142,7 @@ export class GitHubService {
     branches: string[],
   ): ResultAsync<BranchPRMap, GitHubError> {
     if (branches.length === 0) {
-      return graphqlFetch<never>(apiUrl, token, '{ viewer { login } }').map(() => ({}))
+      return okAsync({} as BranchPRMap)
     }
 
     const headFilters = branches.map((b) => `head:${b}`).join(' ')

--- a/src/main/github/GitHubService.ts
+++ b/src/main/github/GitHubService.ts
@@ -1,0 +1,209 @@
+import { ok, err, type ResultAsync } from 'neverthrow'
+import type { PreferencesStore } from '../db/PreferencesStore'
+import type { TaskTrackerConnection } from '../taskTracker/types'
+import type { TaskTrackerManager } from '../taskTracker/TaskTrackerManager'
+import { GitRepository } from '../git/GitRepository'
+import { graphqlFetch } from './graphql'
+import { parseGitHubRemote } from './remoteUrl'
+import type { GitHubError } from './errors'
+import type { RepoIdentifier, BranchPRMap, GitHubPR, CreatePRInput, GitHubRepoInfo } from './types'
+
+const PR_SEARCH_QUERY = `
+query($q: String!) {
+  search(query: $q, type: ISSUE, first: 50) {
+    nodes {
+      ... on PullRequest {
+        number
+        title
+        state
+        url
+        headRefName
+        baseRefName
+        isDraft
+        reviewDecision
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup { state }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+const CREATE_PR_MUTATION = `
+mutation($input: CreatePullRequestInput!) {
+  createPullRequest(input: $input) {
+    pullRequest {
+      number
+      title
+      url
+      headRefName
+      baseRefName
+      isDraft
+    }
+  }
+}
+`
+
+const REPO_INFO_QUERY = `
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    id
+    defaultBranchRef { name }
+  }
+}
+`
+
+interface SearchResponse {
+  search: {
+    nodes: Array<{
+      number?: number
+      title?: string
+      state?: string
+      url?: string
+      headRefName?: string
+      baseRefName?: string
+      isDraft?: boolean
+      reviewDecision?: string | null
+      commits?: { nodes: Array<{ commit: { statusCheckRollup: { state: string } | null } }> }
+    }>
+  }
+}
+
+interface CreatePRResponse {
+  createPullRequest: {
+    pullRequest: {
+      number: number
+      title: string
+      url: string
+      headRefName: string
+      baseRefName: string
+      isDraft: boolean
+    }
+  }
+}
+
+interface RepoInfoResponse {
+  repository: {
+    id: string
+    defaultBranchRef: { name: string } | null
+  }
+}
+
+export class GitHubService {
+  constructor(
+    private preferencesStore: PreferencesStore,
+    private taskTrackerManager: TaskTrackerManager,
+  ) {}
+
+  getRepoIdentifier(repoRoot: string): ResultAsync<RepoIdentifier, GitHubError> {
+    return GitRepository.getRemoteUrl(repoRoot)
+      .mapErr((): GitHubError => ({ _tag: 'NoGitHubRemote', repoRoot }))
+      .andThen((url) => {
+        const result = parseGitHubRemote(url)
+        if (result.isErr()) return err(result.error)
+        return ok(result.value)
+      })
+  }
+
+  findGitHubConnection(
+    repoRoot: string,
+  ): ResultAsync<
+    { connection: TaskTrackerConnection; token: string; repo: RepoIdentifier } | null,
+    GitHubError
+  > {
+    return this.getRepoIdentifier(repoRoot).map((repo) => {
+      const connections = this.taskTrackerManager.getConnections()
+      // Match by exact projectKey, or empty projectKey on same host (or github.com default)
+      const match = connections.find((c) => {
+        if (c.provider !== 'github') return false
+        if (c.projectKey) return c.projectKey === `${repo.owner}/${repo.repo}`
+        const connHost = c.baseUrl ? new URL(c.baseUrl).hostname : 'github.com'
+        return connHost === repo.host
+      })
+      if (!match) return null
+
+      const token = this.preferencesStore.get(match.authPrefKey)
+      if (!token) return null
+
+      return { connection: match, token, repo }
+    })
+  }
+
+  fetchOpenPRsForBranches(
+    apiUrl: string,
+    token: string,
+    owner: string,
+    repo: string,
+    branches: string[],
+  ): ResultAsync<BranchPRMap, GitHubError> {
+    if (branches.length === 0) {
+      return graphqlFetch<never>(apiUrl, token, '{ viewer { login } }').map(() => ({}))
+    }
+
+    const headFilters = branches.map((b) => `head:${b}`).join(' ')
+    const q = `repo:${owner}/${repo} is:pr is:open ${headFilters}`
+
+    return graphqlFetch<SearchResponse>(apiUrl, token, PR_SEARCH_QUERY, { q }).map((data) => {
+      const map: BranchPRMap = {}
+      for (const node of data.search.nodes) {
+        if (!node.headRefName || !node.number) continue
+        const checksNode = node.commits?.nodes?.[0]?.commit?.statusCheckRollup
+        map[node.headRefName] = {
+          number: node.number,
+          title: node.title ?? '',
+          state: node.state ?? 'OPEN',
+          url: node.url ?? '',
+          headRefName: node.headRefName,
+          baseRefName: node.baseRefName ?? '',
+          isDraft: node.isDraft ?? false,
+          reviewDecision: node.reviewDecision ?? null,
+          checksState: checksNode?.state ?? null,
+        }
+      }
+      return map
+    })
+  }
+
+  createPR(
+    apiUrl: string,
+    token: string,
+    input: CreatePRInput,
+  ): ResultAsync<GitHubPR, GitHubError> {
+    return graphqlFetch<CreatePRResponse>(apiUrl, token, CREATE_PR_MUTATION, {
+      input,
+    }).map((data) => {
+      const pr = data.createPullRequest.pullRequest
+      return {
+        number: pr.number,
+        title: pr.title,
+        state: 'OPEN',
+        url: pr.url,
+        headRefName: pr.headRefName,
+        baseRefName: pr.baseRefName,
+        isDraft: pr.isDraft,
+        reviewDecision: null,
+        checksState: null,
+      }
+    })
+  }
+
+  getRepoInfo(
+    apiUrl: string,
+    token: string,
+    owner: string,
+    repo: string,
+  ): ResultAsync<GitHubRepoInfo, GitHubError> {
+    return graphqlFetch<RepoInfoResponse>(apiUrl, token, REPO_INFO_QUERY, {
+      owner,
+      name: repo,
+    }).map((data) => ({
+      id: data.repository.id,
+      defaultBranch: data.repository.defaultBranchRef?.name ?? 'main',
+    }))
+  }
+}

--- a/src/main/github/errors.ts
+++ b/src/main/github/errors.ts
@@ -1,0 +1,29 @@
+import { match } from 'ts-pattern'
+
+export type GitHubError =
+  | { _tag: 'GitHubTokenMissing' }
+  | { _tag: 'GitHubApiError'; status: number; message: string }
+  | { _tag: 'GitHubGraphQLError'; errors: Array<{ message: string }> }
+  | { _tag: 'GitHubRateLimited'; resetAt: number }
+  | { _tag: 'GitHubNetworkError'; message: string }
+  | { _tag: 'InvalidRemoteUrl'; url: string }
+  | { _tag: 'NoGitHubRemote'; repoRoot: string }
+
+export function gitHubErrorMessage(error: GitHubError): string {
+  return match(error)
+    .with({ _tag: 'GitHubTokenMissing' }, () => 'GitHub token is not configured')
+    .with({ _tag: 'GitHubApiError' }, (e) => `GitHub API error (${e.status}): ${e.message}`)
+    .with(
+      { _tag: 'GitHubGraphQLError' },
+      (e) => `GitHub GraphQL error: ${e.errors.map((err) => err.message).join(', ')}`,
+    )
+    .with(
+      { _tag: 'GitHubRateLimited' },
+      (e) =>
+        `GitHub rate limit exceeded, resets at ${new Date(e.resetAt * 1000).toLocaleTimeString()}`,
+    )
+    .with({ _tag: 'GitHubNetworkError' }, (e) => `GitHub network error: ${e.message}`)
+    .with({ _tag: 'InvalidRemoteUrl' }, (e) => `Invalid GitHub remote URL: ${e.url}`)
+    .with({ _tag: 'NoGitHubRemote' }, (e) => `No GitHub remote found in ${e.repoRoot}`)
+    .exhaustive()
+}

--- a/src/main/github/graphql.ts
+++ b/src/main/github/graphql.ts
@@ -1,4 +1,4 @@
-import { errAsync } from 'neverthrow'
+import { errAsync, okAsync } from 'neverthrow'
 import type { ResultAsync } from 'neverthrow'
 import { fromExternalCall, errorMessage } from '../errors'
 import type { GitHubError } from './errors'
@@ -82,10 +82,7 @@ export function graphqlFetch<T>(
           message: 'No data in GraphQL response',
         })
       }
-      return fromExternalCall(
-        Promise.resolve(json.data),
-        (e): GitHubError => ({ _tag: 'GitHubApiError', status: 0, message: errorMessage(e) }),
-      )
+      return okAsync(json.data as T)
     })
   })
 }

--- a/src/main/github/graphql.ts
+++ b/src/main/github/graphql.ts
@@ -1,0 +1,91 @@
+import { errAsync } from 'neverthrow'
+import type { ResultAsync } from 'neverthrow'
+import { fromExternalCall, errorMessage } from '../errors'
+import type { GitHubError } from './errors'
+
+interface GraphQLResponse<T> {
+  data?: T
+  errors?: Array<{ message: string }>
+}
+
+export function graphqlFetch<T>(
+  apiUrl: string,
+  token: string,
+  query: string,
+  variables?: Record<string, unknown>,
+): ResultAsync<T, GitHubError> {
+  return fromExternalCall(
+    fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(15_000),
+    }),
+    (e): GitHubError => ({ _tag: 'GitHubNetworkError', message: errorMessage(e) }),
+  ).andThen((res) => {
+    if (res.status === 401 || res.status === 403) {
+      const resetHeader = res.headers.get('x-ratelimit-reset')
+      if (resetHeader && res.status === 403) {
+        return errAsync<T, GitHubError>({
+          _tag: 'GitHubRateLimited',
+          resetAt: parseInt(resetHeader, 10),
+        })
+      }
+      return fromExternalCall(
+        res.text().catch(() => ''),
+        (e): GitHubError => ({
+          _tag: 'GitHubApiError',
+          status: res.status,
+          message: errorMessage(e),
+        }),
+      ).andThen((body) =>
+        errAsync<T, GitHubError>({
+          _tag: 'GitHubApiError',
+          status: res.status,
+          message: body || res.statusText,
+        }),
+      )
+    }
+
+    if (!res.ok) {
+      return fromExternalCall(
+        res.text().catch(() => ''),
+        (e): GitHubError => ({
+          _tag: 'GitHubApiError',
+          status: res.status,
+          message: errorMessage(e),
+        }),
+      ).andThen((body) =>
+        errAsync<T, GitHubError>({
+          _tag: 'GitHubApiError',
+          status: res.status,
+          message: body || res.statusText,
+        }),
+      )
+    }
+
+    return fromExternalCall(
+      res.json() as Promise<GraphQLResponse<T>>,
+      (e): GitHubError => ({ _tag: 'GitHubApiError', status: 0, message: errorMessage(e) }),
+    ).andThen((json) => {
+      if (json.errors?.length) {
+        return errAsync<T, GitHubError>({ _tag: 'GitHubGraphQLError', errors: json.errors })
+      }
+      if (!json.data) {
+        return errAsync<T, GitHubError>({
+          _tag: 'GitHubApiError',
+          status: 0,
+          message: 'No data in GraphQL response',
+        })
+      }
+      return fromExternalCall(
+        Promise.resolve(json.data),
+        (e): GitHubError => ({ _tag: 'GitHubApiError', status: 0, message: errorMessage(e) }),
+      )
+    })
+  })
+}

--- a/src/main/github/remoteUrl.ts
+++ b/src/main/github/remoteUrl.ts
@@ -1,0 +1,32 @@
+import { ok, err } from 'neverthrow'
+import type { Result } from 'neverthrow'
+import type { GitHubError } from './errors'
+import type { RepoIdentifier } from './types'
+
+const SSH_SHORTHAND = /^git@([^:]+):([^/]+)\/([^/.]+?)(?:\.git)?$/
+const HTTPS_URL = /^https?:\/\/([^/]+)\/([^/]+)\/([^/.]+?)(?:\.git)?$/
+const SSH_URL = /^ssh:\/\/git@([^/]+)\/([^/]+)\/([^/.]+?)(?:\.git)?$/
+
+function apiUrlForHost(host: string): string {
+  if (host === 'github.com') return 'https://api.github.com/graphql'
+  return `https://${host}/api/graphql`
+}
+
+export function parseGitHubRemote(url: string): Result<RepoIdentifier, GitHubError> {
+  for (const pattern of [SSH_SHORTHAND, HTTPS_URL, SSH_URL]) {
+    const m = url.match(pattern)
+    if (m) {
+      return ok({
+        owner: m[2],
+        repo: m[3],
+        host: m[1],
+        apiUrl: apiUrlForHost(m[1]),
+      })
+    }
+  }
+  return err({ _tag: 'InvalidRemoteUrl', url })
+}
+
+export function isGitHubHost(host: string): boolean {
+  return host === 'github.com' || host.includes('github')
+}

--- a/src/main/github/remoteUrl.ts
+++ b/src/main/github/remoteUrl.ts
@@ -26,7 +26,3 @@ export function parseGitHubRemote(url: string): Result<RepoIdentifier, GitHubErr
   }
   return err({ _tag: 'InvalidRemoteUrl', url })
 }
-
-export function isGitHubHost(host: string): boolean {
-  return host === 'github.com' || host.includes('github')
-}

--- a/src/main/github/types.ts
+++ b/src/main/github/types.ts
@@ -1,0 +1,50 @@
+export interface RepoIdentifier {
+  owner: string
+  repo: string
+  host: string
+  apiUrl: string
+}
+
+export interface GitHubPR {
+  number: number
+  title: string
+  state: string
+  url: string
+  headRefName: string
+  baseRefName: string
+  isDraft: boolean
+  reviewDecision: string | null
+  checksState: string | null
+}
+
+export type BranchPRMap = Record<string, GitHubPR>
+
+export interface CreatePRInput {
+  repositoryId: string
+  headRefName: string
+  baseRefName: string
+  title: string
+  body: string
+  draft: boolean
+}
+
+export interface GitHubUser {
+  login: string
+  name: string | null
+}
+
+export interface GitHubRepoInfo {
+  id: string
+  defaultBranch: string
+}
+
+export interface GitHubLabel {
+  name: string
+  color: string
+}
+
+export interface GitHubMilestone {
+  number: number
+  title: string
+  state: string
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,6 +21,7 @@ import { CredentialStore } from './db/CredentialStore'
 import { NotchOverlayManager } from './notch/NotchOverlayManager'
 import { TmuxManager } from './pty/TmuxManager'
 import { TaskTrackerManager } from './taskTracker/TaskTrackerManager'
+import { GitHubService } from './github/GitHubService'
 import semver from 'semver'
 import { isSafeExternalUrl } from './security/validateUrl'
 import { fetchChangelogRange, resolveUpdateChannel } from './changelog/fetchChangelog'
@@ -440,6 +441,7 @@ app.whenReady().then(async () => {
   windowManager.setBrowserManager(browserManager)
 
   const taskTrackerManager = new TaskTrackerManager(preferencesStore)
+  const gitHubService = new GitHubService(preferencesStore, taskTrackerManager)
 
   registerIpcHandlers(
     ptyManager,
@@ -455,6 +457,7 @@ app.whenReady().then(async () => {
     onboardingStore,
     tmuxManager,
     taskTrackerManager,
+    gitHubService,
   )
 
   ipcMain.handle('app:openExternal', (_event, { url }: { url: string }) => {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1642,7 +1642,6 @@ export function registerIpcHandlers(
     const worktrees = await GitRepository.listWorktrees(payload.repoRoot).unwrapOr([])
     const branches = worktrees.map((w) => w.branch).filter((b) => b && b !== '(detached)')
     if (branches.length === 0) return {}
-    // Throw on API errors (rate limit, auth, network) so renderer can surface them
     const result = await gitHubService.fetchOpenPRsForBranches(
       repo.apiUrl,
       token,

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1717,7 +1717,10 @@ export function registerIpcHandlers(
       }
       const { token, repo } = found.value
 
-      await GitRepository.push(payload.repoRoot).unwrapOr({ branch: '', remote: '' })
+      const pushResult = await GitRepository.push(payload.repoRoot)
+      if (pushResult.isErr()) {
+        throw new Error(`Failed to push branch: ${gitErrorMessage(pushResult.error)}`)
+      }
 
       const repoInfo = await gitHubService.getRepoInfo(repo.apiUrl, token, repo.owner, repo.repo)
       const repoInfoValue = unwrapOrThrow(repoInfo, gitHubErrorMessage)

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -45,6 +45,8 @@ import {
   BRANCH_TYPE_OPTIONS,
 } from '../taskTracker/branchTemplate'
 import { createPullRequest, buildPRConfig } from '../taskTracker/prCreation'
+import type { GitHubService } from '../github/GitHubService'
+import { gitHubErrorMessage } from '../github/errors'
 
 function resolveShellArgs(): string[] {
   if (os.platform() === 'win32') return []
@@ -65,6 +67,7 @@ export function registerIpcHandlers(
   onboardingStore: OnboardingStore,
   tmuxManager: TmuxManager,
   taskTrackerManager: TaskTrackerManager,
+  gitHubService: GitHubService,
 ): void {
   function broadcastToolsChanged(): void {
     const tools = toolRegistry.getAll()
@@ -1084,18 +1087,20 @@ export function registerIpcHandlers(
         provider: TaskTrackerProvider
         name: string
         baseUrl: string
-        projectKey: string
+        projectKey?: string
         boardId?: string
         username?: string
         token: string
       },
     ) => {
-      const parsed = new URL(payload.baseUrl)
-      if (!['http:', 'https:'].includes(parsed.protocol)) {
-        throw new Error('Base URL must use http:// or https://')
+      if (payload.baseUrl) {
+        const parsed = new URL(payload.baseUrl)
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          throw new Error('Base URL must use http:// or https://')
+        }
       }
-      const { token, ...connectionData } = payload
-      const c = taskTrackerManager.addConnection(connectionData, token)
+      const { token, projectKey, ...rest } = payload
+      const c = taskTrackerManager.addConnection({ ...rest, projectKey: projectKey ?? '' }, token)
       return {
         id: c.id,
         provider: c.provider,
@@ -1120,6 +1125,7 @@ export function registerIpcHandlers(
         connectionId: string
         name?: string
         baseUrl?: string
+        projectKey?: string
         username?: string
         token?: string
       },
@@ -1161,26 +1167,34 @@ export function registerIpcHandlers(
         provider: TaskTrackerProvider
         name: string
         baseUrl: string
-        projectKey: string
+        projectKey?: string
         boardId?: string
         username?: string
         token: string
       },
     ) => {
-      const parsed = new URL(payload.baseUrl)
-      if (!['http:', 'https:'].includes(parsed.protocol)) {
-        throw new Error('Base URL must use http:// or https://')
+      if (payload.baseUrl) {
+        const parsed = new URL(payload.baseUrl)
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          throw new Error('Base URL must use http:// or https://')
+        }
       }
-      const { token, ...connectionData } = payload
-      const result = await taskTrackerManager.testNewConnection(connectionData, token)
+      const { token, projectKey, ...rest } = payload
+      const result = await taskTrackerManager.testNewConnection(
+        { ...rest, projectKey: projectKey ?? '' },
+        token,
+      )
       return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 
-  ipcMain.handle('taskTracker:fetchBoards', async (_event, payload: { connectionId: string }) => {
-    const result = await taskTrackerManager.fetchBoards(payload.connectionId)
-    return unwrapOrThrow(result, taskTrackerErrorMessage)
-  })
+  ipcMain.handle(
+    'taskTracker:fetchBoards',
+    async (_event, payload: { connectionId: string; repoRoot?: string }) => {
+      const result = await taskTrackerManager.fetchBoards(payload.connectionId, payload.repoRoot)
+      return unwrapOrThrow(result, taskTrackerErrorMessage)
+    },
+  )
 
   ipcMain.handle(
     'taskTracker:fetchBoardsForNew',
@@ -1210,8 +1224,12 @@ export function registerIpcHandlers(
 
   ipcMain.handle(
     'taskTracker:fetchStatuses',
-    async (_event, payload: { connectionId: string; boardId?: string }) => {
-      const result = await taskTrackerManager.fetchStatuses(payload.connectionId, payload.boardId)
+    async (_event, payload: { connectionId: string; boardId?: string; repoRoot?: string }) => {
+      const result = await taskTrackerManager.fetchStatuses(
+        payload.connectionId,
+        payload.boardId,
+        payload.repoRoot,
+      )
       return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
@@ -1225,10 +1243,11 @@ export function registerIpcHandlers(
         statuses?: string[]
         assignedToMe?: boolean
         boardId?: string
+        repoRoot?: string
       },
     ) => {
-      const { connectionId, ...params } = payload
-      const result = await taskTrackerManager.fetchTasks(connectionId, params)
+      const { connectionId, repoRoot, ...params } = payload
+      const result = await taskTrackerManager.fetchTasks(connectionId, params, repoRoot)
       return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
@@ -1243,24 +1262,26 @@ export function registerIpcHandlers(
 
   ipcMain.handle(
     'taskTracker:getCurrentSprint',
-    async (_event, payload: { connectionId: string; boardId?: string }) => {
+    async (_event, payload: { connectionId: string; boardId?: string; repoRoot?: string }) => {
       const result = await taskTrackerManager.getCurrentSprint(
         payload.connectionId,
         payload.boardId,
+        payload.repoRoot,
       )
       return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
   )
 
-  const TASK_KEY_RE = /^[A-Za-z0-9_-]+-\d+$/
+  const TASK_KEY_RE = /^[A-Za-z0-9_#-]+-?\d+$/
 
   ipcMain.handle(
     'taskTracker:fetchTaskComments',
-    async (_event, payload: { connectionId: string; taskKey: string }) => {
+    async (_event, payload: { connectionId: string; taskKey: string; repoRoot?: string }) => {
       if (!TASK_KEY_RE.test(payload.taskKey)) throw new Error('Invalid task key')
       const result = await taskTrackerManager.fetchTaskComments(
         payload.connectionId,
         payload.taskKey,
+        payload.repoRoot,
       )
       return unwrapOrThrow(result, taskTrackerErrorMessage)
     },
@@ -1609,5 +1630,77 @@ export function registerIpcHandlers(
 
   ipcMain.handle('onboarding:reset', () => {
     onboardingStore.reset()
+  })
+
+  // ── GitHub PR features ──────────────────────────────────────────────
+
+  ipcMain.handle('github:fetchBranchPRs', async (_event, payload: { repoRoot: string }) => {
+    const found = await gitHubService.findGitHubConnection(payload.repoRoot)
+    // No connection configured — silent empty return (expected for non-GitHub repos)
+    if (found.isErr() || !found.value) return {}
+    const { token, repo } = found.value
+    const worktrees = await GitRepository.listWorktrees(payload.repoRoot).unwrapOr([])
+    const branches = worktrees.map((w) => w.branch).filter((b) => b && b !== '(detached)')
+    if (branches.length === 0) return {}
+    // Throw on API errors (rate limit, auth, network) so renderer can surface them
+    const result = await gitHubService.fetchOpenPRsForBranches(
+      repo.apiUrl,
+      token,
+      repo.owner,
+      repo.repo,
+      branches,
+    )
+    return unwrapOrThrow(result, gitHubErrorMessage)
+  })
+
+  ipcMain.handle('github:getRepoInfo', async (_event, payload: { repoRoot: string }) => {
+    const found = await gitHubService.findGitHubConnection(payload.repoRoot)
+    if (found.isErr() || !found.value) return null
+    const { token, repo } = found.value
+    const result = await gitHubService.getRepoInfo(repo.apiUrl, token, repo.owner, repo.repo)
+    return unwrapOrThrow(result, gitHubErrorMessage)
+  })
+
+  ipcMain.handle(
+    'github:createPR',
+    async (
+      _event,
+      payload: {
+        repoRoot: string
+        title: string
+        body: string
+        baseRefName: string
+        draft: boolean
+      },
+    ) => {
+      const found = await gitHubService.findGitHubConnection(payload.repoRoot)
+      if (found.isErr() || !found.value) {
+        throw new Error('No GitHub connection found for this repository')
+      }
+      const { token, repo } = found.value
+
+      await GitRepository.push(payload.repoRoot).unwrapOr({ branch: '', remote: '' })
+
+      const repoInfo = await gitHubService.getRepoInfo(repo.apiUrl, token, repo.owner, repo.repo)
+      const repoInfoValue = unwrapOrThrow(repoInfo, gitHubErrorMessage)
+
+      const branch = await GitRepository.getBranch(payload.repoRoot).unwrapOr(null)
+      if (!branch) throw new Error('Could not determine current branch')
+
+      const result = await gitHubService.createPR(repo.apiUrl, token, {
+        repositoryId: repoInfoValue.id,
+        headRefName: branch,
+        baseRefName: payload.baseRefName || repoInfoValue.defaultBranch,
+        title: payload.title,
+        body: payload.body,
+        draft: payload.draft,
+      })
+      return unwrapOrThrow(result, gitHubErrorMessage)
+    },
+  )
+
+  ipcMain.handle('github:getRepoIdentifier', async (_event, payload: { repoRoot: string }) => {
+    const result = await gitHubService.getRepoIdentifier(payload.repoRoot)
+    return result.unwrapOr(null)
   })
 }

--- a/src/main/taskTracker/TaskTrackerManager.ts
+++ b/src/main/taskTracker/TaskTrackerManager.ts
@@ -4,11 +4,13 @@ import os from 'os'
 import { randomUUID } from 'crypto'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
-import { ok, err, errAsync, type Result, type ResultAsync } from 'neverthrow'
+import { ok, err, okAsync, errAsync, type Result, type ResultAsync } from 'neverthrow'
 import type { PreferencesStore } from '../db/PreferencesStore'
 import type { TaskTrackerError } from './errors'
 import { fromExternalCall, errorMessage } from '../errors'
 import { createProviderClient } from './providers'
+import { GitRepository } from '../git/GitRepository'
+import { parseGitHubRemote } from '../github/remoteUrl'
 import type {
   TaskTrackerConnection,
   TrackerAttachment,
@@ -48,6 +50,47 @@ export class TaskTrackerManager {
     const token = this.preferencesStore.get(connection.authPrefKey)
     if (!token) return err({ _tag: 'AuthTokenMissing', connectionName: connection.name })
     return ok(token)
+  }
+
+  private resolveGitHubConnection(
+    conn: TaskTrackerConnection,
+    repoRoot?: string,
+  ): ResultAsync<TaskTrackerConnection, TaskTrackerError> {
+    if (conn.provider !== 'github' || conn.projectKey) return okAsync(conn)
+    if (!repoRoot) {
+      return errAsync({
+        _tag: 'ProviderApiError',
+        status: 0,
+        message: 'Repository not configured and no workspace to auto-detect from',
+        provider: 'github',
+      })
+    }
+    return GitRepository.getRemoteUrl(repoRoot)
+      .mapErr(
+        (): TaskTrackerError => ({
+          _tag: 'ProviderApiError',
+          status: 0,
+          message: 'Could not read git remote URL from workspace',
+          provider: 'github',
+        }),
+      )
+      .andThen((url) => {
+        const parsed = parseGitHubRemote(url)
+        if (parsed.isErr()) {
+          return errAsync<TaskTrackerConnection, TaskTrackerError>({
+            _tag: 'ProviderApiError',
+            status: 0,
+            message: 'Workspace remote is not a GitHub repository',
+            provider: 'github',
+          })
+        }
+        const { owner, repo, host } = parsed.value
+        return okAsync({
+          ...conn,
+          projectKey: `${owner}/${repo}`,
+          baseUrl: conn.baseUrl || `https://${host}`,
+        })
+      })
   }
 
   addConnection(
@@ -157,61 +200,78 @@ export class TaskTrackerManager {
       })
   }
 
-  fetchBoards(connectionId: string): ResultAsync<TrackerBoard[], TaskTrackerError> {
+  fetchBoards(
+    connectionId: string,
+    repoRoot?: string,
+  ): ResultAsync<TrackerBoard[], TaskTrackerError> {
     return this.getConnection(connectionId)
       .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
-      .asyncAndThen(({ conn, token }) => {
-        const client = createProviderClient(conn.provider)
-        return client.fetchBoards(conn, token)
-      })
+      .asyncAndThen(({ conn, token }) =>
+        this.resolveGitHubConnection(conn, repoRoot).andThen((resolved) => {
+          const client = createProviderClient(resolved.provider)
+          return client.fetchBoards(resolved, token)
+        }),
+      )
   }
 
   fetchStatuses(
     connectionId: string,
     boardId?: string,
+    repoRoot?: string,
   ): ResultAsync<TrackerStatus[], TaskTrackerError> {
     return this.getConnection(connectionId)
       .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
-      .asyncAndThen(({ conn, token }) => {
-        const client = createProviderClient(conn.provider)
-        return client.fetchStatuses(conn, token, boardId)
-      })
+      .asyncAndThen(({ conn, token }) =>
+        this.resolveGitHubConnection(conn, repoRoot).andThen((resolved) => {
+          const client = createProviderClient(resolved.provider)
+          return client.fetchStatuses(resolved, token, boardId)
+        }),
+      )
   }
 
   fetchTasks(
     connectionId: string,
     params: { statuses?: string[]; assignedToMe?: boolean; boardId?: string },
+    repoRoot?: string,
   ): ResultAsync<TrackerTask[], TaskTrackerError> {
     return this.getConnection(connectionId)
       .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
-      .asyncAndThen(({ conn, token }) => {
-        const client = createProviderClient(conn.provider)
-        return client.fetchTasks(conn, token, params)
-      })
+      .asyncAndThen(({ conn, token }) =>
+        this.resolveGitHubConnection(conn, repoRoot).andThen((resolved) => {
+          const client = createProviderClient(resolved.provider)
+          return client.fetchTasks(resolved, token, params)
+        }),
+      )
   }
 
   getCurrentSprint(
     connectionId: string,
     boardId?: string,
+    repoRoot?: string,
   ): ResultAsync<TrackerSprint | null, TaskTrackerError> {
     return this.getConnection(connectionId)
       .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
-      .asyncAndThen(({ conn, token }) => {
-        const client = createProviderClient(conn.provider)
-        return client.getCurrentSprint(conn, token, boardId)
-      })
+      .asyncAndThen(({ conn, token }) =>
+        this.resolveGitHubConnection(conn, repoRoot).andThen((resolved) => {
+          const client = createProviderClient(resolved.provider)
+          return client.getCurrentSprint(resolved, token, boardId)
+        }),
+      )
   }
 
   fetchTaskComments(
     connectionId: string,
     taskKey: string,
+    repoRoot?: string,
   ): ResultAsync<TrackerComment[], TaskTrackerError> {
     return this.getConnection(connectionId)
       .andThen((conn) => this.getToken(conn).map((token) => ({ conn, token })))
-      .asyncAndThen(({ conn, token }) => {
-        const client = createProviderClient(conn.provider)
-        return client.fetchTaskComments(conn, token, taskKey)
-      })
+      .asyncAndThen(({ conn, token }) =>
+        this.resolveGitHubConnection(conn, repoRoot).andThen((resolved) => {
+          const client = createProviderClient(resolved.provider)
+          return client.fetchTaskComments(resolved, token, taskKey)
+        }),
+      )
   }
 
   fetchTaskAttachments(

--- a/src/main/taskTracker/providers/github.ts
+++ b/src/main/taskTracker/providers/github.ts
@@ -1,0 +1,335 @@
+import { okAsync, type ResultAsync } from 'neverthrow'
+import type { TaskTrackerError } from '../errors'
+import type {
+  TaskTrackerConnection,
+  TaskTrackerProviderClient,
+  TrackerAttachment,
+  TrackerBoard,
+  TrackerComment,
+  TrackerTask,
+  TrackerSprint,
+  TrackerStatus,
+} from '../types'
+import { graphqlFetch } from '../../github/graphql'
+
+function apiError(status: number, message: string): TaskTrackerError {
+  return { _tag: 'ProviderApiError', status, message, provider: 'github' }
+}
+
+function apiUrlForConnection(connection: TaskTrackerConnection): string {
+  const baseUrl = connection.baseUrl || 'https://github.com'
+  const host = new URL(baseUrl).hostname
+  if (host === 'github.com') return 'https://api.github.com/graphql'
+  return `https://${host}/api/graphql`
+}
+
+function ownerRepo(connection: TaskTrackerConnection): { owner: string; repo: string } {
+  const parts = connection.projectKey.split('/')
+  return { owner: parts[0], repo: parts[1] }
+}
+
+function mapGitHubError<T>(result: ResultAsync<T, unknown>): ResultAsync<T, TaskTrackerError> {
+  return result.mapErr((e) => {
+    if (e && typeof e === 'object' && '_tag' in e) {
+      const gh = e as {
+        _tag: string
+        status?: number
+        message?: string
+        errors?: Array<{ message: string }>
+      }
+      const msg =
+        gh.errors?.map((err) => err.message).join(', ') ?? gh.message ?? 'Unknown GitHub error'
+      return apiError(gh.status ?? 0, msg)
+    }
+    return apiError(0, String(e))
+  })
+}
+
+interface ViewerResponse {
+  viewer: { login: string; name: string | null }
+}
+
+interface IssuesResponse {
+  repository: {
+    issues: {
+      nodes: Array<{
+        number: number
+        title: string
+        body: string
+        state: string
+        url: string
+        labels: { nodes: Array<{ name: string; color: string }> }
+        assignees: { nodes: Array<{ login: string }> }
+        milestone: { title: string; number: number } | null
+        author: { login: string } | null
+      }>
+    }
+    labels: { nodes: Array<{ name: string; color: string }> }
+    milestones: { nodes: Array<{ title: string; number: number; state: string }> }
+  }
+}
+
+interface CommentsResponse {
+  repository: {
+    issue: {
+      comments: {
+        nodes: Array<{
+          id: string
+          body: string
+          author: { login: string } | null
+          createdAt: string
+        }>
+      }
+    }
+  }
+}
+
+function mapTaskType(labels: Array<{ name: string }>): string {
+  for (const label of labels) {
+    const lower = label.name.toLowerCase()
+    if (lower.startsWith('type:') || lower.startsWith('kind:')) {
+      const type = lower.split(':')[1].trim()
+      if (type === 'bug' || type === 'fix') return 'bug'
+      if (type === 'feature' || type === 'enhancement') return 'story'
+      if (type === 'epic') return 'epic'
+      return type
+    }
+    if (lower === 'bug') return 'bug'
+    if (lower === 'enhancement' || lower === 'feature') return 'story'
+    if (lower === 'epic') return 'epic'
+  }
+  return 'task'
+}
+
+function mapPriority(labels: Array<{ name: string }>): string {
+  for (const label of labels) {
+    const lower = label.name.toLowerCase()
+    if (lower.startsWith('priority:') || lower.startsWith('p:')) {
+      return lower.split(':')[1].trim()
+    }
+    if (lower === 'critical' || lower === 'urgent') return 'critical'
+    if (lower === 'high') return 'high'
+    if (lower === 'low') return 'low'
+  }
+  return 'medium'
+}
+
+const ISSUES_QUERY = `
+query($owner: String!, $name: String!, $first: Int!, $states: [IssueState!], $filterBy: IssueFilters) {
+  repository(owner: $owner, name: $name) {
+    issues(first: $first, states: $states, filterBy: $filterBy, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number, title, body, state, url
+        labels(first: 10) { nodes { name, color } }
+        assignees(first: 3) { nodes { login } }
+        milestone { title, number }
+        author { login }
+      }
+    }
+    labels(first: 50) { nodes { name, color } }
+    milestones(first: 20, states: OPEN) { nodes { title, number, state } }
+  }
+}
+`
+
+const COMMENTS_QUERY = `
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      comments(first: 50, orderBy: {field: UPDATED_AT, direction: DESC}) {
+        nodes {
+          id, body
+          author { login }
+          createdAt
+        }
+      }
+    }
+  }
+}
+`
+
+export const githubClient: TaskTrackerProviderClient = {
+  testConnection(connection, token) {
+    const apiUrl = apiUrlForConnection(connection)
+    return mapGitHubError(graphqlFetch<ViewerResponse>(apiUrl, token, '{ viewer { login } }')).map(
+      () => true,
+    )
+  },
+
+  getCurrentUserDisplayName(connection, token) {
+    const apiUrl = apiUrlForConnection(connection)
+    return mapGitHubError(
+      graphqlFetch<ViewerResponse>(apiUrl, token, '{ viewer { login, name } }'),
+    ).map((data) => data.viewer.name ?? data.viewer.login)
+  },
+
+  fetchTaskByKey(connection, token, taskKey) {
+    const apiUrl = apiUrlForConnection(connection)
+    const { owner, repo } = ownerRepo(connection)
+    const issueNumber = parseInt(taskKey.replace(/^#/, ''), 10)
+    if (isNaN(issueNumber)) return okAsync(null)
+
+    const query = `
+      query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          issue(number: $number) {
+            number, title, body, state, url
+            labels(first: 10) { nodes { name, color } }
+            assignees(first: 3) { nodes { login } }
+            milestone { title, number }
+            author { login }
+          }
+        }
+      }
+    `
+
+    return mapGitHubError(
+      graphqlFetch<{
+        repository: {
+          issue: {
+            number: number
+            title: string
+            body: string
+            state: string
+            url: string
+            labels: { nodes: Array<{ name: string; color: string }> }
+            assignees: { nodes: Array<{ login: string }> }
+            milestone: { title: string; number: number } | null
+            author: { login: string } | null
+          }
+        }
+      }>(apiUrl, token, query, { owner, name: repo, number: issueNumber }),
+    ).map((data) => {
+      const issue = data.repository.issue
+      return {
+        key: `#${issue.number}`,
+        summary: issue.title,
+        description: issue.body ?? '',
+        status: issue.state.toLowerCase(),
+        priority: mapPriority(issue.labels.nodes),
+        type: mapTaskType(issue.labels.nodes),
+        assignee: issue.assignees.nodes[0]?.login,
+        sprintName: issue.milestone?.title,
+        sprintNumber: issue.milestone?.number,
+        url: issue.url,
+      } as TrackerTask | null
+    })
+  },
+
+  fetchBoards(connection) {
+    const { owner, repo } = ownerRepo(connection)
+    return okAsync([{ id: 'repo', name: `${owner}/${repo}` }] satisfies TrackerBoard[])
+  },
+
+  fetchStatuses() {
+    return okAsync([
+      { id: 'OPEN', name: 'Open' },
+      { id: 'CLOSED', name: 'Closed' },
+    ] satisfies TrackerStatus[])
+  },
+
+  fetchTasks(connection, token, params) {
+    const apiUrl = apiUrlForConnection(connection)
+    const { owner, repo } = ownerRepo(connection)
+
+    const states: string[] = []
+    if (params.statuses?.length) {
+      for (const s of params.statuses) {
+        if (s.toUpperCase() === 'OPEN' || s.toUpperCase() === 'CLOSED') {
+          states.push(s.toUpperCase())
+        }
+      }
+    }
+    if (states.length === 0) states.push('OPEN')
+
+    const filterBy: Record<string, unknown> = {}
+    if (params.assignedToMe) {
+      filterBy.assignee = '*'
+    }
+
+    return mapGitHubError(
+      graphqlFetch<IssuesResponse>(apiUrl, token, ISSUES_QUERY, {
+        owner,
+        name: repo,
+        first: 100,
+        states,
+        filterBy: Object.keys(filterBy).length > 0 ? filterBy : undefined,
+      }),
+    ).map((data) =>
+      data.repository.issues.nodes.map(
+        (issue): TrackerTask => ({
+          key: `#${issue.number}`,
+          summary: issue.title,
+          description: issue.body ?? '',
+          status: issue.state.toLowerCase(),
+          priority: mapPriority(issue.labels.nodes),
+          type: mapTaskType(issue.labels.nodes),
+          assignee: issue.assignees.nodes[0]?.login,
+          sprintName: issue.milestone?.title,
+          sprintNumber: issue.milestone?.number,
+          url: issue.url,
+        }),
+      ),
+    )
+  },
+
+  getCurrentSprint(connection, token) {
+    const apiUrl = apiUrlForConnection(connection)
+    const { owner, repo } = ownerRepo(connection)
+
+    const query = `
+      query($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          milestones(first: 1, states: OPEN, orderBy: {field: DUE_DATE, direction: ASC}) {
+            nodes { title, number, state }
+          }
+        }
+      }
+    `
+
+    return mapGitHubError(
+      graphqlFetch<{
+        repository: {
+          milestones: { nodes: Array<{ title: string; number: number; state: string }> }
+        }
+      }>(apiUrl, token, query, { owner, name: repo }),
+    ).map((data) => {
+      const ms = data.repository.milestones.nodes[0]
+      if (!ms) return null
+      return {
+        id: String(ms.number),
+        name: ms.title,
+        number: ms.number,
+        state: 'active' as const,
+      } satisfies TrackerSprint
+    })
+  },
+
+  fetchTaskComments(connection, token, taskKey) {
+    const apiUrl = apiUrlForConnection(connection)
+    const { owner, repo } = ownerRepo(connection)
+    const issueNumber = parseInt(taskKey.replace(/^#/, ''), 10)
+    if (isNaN(issueNumber)) return okAsync([])
+
+    return mapGitHubError(
+      graphqlFetch<CommentsResponse>(apiUrl, token, COMMENTS_QUERY, {
+        owner,
+        name: repo,
+        number: issueNumber,
+      }),
+    ).map((data) =>
+      data.repository.issue.comments.nodes.map(
+        (c): TrackerComment => ({
+          id: c.id,
+          author: c.author?.login ?? '',
+          body: c.body,
+          created: c.createdAt,
+        }),
+      ),
+    )
+  },
+
+  fetchTaskAttachments() {
+    return okAsync([] satisfies TrackerAttachment[])
+  },
+}

--- a/src/main/taskTracker/providers/index.ts
+++ b/src/main/taskTracker/providers/index.ts
@@ -1,10 +1,12 @@
 import type { TaskTrackerProvider, TaskTrackerProviderClient } from '../types'
 import { jiraClient } from './jira'
 import { youtrackClient } from './youtrack'
+import { githubClient } from './github'
 
 const clients: Record<TaskTrackerProvider, TaskTrackerProviderClient> = {
   jira: jiraClient,
   youtrack: youtrackClient,
+  github: githubClient,
 }
 
 export function createProviderClient(provider: TaskTrackerProvider): TaskTrackerProviderClient {

--- a/src/main/taskTracker/types.ts
+++ b/src/main/taskTracker/types.ts
@@ -1,7 +1,7 @@
 import type { ResultAsync } from 'neverthrow'
 import type { TaskTrackerError } from './errors'
 
-export type TaskTrackerProvider = 'jira' | 'youtrack'
+export type TaskTrackerProvider = 'jira' | 'youtrack' | 'github'
 
 export interface TaskTrackerConnection {
   id: string

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -472,7 +472,7 @@ interface CanopyAPI {
     username?: string
     token: string
   }) => Promise<boolean>
-  taskTrackerFetchBoards: (connectionId: string) => Promise<TrackerBoard[]>
+  taskTrackerFetchBoards: (connectionId: string, repoRoot?: string) => Promise<TrackerBoard[]>
   taskTrackerFetchBoardsForNew: (connection: {
     provider: TaskTrackerProvider
     name: string
@@ -481,19 +481,30 @@ interface CanopyAPI {
     username?: string
     token: string
   }) => Promise<TrackerBoard[]>
-  taskTrackerFetchStatuses: (connectionId: string, boardId?: string) => Promise<TrackerStatus[]>
+  taskTrackerFetchStatuses: (
+    connectionId: string,
+    boardId?: string,
+    repoRoot?: string,
+  ) => Promise<TrackerStatus[]>
   taskTrackerFetchTasks: (
     connectionId: string,
-    params: { statuses?: string[]; assignedToMe?: boolean; boardId?: string },
+    params: {
+      statuses?: string[]
+      assignedToMe?: boolean
+      boardId?: string
+      repoRoot?: string
+    },
   ) => Promise<TrackerTask[]>
   taskTrackerGetCurrentSprint: (
     connectionId: string,
     boardId?: string,
+    repoRoot?: string,
   ) => Promise<TrackerSprint | null>
   taskTrackerGetCurrentUser: (connectionId: string) => Promise<string>
   taskTrackerFetchTaskComments: (
     connectionId: string,
     taskKey: string,
+    repoRoot?: string,
   ) => Promise<Array<{ id: string; author: string; body: string; created: string }>>
   taskTrackerFetchTaskAttachments: (
     connectionId: string,
@@ -542,11 +553,22 @@ interface CanopyAPI {
     boardId?: string,
   ) => Promise<{ url: string; title: string; targetBranch: string }>
 
+  // GitHub PR features
+  githubFetchBranchPRs: (repoRoot: string) => Promise<GitHubBranchPRMap>
+  githubGetRepoInfo: (repoRoot: string) => Promise<GitHubRepoInfo | null>
+  githubCreatePR: (
+    repoRoot: string,
+    params: { title: string; body: string; baseRefName: string; draft: boolean },
+  ) => Promise<GitHubPRInfo>
+  githubGetRepoIdentifier: (
+    repoRoot: string,
+  ) => Promise<{ owner: string; repo: string; host: string; apiUrl: string } | null>
+
   // File utilities
   getPathForFile: (file: File) => string
 }
 
-type TaskTrackerProvider = 'jira' | 'youtrack'
+type TaskTrackerProvider = 'jira' | 'youtrack' | 'github'
 
 interface TaskTrackerConnectionInfo {
   id: string
@@ -615,6 +637,25 @@ interface NotchOverlayState {
   notchWidth: number
   notchHeight: number
   peekSessionIds?: string[]
+}
+
+interface GitHubPRInfo {
+  number: number
+  title: string
+  state: string
+  url: string
+  headRefName: string
+  baseRefName: string
+  isDraft: boolean
+  reviewDecision: string | null
+  checksState: string | null
+}
+
+type GitHubBranchPRMap = Record<string, GitHubPRInfo>
+
+interface GitHubRepoInfo {
+  id: string
+  defaultBranch: string
 }
 
 interface NotchAPI {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -538,8 +538,8 @@ const api = {
     username?: string
     token: string
   }) => ipcRenderer.invoke('taskTracker:testNewConnection', connection),
-  taskTrackerFetchBoards: (connectionId: string) =>
-    ipcRenderer.invoke('taskTracker:fetchBoards', { connectionId }),
+  taskTrackerFetchBoards: (connectionId: string, repoRoot?: string) =>
+    ipcRenderer.invoke('taskTracker:fetchBoards', { connectionId, repoRoot }),
   taskTrackerFetchBoardsForNew: (connection: {
     provider: string
     name: string
@@ -548,18 +548,18 @@ const api = {
     username?: string
     token: string
   }) => ipcRenderer.invoke('taskTracker:fetchBoardsForNew', connection),
-  taskTrackerFetchStatuses: (connectionId: string, boardId?: string) =>
-    ipcRenderer.invoke('taskTracker:fetchStatuses', { connectionId, boardId }),
+  taskTrackerFetchStatuses: (connectionId: string, boardId?: string, repoRoot?: string) =>
+    ipcRenderer.invoke('taskTracker:fetchStatuses', { connectionId, boardId, repoRoot }),
   taskTrackerFetchTasks: (
     connectionId: string,
-    params: { statuses?: string[]; assignedToMe?: boolean; boardId?: string },
+    params: { statuses?: string[]; assignedToMe?: boolean; boardId?: string; repoRoot?: string },
   ) => ipcRenderer.invoke('taskTracker:fetchTasks', { connectionId, ...params }),
-  taskTrackerGetCurrentSprint: (connectionId: string, boardId?: string) =>
-    ipcRenderer.invoke('taskTracker:getCurrentSprint', { connectionId, boardId }),
+  taskTrackerGetCurrentSprint: (connectionId: string, boardId?: string, repoRoot?: string) =>
+    ipcRenderer.invoke('taskTracker:getCurrentSprint', { connectionId, boardId, repoRoot }),
   taskTrackerGetCurrentUser: (connectionId: string) =>
     ipcRenderer.invoke('taskTracker:getCurrentUser', { connectionId }) as Promise<string>,
-  taskTrackerFetchTaskComments: (connectionId: string, taskKey: string) =>
-    ipcRenderer.invoke('taskTracker:fetchTaskComments', { connectionId, taskKey }),
+  taskTrackerFetchTaskComments: (connectionId: string, taskKey: string, repoRoot?: string) =>
+    ipcRenderer.invoke('taskTracker:fetchTaskComments', { connectionId, taskKey, repoRoot }),
   taskTrackerFetchTaskAttachments: (connectionId: string, taskKey: string) =>
     ipcRenderer.invoke('taskTracker:fetchTaskAttachments', { connectionId, taskKey }),
   taskTrackerDownloadAttachment: (connectionId: string, url: string, filename: string) =>
@@ -620,6 +620,17 @@ const api = {
       connectionId,
       boardId,
     }),
+
+  // GitHub PR features
+  githubFetchBranchPRs: (repoRoot: string) =>
+    ipcRenderer.invoke('github:fetchBranchPRs', { repoRoot }),
+  githubGetRepoInfo: (repoRoot: string) => ipcRenderer.invoke('github:getRepoInfo', { repoRoot }),
+  githubCreatePR: (
+    repoRoot: string,
+    params: { title: string; body: string; baseRefName: string; draft: boolean },
+  ) => ipcRenderer.invoke('github:createPR', { repoRoot, ...params }),
+  githubGetRepoIdentifier: (repoRoot: string) =>
+    ipcRenderer.invoke('github:getRepoIdentifier', { repoRoot }),
 
   // File utilities
   getPathForFile: (file: File) => webUtils.getPathForFile(file),

--- a/src/renderer/src/components/github/CreatePRModal.svelte
+++ b/src/renderer/src/components/github/CreatePRModal.svelte
@@ -60,8 +60,15 @@
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<div class="overlay" role="dialog" onkeydown={handleKeydown}>
-  <div class="modal">
+<div
+  class="overlay"
+  role="dialog"
+  aria-modal="true"
+  onkeydown={handleKeydown}
+  onclick={closeDialog}
+>
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div class="modal" role="none" onclick={(e) => e.stopPropagation()}>
     <h2 class="modal-title">Create pull request</h2>
 
     <div class="form-row">

--- a/src/renderer/src/components/github/CreatePRModal.svelte
+++ b/src/renderer/src/components/github/CreatePRModal.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { workspaceState } from '../../lib/stores/workspace.svelte'
+  import { closeDialog } from '../../lib/stores/dialogs.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
+  import { loadBranchPRs } from '../../lib/stores/github.svelte'
+
+  let title = $state('')
+  let body = $state('')
+  let baseRefName = $state('')
+  let draft = $state(false)
+  let defaultBranch = $state('main')
+  let submitting = $state(false)
+  let titleEl: HTMLInputElement | undefined = $state()
+
+  onMount(async () => {
+    titleEl?.focus()
+    const repoRoot = workspaceState.repoRoot
+    if (!repoRoot) return
+
+    const info = await window.api.githubGetRepoInfo(repoRoot)
+    if (info) {
+      defaultBranch = info.defaultBranch
+      baseRefName = info.defaultBranch
+    }
+
+    const branch = workspaceState.branch
+    if (branch) {
+      title = branch.replace(/^(feat|fix|chore|refactor|docs|test)\//, '').replace(/[-_]/g, ' ')
+    }
+  })
+
+  async function submit(): Promise<void> {
+    const repoRoot = workspaceState.repoRoot
+    if (!repoRoot || !title.trim()) return
+
+    submitting = true
+    try {
+      const pr = await window.api.githubCreatePR(repoRoot, {
+        title: title.trim(),
+        body,
+        baseRefName: baseRefName || defaultBranch,
+        draft,
+      })
+      addToast(`PR #${pr.number} created`)
+      window.api.openExternal(pr.url)
+      closeDialog()
+      loadBranchPRs(repoRoot)
+    } catch (e) {
+      addToast(e instanceof Error ? e.message : 'Failed to create PR')
+    } finally {
+      submitting = false
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') closeDialog()
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) submit()
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div class="overlay" role="dialog" onkeydown={handleKeydown}>
+  <div class="modal">
+    <h2 class="modal-title">Create pull request</h2>
+
+    <div class="form-row">
+      <label class="form-label">Title</label>
+      <input class="form-input" bind:value={title} bind:this={titleEl} placeholder="PR title" />
+    </div>
+
+    <div class="form-row">
+      <label class="form-label">Base branch</label>
+      <input class="form-input" bind:value={baseRefName} placeholder={defaultBranch} />
+    </div>
+
+    <div class="form-row body-row">
+      <label class="form-label">Description</label>
+      <textarea
+        class="form-input form-textarea"
+        bind:value={body}
+        placeholder="Optional description"
+        rows="5"
+      ></textarea>
+    </div>
+
+    <div class="form-row checkbox-row">
+      <label class="checkbox-label">
+        <input type="checkbox" bind:checked={draft} />
+        Create as draft
+      </label>
+    </div>
+
+    <div class="form-actions">
+      <button class="btn btn-secondary" onclick={closeDialog}>Cancel</button>
+      <button class="btn btn-primary" onclick={submit} disabled={submitting || !title.trim()}>
+        {#if submitting}Creating...{:else}Create PR{/if}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 100;
+  }
+
+  .modal {
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: 12px;
+    padding: 20px;
+    width: 480px;
+    max-width: 90vw;
+  }
+
+  .modal-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--c-text);
+    margin: 0 0 16px;
+  }
+
+  .form-row {
+    margin-bottom: 10px;
+  }
+
+  .form-label {
+    display: block;
+    font-size: 12px;
+    color: var(--c-text-secondary);
+    margin-bottom: 4px;
+  }
+
+  .form-input {
+    width: 100%;
+    padding: 6px 8px;
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+    background: var(--c-bg-input);
+    color: var(--c-text);
+    font-size: 13px;
+    font-family: inherit;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .form-input:focus {
+    border-color: var(--c-focus-ring);
+  }
+
+  .form-textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--c-text-secondary);
+    cursor: pointer;
+  }
+
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 16px;
+  }
+
+  .btn {
+    padding: 6px 14px;
+    border: none;
+    border-radius: 6px;
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .btn-primary {
+    background: var(--c-accent-bg);
+    color: var(--c-accent-text);
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: var(--c-accent-bg-hover);
+  }
+
+  .btn-secondary {
+    background: var(--c-active);
+    color: var(--c-text-secondary);
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    background: var(--c-hover-strong);
+  }
+</style>

--- a/src/renderer/src/components/github/CreatePRModal.svelte
+++ b/src/renderer/src/components/github/CreatePRModal.svelte
@@ -18,10 +18,14 @@
     const repoRoot = workspaceState.repoRoot
     if (!repoRoot) return
 
-    const info = await window.api.githubGetRepoInfo(repoRoot)
-    if (info) {
-      defaultBranch = info.defaultBranch
-      baseRefName = info.defaultBranch
+    try {
+      const info = await window.api.githubGetRepoInfo(repoRoot)
+      if (info) {
+        defaultBranch = info.defaultBranch
+        baseRefName = info.defaultBranch
+      }
+    } catch {
+      // Keep defaults on network/auth error
     }
 
     const branch = workspaceState.branch

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -15,6 +15,7 @@
   import OnboardingWizard from '../onboarding/OnboardingWizard.svelte'
   import FeatureOnboarding from '../onboarding/FeatureOnboarding.svelte'
   import TmuxSessionBrowser from '../terminal/TmuxSessionBrowser.svelte'
+  import CreatePRModal from '../github/CreatePRModal.svelte'
   import WelcomeDashboard from '../dashboard/WelcomeDashboard.svelte'
   import Toast from '../shared/Toast.svelte'
   import { getPref, setPref } from '../../lib/stores/preferences.svelte'
@@ -450,6 +451,8 @@
   <FeatureOnboarding fromVersion={dialogState.current.fromVersion} />
 {:else if dialogState.current.type === 'tmuxBrowser'}
   <TmuxSessionBrowser />
+{:else if dialogState.current.type === 'createGitHubPR'}
+  <CreatePRModal />
 {/if}
 
 <Toast />

--- a/src/renderer/src/components/preferences/TaskConnectionsPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskConnectionsPrefs.svelte
@@ -8,7 +8,8 @@
   let connections = $derived(getTaskTrackerConnections())
   let showAddForm = $state(false)
   let editingConnectionId = $state<string | null>(null)
-  let newProvider = $state<'jira' | 'youtrack'>('jira')
+  let newProvider = $state<'jira' | 'youtrack' | 'github'>('jira')
+  let newProjectKey = $state('')
   let newName = $state('')
   let newBaseUrl = $state('')
   let newUsername = $state('')
@@ -20,11 +21,15 @@
     testing = true
     testResult = ''
     try {
+      const baseUrl =
+        newProvider === 'github' && !newBaseUrl
+          ? 'https://github.com'
+          : newBaseUrl.replace(/\/$/, '')
       await window.api.taskTrackerTestNewConnection({
         provider: newProvider,
         name: newName,
-        baseUrl: newBaseUrl.replace(/\/$/, ''),
-        projectKey: '',
+        baseUrl,
+        projectKey: newProvider === 'github' ? newProjectKey : '',
         username: newUsername || undefined,
         token: newToken,
       })
@@ -38,11 +43,15 @@
 
   async function addConnection(): Promise<void> {
     try {
+      const baseUrl =
+        newProvider === 'github' && !newBaseUrl
+          ? 'https://github.com'
+          : newBaseUrl.replace(/\/$/, '')
       await window.api.taskTrackerAddConnection({
         provider: newProvider,
         name: newName,
-        baseUrl: newBaseUrl.replace(/\/$/, ''),
-        projectKey: '',
+        baseUrl,
+        projectKey: newProvider === 'github' ? newProjectKey : '',
         username: newUsername || undefined,
         token: newToken,
       })
@@ -72,13 +81,15 @@
     provider: string
     name: string
     baseUrl: string
+    projectKey?: string
     username?: string
   }): void {
     editingConnectionId = conn.id
     showAddForm = true
-    newProvider = conn.provider as 'jira' | 'youtrack'
+    newProvider = conn.provider as 'jira' | 'youtrack' | 'github'
     newName = conn.name
     newBaseUrl = conn.baseUrl
+    newProjectKey = conn.projectKey ?? ''
     newUsername = conn.username ?? ''
     newToken = ''
     testResult = ''
@@ -90,6 +101,7 @@
       await window.api.taskTrackerUpdateConnection(editingConnectionId, {
         name: newName,
         baseUrl: newBaseUrl.replace(/\/$/, ''),
+        projectKey: newProvider === 'github' ? newProjectKey : undefined,
         username: newUsername || undefined,
         token: newToken || undefined,
       })
@@ -107,6 +119,7 @@
     newProvider = 'jira'
     newName = ''
     newBaseUrl = ''
+    newProjectKey = ''
     newUsername = ''
     newToken = ''
     testResult = ''
@@ -119,7 +132,13 @@
 
   {#each connections as conn (conn.id)}
     <div class="conn-row">
-      <span class="conn-provider">{conn.provider === 'jira' ? 'Jira' : 'YouTrack'}</span>
+      <span class="conn-provider"
+        >{conn.provider === 'jira'
+          ? 'Jira'
+          : conn.provider === 'github'
+            ? 'GitHub'
+            : 'YouTrack'}</span
+      >
       <span class="conn-name">{conn.name}</span>
       <span class="conn-url" title={conn.baseUrl}>{conn.baseUrl}</span>
       <button class="icon-btn" onclick={() => editConnection(conn)} title="Edit">
@@ -140,23 +159,48 @@
           options={[
             { value: 'jira', label: 'Jira' },
             { value: 'youtrack', label: 'YouTrack' },
+            { value: 'github', label: 'GitHub' },
           ]}
-          onchange={(v) => (newProvider = v as 'jira' | 'youtrack')}
+          onchange={(v) => (newProvider = v as 'jira' | 'youtrack' | 'github')}
           maxWidth="none"
         />
       </div>
       <div class="form-row">
         <label class="form-label">Name</label>
-        <input class="form-input" bind:value={newName} placeholder="My Jira" />
-      </div>
-      <div class="form-row">
-        <label class="form-label">Base URL</label>
         <input
           class="form-input"
-          bind:value={newBaseUrl}
-          placeholder="https://company.atlassian.net"
+          bind:value={newName}
+          placeholder={newProvider === 'github' ? 'My GitHub' : 'My Jira'}
         />
       </div>
+      {#if newProvider !== 'github'}
+        <div class="form-row">
+          <label class="form-label">Base URL</label>
+          <input
+            class="form-input"
+            bind:value={newBaseUrl}
+            placeholder="https://company.atlassian.net"
+          />
+        </div>
+      {/if}
+      {#if newProvider === 'github'}
+        <div class="form-row">
+          <label class="form-label">Host URL</label>
+          <input
+            class="form-input"
+            bind:value={newBaseUrl}
+            placeholder="https://github.com (default)"
+          />
+        </div>
+        <div class="form-row">
+          <label class="form-label">Repository</label>
+          <input
+            class="form-input"
+            bind:value={newProjectKey}
+            placeholder="Auto-detected from workspace"
+          />
+        </div>
+      {/if}
       {#if newProvider === 'jira'}
         <div class="form-row">
           <label class="form-label">Email</label>
@@ -164,7 +208,7 @@
         </div>
       {/if}
       <div class="form-row">
-        <label class="form-label">API Token</label>
+        <label class="form-label">{newProvider === 'github' ? 'Access Token' : 'API Token'}</label>
         <input class="form-input" type="password" bind:value={newToken} placeholder="Enter token" />
       </div>
       <div class="test-result" aria-live="polite">
@@ -179,14 +223,16 @@
         <button
           class="btn btn-secondary"
           onclick={testNewConnection}
-          disabled={testing || !newBaseUrl || !newToken}
+          disabled={testing || (newProvider !== 'github' && !newBaseUrl) || !newToken}
         >
           {#if testing}Testing...{:else}Test{/if}
         </button>
         <button
           class="btn btn-primary"
           onclick={editingConnectionId ? saveEditedConnection : addConnection}
-          disabled={!newName || !newBaseUrl || (!editingConnectionId && !newToken)}
+          disabled={!newName ||
+            (newProvider !== 'github' && !newBaseUrl) ||
+            (!editingConnectionId && !newToken)}
         >
           {editingConnectionId ? 'Save' : 'Add'}
         </button>

--- a/src/renderer/src/components/preferences/TaskTrackerPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskTrackerPrefs.svelte
@@ -5,6 +5,7 @@
   import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import { loadConnections, getTaskTrackerConnections } from '../../lib/stores/taskTracker.svelte'
   import { addToast } from '../../lib/stores/toast.svelte'
+  import { workspaceState } from '../../lib/stores/workspace.svelte'
   import TaskConnectionsPrefs from './TaskConnectionsPrefs.svelte'
   import TaskBranchNamingPrefs from './TaskBranchNamingPrefs.svelte'
   import TaskPRNamingPrefs from './TaskPRNamingPrefs.svelte'
@@ -18,7 +19,10 @@
   async function loadBoardsForConnection(connId: string): Promise<void> {
     if (scopeBoards[connId]) return
     try {
-      const boards = await window.api.taskTrackerFetchBoards(connId)
+      const boards = await window.api.taskTrackerFetchBoards(
+        connId,
+        workspaceState.repoRoot ?? undefined,
+      )
       scopeBoards = { ...scopeBoards, [connId]: boards }
     } catch {
       scopeBoards = { ...scopeBoards, [connId]: [] }
@@ -97,7 +101,11 @@
     if (connections.length === 0) return
     loadingStatuses = true
     try {
-      const statuses = await window.api.taskTrackerFetchStatuses(connections[0].id)
+      const statuses = await window.api.taskTrackerFetchStatuses(
+        connections[0].id,
+        undefined,
+        workspaceState.repoRoot ?? undefined,
+      )
       availableStatuses = statuses.map((s) => s.name)
     } catch {
       addToast('Failed to fetch statuses')

--- a/src/renderer/src/components/sidebar/GitSection.svelte
+++ b/src/renderer/src/components/sidebar/GitSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { workspaceState } from '../../lib/stores/workspace.svelte'
-  import { confirm, prompt } from '../../lib/stores/dialogs.svelte'
+  import { confirm, prompt, showCreateGitHubPR } from '../../lib/stores/dialogs.svelte'
   import { addToast } from '../../lib/stores/toast.svelte'
   import CollapsibleSection from './CollapsibleSection.svelte'
 
@@ -124,10 +124,25 @@
     const branch = workspaceState.branch
     if (!branch) return
 
+    // Check if there's a GitHub connection for this repo
+    const repoRoot = workspaceState.repoRoot
+    if (repoRoot) {
+      const repoId = await window.api.githubGetRepoIdentifier(repoRoot)
+      if (repoId) {
+        const info = await window.api.githubGetRepoInfo(repoRoot)
+        if (info) {
+          showCreateGitHubPR()
+          return
+        }
+        // GitHub repo detected but no connection configured
+        addToast('GitHub repo detected. Add a GitHub connection in Preferences to create PRs.')
+      }
+    }
+
+    // Fallback to task tracker PR creation (gh CLI)
     const taskKey = taskKeyFromBranch
     loading = 'pr'
 
-    // Resolve PR title and target using scoped config (board → connection → global)
     let prTitle = taskKey ? `[${taskKey}]` : branch
     let defaultTarget = 'develop'
     try {

--- a/src/renderer/src/components/sidebar/GitSection.svelte
+++ b/src/renderer/src/components/sidebar/GitSection.svelte
@@ -127,15 +127,18 @@
     // Check if there's a GitHub connection for this repo
     const repoRoot = workspaceState.repoRoot
     if (repoRoot) {
-      const repoId = await window.api.githubGetRepoIdentifier(repoRoot)
-      if (repoId) {
-        const info = await window.api.githubGetRepoInfo(repoRoot)
-        if (info) {
-          showCreateGitHubPR()
-          return
+      try {
+        const repoId = await window.api.githubGetRepoIdentifier(repoRoot)
+        if (repoId) {
+          const info = await window.api.githubGetRepoInfo(repoRoot)
+          if (info) {
+            showCreateGitHubPR()
+            return
+          }
+          addToast('GitHub repo detected. Add a GitHub connection in Preferences to create PRs.')
         }
-        // GitHub repo detected but no connection configured
-        addToast('GitHub repo detected. Add a GitHub connection in Preferences to create PRs.')
+      } catch {
+        // GitHub detection failed (network/auth) — fall through to gh CLI
       }
     }
 

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -790,7 +790,7 @@
     border: none;
     cursor: pointer;
     flex-shrink: 0;
-    margin-left: auto;
+    margin-left: 4px;
     background: var(--c-accent-bg);
     color: var(--c-accent-text);
     font-family: inherit;

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -120,20 +120,16 @@
     getTaskTrackerConnections().filter((c) => c.provider === 'github').length,
   )
 
+  let prevGhConnCount = 0
   $effect(() => {
-    if (githubConnectionCount === 0) return
+    const connCount = githubConnectionCount
+    if (connCount === 0) return
     const deps = projects.map((p) => p.worktrees.length)
     void deps
+    const force = connCount !== prevGhConnCount
+    prevGhConnCount = connCount
     for (const p of projects) {
-      if (p.isGitRepo && p.repoRoot) loadBranchPRs(p.repoRoot)
-    }
-  })
-
-  // Force refresh when connections change
-  $effect(() => {
-    if (githubConnectionCount === 0) return
-    for (const p of projects) {
-      if (p.isGitRepo && p.repoRoot) loadBranchPRs(p.repoRoot, true)
+      if (p.isGitRepo && p.repoRoot) loadBranchPRs(p.repoRoot, force)
     }
   })
 
@@ -808,7 +804,7 @@
 
   .pr-badge.approved {
     background: var(--c-success-bg, var(--c-success));
-    color: var(--c-success-text, #fff);
+    color: var(--c-success-text, var(--c-text));
   }
 
   .pr-badge.changes-requested {

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -15,6 +15,8 @@
   import { allPanes } from '../../lib/stores/splitTree'
   import { worktreeBadges } from '../../lib/agents/agentState.svelte'
   import { getWorktreeAgentStatus } from '../../lib/agents/worktreeStatus.svelte'
+  import { getBranchPRMap, loadBranchPRs } from '../../lib/stores/github.svelte'
+  import { getTaskTrackerConnections } from '../../lib/stores/taskTracker.svelte'
 
   function worktreeLabel(wt: { branch: string; path: string }): string {
     if (wt.branch !== '(detached)') return wt.branch
@@ -110,6 +112,43 @@
 
   function getMerged(project: ProjectState): Set<string> {
     return mergedBranches[project.workspace.path] ?? new Set()
+  }
+
+  // GitHub PR badges
+  let prMap = $derived(getBranchPRMap())
+  let githubConnectionCount = $derived(
+    getTaskTrackerConnections().filter((c) => c.provider === 'github').length,
+  )
+
+  $effect(() => {
+    if (githubConnectionCount === 0) return
+    const deps = projects.map((p) => p.worktrees.length)
+    void deps
+    for (const p of projects) {
+      if (p.isGitRepo && p.repoRoot) loadBranchPRs(p.repoRoot)
+    }
+  })
+
+  // Force refresh when connections change
+  $effect(() => {
+    if (githubConnectionCount === 0) return
+    for (const p of projects) {
+      if (p.isGitRepo && p.repoRoot) loadBranchPRs(p.repoRoot, true)
+    }
+  })
+
+  function prBadgeClass(pr: (typeof prMap)[string]): string {
+    if (pr.isDraft) return 'pr-badge draft'
+    if (pr.reviewDecision === 'APPROVED') return 'pr-badge approved'
+    if (pr.reviewDecision === 'CHANGES_REQUESTED') return 'pr-badge changes-requested'
+    return 'pr-badge'
+  }
+
+  function prBadgeLabel(pr: (typeof prMap)[string]): string {
+    if (pr.isDraft) return 'Draft'
+    if (pr.reviewDecision === 'APPROVED') return 'Approved'
+    if (pr.reviewDecision === 'CHANGES_REQUESTED') return 'Changes'
+    return `PR #${pr.number}`
   }
 
   const removingPaths = new SvelteSet<string>()
@@ -427,6 +466,19 @@
                 {:else if merged.has(wt.branch)}
                   <span class="merged-badge" title="Merged">merged</span>
                 {/if}
+                {#if prMap[wt.branch]}
+                  {@const pr = prMap[wt.branch]}
+                  <button
+                    class={prBadgeClass(pr)}
+                    title={`${pr.title} — click to open`}
+                    onclick={(e) => {
+                      e.stopPropagation()
+                      window.api.openExternal(pr.url)
+                    }}
+                  >
+                    {prBadgeLabel(pr)}
+                  </button>
+                {/if}
                 {#if wtActive}
                   <!-- svelte-ignore a11y_click_events_have_key_events -->
                   <span
@@ -728,6 +780,40 @@
     color: var(--c-success);
     flex-shrink: 0;
     margin-left: auto;
+  }
+
+  .pr-badge {
+    font-size: 9px;
+    font-weight: 500;
+    padding: 0 4px;
+    border-radius: 3px;
+    border: none;
+    cursor: pointer;
+    flex-shrink: 0;
+    margin-left: auto;
+    background: var(--c-accent-bg);
+    color: var(--c-accent-text);
+    font-family: inherit;
+    line-height: 16px;
+  }
+
+  .pr-badge:hover {
+    opacity: 0.8;
+  }
+
+  .pr-badge.draft {
+    background: var(--c-hover-strong);
+    color: var(--c-text-muted);
+  }
+
+  .pr-badge.approved {
+    background: var(--c-success-bg, var(--c-success));
+    color: var(--c-success-text, #fff);
+  }
+
+  .pr-badge.changes-requested {
+    background: var(--c-warning-bg, var(--c-warning));
+    color: var(--c-warning-text);
   }
 
   .removing-label {

--- a/src/renderer/src/components/sidebar/WorktreeSection.svelte
+++ b/src/renderer/src/components/sidebar/WorktreeSection.svelte
@@ -5,6 +5,7 @@
   import { showCreateWorktree, confirm } from '../../lib/stores/dialogs.svelte'
   import { Trash2 } from '@lucide/svelte'
   import CollapsibleSection from './CollapsibleSection.svelte'
+  import { getBranchPRMap, loadBranchPRs } from '../../lib/stores/github.svelte'
 
   let mergedBranches = new SvelteSet<string>()
 
@@ -39,6 +40,29 @@
     if (workspaceState.worktrees.length >= 0) checkMergedStatus(ac.signal)
     return () => ac.abort()
   })
+
+  $effect(() => {
+    const repoRoot = workspaceState.repoRoot
+    // Read length to track worktree list changes
+    void workspaceState.worktrees.length
+    if (repoRoot) loadBranchPRs(repoRoot)
+  })
+
+  let prMap = $derived(getBranchPRMap())
+
+  function prBadgeClass(pr: (typeof prMap)[string]): string {
+    if (pr.isDraft) return 'pr-badge draft'
+    if (pr.reviewDecision === 'APPROVED') return 'pr-badge approved'
+    if (pr.reviewDecision === 'CHANGES_REQUESTED') return 'pr-badge changes-requested'
+    return 'pr-badge'
+  }
+
+  function prBadgeLabel(pr: (typeof prMap)[string]): string {
+    if (pr.isDraft) return 'Draft'
+    if (pr.reviewDecision === 'APPROVED') return 'Approved'
+    if (pr.reviewDecision === 'CHANGES_REQUESTED') return 'Changes'
+    return `PR #${pr.number}`
+  }
 
   async function removeWorktree(
     e: MouseEvent,
@@ -101,6 +125,19 @@
             <span class="detached-badge" title={wt.head}>{wt.head.slice(0, 7)}</span>
           {:else if mergedBranches.has(wt.branch)}
             <span class="merged-badge" title="Merged">merged</span>
+          {/if}
+          {#if prMap[wt.branch]}
+            {@const pr = prMap[wt.branch]}
+            <button
+              class={prBadgeClass(pr)}
+              title={`${pr.title} — click to open`}
+              onclick={(e) => {
+                e.stopPropagation()
+                window.api.openExternal(pr.url)
+              }}
+            >
+              {prBadgeLabel(pr)}
+            </button>
           {/if}
         </button>
         {#if !wt.isMain && mergedBranches.has(wt.branch)}
@@ -205,6 +242,40 @@
     color: var(--c-success);
     flex-shrink: 0;
     margin-left: auto;
+  }
+
+  .pr-badge {
+    font-size: 9px;
+    font-weight: 500;
+    padding: 0 4px;
+    border-radius: 3px;
+    border: none;
+    cursor: pointer;
+    flex-shrink: 0;
+    margin-left: auto;
+    background: var(--c-accent-bg);
+    color: var(--c-accent-text);
+    font-family: inherit;
+    line-height: 16px;
+  }
+
+  .pr-badge:hover {
+    opacity: 0.8;
+  }
+
+  .pr-badge.draft {
+    background: var(--c-hover-strong);
+    color: var(--c-text-muted);
+  }
+
+  .pr-badge.approved {
+    background: var(--c-success-bg, var(--c-success));
+    color: var(--c-success-text, #fff);
+  }
+
+  .pr-badge.changes-requested {
+    background: var(--c-warning-bg, var(--c-warning));
+    color: var(--c-warning-text);
   }
 
   .remove-btn {

--- a/src/renderer/src/components/sidebar/WorktreeSection.svelte
+++ b/src/renderer/src/components/sidebar/WorktreeSection.svelte
@@ -6,6 +6,7 @@
   import { Trash2 } from '@lucide/svelte'
   import CollapsibleSection from './CollapsibleSection.svelte'
   import { getBranchPRMap, loadBranchPRs } from '../../lib/stores/github.svelte'
+  import { getTaskTrackerConnections } from '../../lib/stores/taskTracker.svelte'
 
   let mergedBranches = new SvelteSet<string>()
 
@@ -41,11 +42,21 @@
     return () => ac.abort()
   })
 
+  let githubConnectionCount = $derived(
+    getTaskTrackerConnections().filter((c) => c.provider === 'github').length,
+  )
+
+  // Re-fetch PRs when worktree list changes (debounced)
   $effect(() => {
     const repoRoot = workspaceState.repoRoot
-    // Read length to track worktree list changes
     void workspaceState.worktrees.length
-    if (repoRoot) loadBranchPRs(repoRoot)
+    if (repoRoot && githubConnectionCount > 0) loadBranchPRs(repoRoot)
+  })
+
+  // Force re-fetch when GitHub connections are added/removed
+  $effect(() => {
+    const repoRoot = workspaceState.repoRoot
+    if (repoRoot && githubConnectionCount > 0) loadBranchPRs(repoRoot, true)
   })
 
   let prMap = $derived(getBranchPRMap())

--- a/src/renderer/src/components/sidebar/WorktreeSection.svelte
+++ b/src/renderer/src/components/sidebar/WorktreeSection.svelte
@@ -46,17 +46,16 @@
     getTaskTrackerConnections().filter((c) => c.provider === 'github').length,
   )
 
-  // Re-fetch PRs when worktree list changes (debounced)
+  // Fetch PRs when worktree list or GitHub connections change
+  let prevGhConnCount = 0
   $effect(() => {
     const repoRoot = workspaceState.repoRoot
     void workspaceState.worktrees.length
-    if (repoRoot && githubConnectionCount > 0) loadBranchPRs(repoRoot)
-  })
-
-  // Force re-fetch when GitHub connections are added/removed
-  $effect(() => {
-    const repoRoot = workspaceState.repoRoot
-    if (repoRoot && githubConnectionCount > 0) loadBranchPRs(repoRoot, true)
+    const connCount = githubConnectionCount
+    if (!repoRoot || connCount === 0) return
+    const force = connCount !== prevGhConnCount
+    prevGhConnCount = connCount
+    loadBranchPRs(repoRoot, force)
   })
 
   let prMap = $derived(getBranchPRMap())
@@ -281,7 +280,7 @@
 
   .pr-badge.approved {
     background: var(--c-success-bg, var(--c-success));
-    color: var(--c-success-text, #fff);
+    color: var(--c-success-text, var(--c-text));
   }
 
   .pr-badge.changes-requested {

--- a/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
@@ -129,7 +129,7 @@
   async function loadBoards(): Promise<void> {
     try {
       const [boardList, userName] = await Promise.all([
-        window.api.taskTrackerFetchBoards(connectionId),
+        window.api.taskTrackerFetchBoards(connectionId, workspaceState.repoRoot ?? undefined),
         window.api.taskTrackerGetCurrentUser(connectionId).catch(() => ''),
       ])
       boards = boardList
@@ -172,6 +172,7 @@
     try {
       allTasks = await window.api.taskTrackerFetchTasks(connectionId, {
         boardId: selectedBoardId || undefined,
+        repoRoot: workspaceState.repoRoot ?? undefined,
       })
       // Auto-exclude done/closed only if no saved filters
       if (!hasSavedFilters && excludedStatuses.size === 0 && allTasks.length > 0) {

--- a/src/renderer/src/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/src/lib/stores/dialogs.svelte.ts
@@ -76,6 +76,10 @@ interface TmuxBrowserState {
   type: 'tmuxBrowser'
 }
 
+interface CreateGitHubPRState {
+  type: 'createGitHubPR'
+}
+
 interface NoneState {
   type: 'none'
 }
@@ -92,6 +96,7 @@ type DialogState =
   | OnboardingWizardState
   | FeatureOnboardingState
   | TmuxBrowserState
+  | CreateGitHubPRState
 
 export const dialogState: { current: DialogState } = $state({ current: { type: 'none' } })
 
@@ -172,6 +177,10 @@ export function showFeatureOnboarding(fromVersion: string): void {
 
 export function showTmuxBrowser(): void {
   dialogState.current = { type: 'tmuxBrowser' }
+}
+
+export function showCreateGitHubPR(): void {
+  dialogState.current = { type: 'createGitHubPR' }
 }
 
 export function closeDialog(): void {

--- a/src/renderer/src/lib/stores/github.svelte.ts
+++ b/src/renderer/src/lib/stores/github.svelte.ts
@@ -3,7 +3,7 @@ import { addToast } from './toast.svelte'
 let branchPRs: GitHubBranchPRMap = $state({})
 let repoInfo: GitHubRepoInfo | null = $state(null)
 let loading = $state(false)
-let lastFetch = 0
+const lastFetchByRepo: Record<string, number> = {}
 
 const DEBOUNCE_MS = 30_000
 
@@ -25,13 +25,15 @@ export function isGitHubLoading(): boolean {
 
 export async function loadBranchPRs(repoRoot: string, force = false): Promise<void> {
   const now = Date.now()
+  const lastFetch = lastFetchByRepo[repoRoot] ?? 0
   if (!force && now - lastFetch < DEBOUNCE_MS) return
   loading = true
   try {
-    branchPRs = await window.api.githubFetchBranchPRs(repoRoot)
-    lastFetch = Date.now()
+    const result = await window.api.githubFetchBranchPRs(repoRoot)
+    lastFetchByRepo[repoRoot] = Date.now()
+    // Merge with existing PRs from other repos
+    branchPRs = { ...branchPRs, ...result }
   } catch (e) {
-    branchPRs = {}
     const msg = e instanceof Error ? e.message : String(e)
     if (msg.includes('rate limit') || msg.includes('401') || msg.includes('403')) {
       addToast(msg)
@@ -56,5 +58,5 @@ export async function loadRepoInfo(repoRoot: string): Promise<void> {
 export function resetGitHubState(): void {
   branchPRs = {}
   repoInfo = null
-  lastFetch = 0
+  for (const key of Object.keys(lastFetchByRepo)) delete lastFetchByRepo[key]
 }

--- a/src/renderer/src/lib/stores/github.svelte.ts
+++ b/src/renderer/src/lib/stores/github.svelte.ts
@@ -23,17 +23,17 @@ export function isGitHubLoading(): boolean {
   return loading
 }
 
-export async function loadBranchPRs(repoRoot: string): Promise<void> {
+export async function loadBranchPRs(repoRoot: string, force = false): Promise<void> {
   const now = Date.now()
-  if (now - lastFetch < DEBOUNCE_MS) return
-  lastFetch = now
+  if (!force && now - lastFetch < DEBOUNCE_MS) return
   loading = true
   try {
     branchPRs = await window.api.githubFetchBranchPRs(repoRoot)
+    lastFetch = Date.now()
   } catch (e) {
     branchPRs = {}
     const msg = e instanceof Error ? e.message : String(e)
-    if (msg.includes('rate limit')) {
+    if (msg.includes('rate limit') || msg.includes('401') || msg.includes('403')) {
       addToast(msg)
     }
   } finally {

--- a/src/renderer/src/lib/stores/github.svelte.ts
+++ b/src/renderer/src/lib/stores/github.svelte.ts
@@ -1,0 +1,60 @@
+import { addToast } from './toast.svelte'
+
+let branchPRs: GitHubBranchPRMap = $state({})
+let repoInfo: GitHubRepoInfo | null = $state(null)
+let loading = $state(false)
+let lastFetch = 0
+
+const DEBOUNCE_MS = 30_000
+
+export function getBranchPRMap(): GitHubBranchPRMap {
+  return branchPRs
+}
+
+export function getPRForBranch(branch: string): GitHubPRInfo | undefined {
+  return branchPRs[branch]
+}
+
+export function getGitHubRepoInfo(): GitHubRepoInfo | null {
+  return repoInfo
+}
+
+export function isGitHubLoading(): boolean {
+  return loading
+}
+
+export async function loadBranchPRs(repoRoot: string): Promise<void> {
+  const now = Date.now()
+  if (now - lastFetch < DEBOUNCE_MS) return
+  lastFetch = now
+  loading = true
+  try {
+    branchPRs = await window.api.githubFetchBranchPRs(repoRoot)
+  } catch (e) {
+    branchPRs = {}
+    const msg = e instanceof Error ? e.message : String(e)
+    if (msg.includes('rate limit')) {
+      addToast(msg)
+    }
+  } finally {
+    loading = false
+  }
+}
+
+export async function loadRepoInfo(repoRoot: string): Promise<void> {
+  try {
+    repoInfo = await window.api.githubGetRepoInfo(repoRoot)
+  } catch (e) {
+    repoInfo = null
+    const msg = e instanceof Error ? e.message : String(e)
+    if (msg.includes('rate limit') || msg.includes('401') || msg.includes('403')) {
+      addToast(msg)
+    }
+  }
+}
+
+export function resetGitHubState(): void {
+  branchPRs = {}
+  repoInfo = null
+  lastFetch = 0
+}


### PR DESCRIPTION
## What

Adds GitHub as a first-class integration with GraphQL API:
- GitHub issues via task tracker provider (flows through existing TaskPickerModal)
- Per-worktree PR detection with color-coded badges (draft/approved/changes requested)
- PR creation modal replacing `gh` CLI dependency for GitHub repos
- Auto-detect owner/repo from git remote (connection only needs name + token)

## Why

Previously PR creation required `gh` CLI installed and there was no GitHub issue tracking in Canopy. This adds native GitHub support via GraphQL API with better rate limits and batched queries (single API call detects PRs for all worktree branches).

## How to test

1. Go to Preferences > Connections > Add Connection > select GitHub
2. Enter a name and a GitHub PAT (host URL and repository are optional, auto-detected)
3. Click Test to verify the token works
4. Open the Tasks panel for the GitHub connection in a repo workspace -- issues should load
5. Check the Worktrees sidebar section -- PR badges should appear for branches with open PRs
6. Click a PR badge -- should open the PR in browser
7. Click "Create PR" in the Git section -- should open the GitHub PR creation modal (if GitHub connection exists for current repo)
8. Create a PR with title, base branch, optional body, draft toggle -- should succeed and open in browser

## Checklist

- [x] `npm run typecheck` passes (node + svelte-check, 0 errors)
- [x] `npm run lint` passes (0 errors)
- [x] Follows existing patterns (neverthrow, IPC bridge, provider interface, Svelte 5 runes)
- [x] No new npm dependencies (native fetch + typed GraphQL wrapper)
- [x] GHE support via optional host URL
- [x] Rate limit and auth errors surfaced via toast