### PR TITLE
fix(tasks): run worktree setup commands when starting task

### DIFF
--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -95,6 +95,19 @@
     await updateBranchPreview()
   }
 
+  function hasSetupConfig(): boolean {
+    const wsId = workspaceState.workspace?.id
+    if (!wsId) return false
+    const raw = getPref(`workspace:${wsId}:worktreeSetup`, '')
+    if (!raw) return false
+    try {
+      const actions = JSON.parse(raw) as unknown[]
+      return Array.isArray(actions) && actions.length > 0
+    } catch {
+      return false
+    }
+  }
+
   async function confirmBranchCreation(): Promise<void> {
     const repoRoot = workspaceState.repoRoot
     const currentBranch = workspaceState.branch
@@ -113,6 +126,17 @@
       await window.api.gitWorktreeAdd(repoRoot, worktreePath, resolvedBranchName, currentBranch)
       closeDialog()
       await selectWorktree(worktreePath)
+
+      if (hasSetupConfig()) {
+        const wsId = workspaceState.workspace!.id
+        addToast('Running worktree setup...')
+        try {
+          await window.api.runWorktreeSetup(wsId, repoRoot, worktreePath)
+          addToast('Worktree setup complete')
+        } catch (e) {
+          addToast('Worktree setup failed: ' + (e instanceof Error ? e.message : String(e)))
+        }
+      }
 
       if (selectedAgentId) {
         try {
@@ -164,6 +188,7 @@
 
   onDestroy(() => {
     abortController.abort()
+    window.api.abortWorktreeSetup()
   })
 </script>
 

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte'
+  import { onMount } from 'svelte'
   import { X, ExternalLink, ArrowLeft } from '@lucide/svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import { closeDialog, confirm } from '../../lib/stores/dialogs.svelte'
@@ -139,7 +139,6 @@
         connectionId,
         boardId: selectedBoardId || undefined,
       })
-      closeDialog()
 
       if (hasSetupConfig()) {
         const wsId = workspaceState.workspace!.id
@@ -178,6 +177,8 @@
       } else {
         await selectWorktree(worktreePath)
       }
+
+      closeDialog()
     } catch (e) {
       creatingWorktree = false
       closeDialog()
@@ -204,10 +205,6 @@
 
   onMount(() => {
     init()
-  })
-
-  onDestroy(() => {
-    window.api.abortWorktreeSetup()
   })
 </script>
 


### PR DESCRIPTION
## What

Adds worktree setup execution to the task module's branch creation flow in `BranchCreateForm.svelte`.

## Why

`BranchCreateForm` called `gitWorktreeAdd()` but skipped `runWorktreeSetup()`, so workspace setup commands (e.g. `npm install`, file copies) never ran when starting a task via the task picker. The manual `CreateWorktreeModal` already handled this correctly.

## How to test

1. Configure worktree setup commands for a workspace (Settings → Worktree Setup)
2. Open the task picker and select a task to start
3. Confirm branch creation
4. Verify toast notifications appear: "Running worktree setup..." → "Worktree setup complete"
5. Verify the configured commands actually executed in the new worktree
6. Verify agent still launches and receives task context after setup completes

## Checklist

- [x] Code follows project conventions
- [x] Changes limited to the described scope
- [ ] Tests added/updated
- [x] Tested manually
- [ ] Documentation updated