### PR TITLE
refactor: group settings tabs into thematic categories

### DIFF
--- a/src/renderer/src/components/preferences/PreferencesModal.svelte
+++ b/src/renderer/src/components/preferences/PreferencesModal.svelte
@@ -27,7 +27,7 @@
   ] as const
 
   type Section = (typeof groups)[number]['sections'][number]
-  const allSections = groups.flatMap((g) => g.sections) as unknown as Section[]
+  const allSections: readonly Section[] = groups.flatMap((g) => g.sections as readonly Section[])
 
   function resolveInitialSection(): Section {
     if (initialSection) {
@@ -67,16 +67,18 @@
     <div class="prefs-sidebar">
       <h2 id="prefs-dialog-title" class="prefs-title">Settings</h2>
       {#each groups as group (group.label)}
-        <span class="prefs-group-label">{group.label}</span>
-        {#each group.sections as section (section)}
-          <button
-            class="prefs-tab"
-            class:active={activeSection === section}
-            onclick={() => (activeSection = section)}
-          >
-            {section}
-          </button>
-        {/each}
+        <div role="group" aria-labelledby={`prefs-group-${group.label}`} class="prefs-group">
+          <span id={`prefs-group-${group.label}`} class="prefs-group-label">{group.label}</span>
+          {#each group.sections as section (section)}
+            <button
+              class="prefs-tab"
+              class:active={activeSection === section}
+              onclick={() => (activeSection = section)}
+            >
+              {section}
+            </button>
+          {/each}
+        </div>
       {/each}
     </div>
 
@@ -142,7 +144,6 @@
     padding: 16px 0;
     display: flex;
     flex-direction: column;
-    gap: 2px;
     overflow-y: auto;
   }
 
@@ -166,8 +167,14 @@
     user-select: none;
   }
 
-  .prefs-group-label:first-child {
+  .prefs-group:first-of-type > .prefs-group-label {
     padding-top: 0;
+  }
+
+  .prefs-group {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
   }
 
   .prefs-tab {

--- a/src/renderer/src/components/preferences/PreferencesModal.svelte
+++ b/src/renderer/src/components/preferences/PreferencesModal.svelte
@@ -143,6 +143,7 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+    overflow-y: auto;
   }
 
   .prefs-title {

--- a/src/renderer/src/components/preferences/PreferencesModal.svelte
+++ b/src/renderer/src/components/preferences/PreferencesModal.svelte
@@ -18,25 +18,20 @@
 
   let containerEl: HTMLDivElement | undefined = $state()
 
-  const sections = [
-    'General',
-    'Updates',
-    'Appearance',
-    'Sidebar',
-    'Terminal',
-    'Tools',
-    'Claude',
-    'Gemini',
-    'Git',
-    'Web Browser',
-    'Tasks',
-    'Shortcuts',
+  const groups = [
+    { label: 'General', sections: ['General', 'Updates', 'Shortcuts'] },
+    { label: 'Appearance', sections: ['Appearance', 'Sidebar'] },
+    { label: 'AI Agents', sections: ['Claude', 'Gemini'] },
+    { label: 'Dev Tools', sections: ['Terminal', 'Tools', 'Git', 'Tasks'] },
+    { label: 'Web Browser', sections: ['Web Browser'] },
   ] as const
-  type Section = (typeof sections)[number]
+
+  type Section = (typeof groups)[number]['sections'][number]
+  const allSections = groups.flatMap((g) => g.sections) as unknown as Section[]
 
   function resolveInitialSection(): Section {
     if (initialSection) {
-      const match = sections.find((s) => s.toLowerCase() === initialSection!.toLowerCase())
+      const match = allSections.find((s) => s.toLowerCase() === initialSection!.toLowerCase())
       if (match) return match
     }
     return 'General'
@@ -71,14 +66,17 @@
   >
     <div class="prefs-sidebar">
       <h2 id="prefs-dialog-title" class="prefs-title">Settings</h2>
-      {#each sections as section (section)}
-        <button
-          class="prefs-tab"
-          class:active={activeSection === section}
-          onclick={() => (activeSection = section)}
-        >
-          {section}
-        </button>
+      {#each groups as group (group.label)}
+        <span class="prefs-group-label">{group.label}</span>
+        {#each group.sections as section (section)}
+          <button
+            class="prefs-tab"
+            class:active={activeSection === section}
+            onclick={() => (activeSection = section)}
+          >
+            {section}
+          </button>
+        {/each}
       {/each}
     </div>
 
@@ -156,10 +154,25 @@
     letter-spacing: 0.3px;
   }
 
+  .prefs-group-label {
+    display: block;
+    padding: 8px 16px 4px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--c-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    user-select: none;
+  }
+
+  .prefs-group-label:first-child {
+    padding-top: 0;
+  }
+
   .prefs-tab {
     display: block;
     width: 100%;
-    padding: 6px 16px;
+    padding: 6px 16px 6px 28px;
     border: none;
     background: transparent;
     color: var(--c-text);


### PR DESCRIPTION
## What
Reorganize the flat list of 12 settings tabs into 5 thematic groups (General, Appearance, AI Agents, Dev Tools, Web Browser) with labeled headers and indented sub-tabs. Adds scrollbar to the sidebar for smaller windows.

## Why
The settings sidebar was hard to navigate with 12 ungrouped tabs. Thematic grouping makes related settings easier to find.

## How to test
1. `npm run dev` → open Settings (Cmd+,)
2. Verify 5 group headers with sub-tabs underneath
3. Click tabs in each group — correct content renders
4. Resize window vertically — sidebar should scroll

## Screenshots / recordings
_UI change — reviewer should verify visually_

## Checklist
- [x] Follows conventional commit format
- [x] TypeScript compiles without errors
- [x] svelte-check passes
- [ ] Tested on Windows/Linux
- [x] Tested on macOS
- [ ] Unit tests added/updated