### PR TITLE
fix(session): prevent project loss during window restore

### DIFF
--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -15,7 +15,7 @@ import {
   graftSubtree,
 } from './splitTree'
 import type { DropZone } from './dragState.svelte'
-import { workspaceState, getProjectForWorktree } from './workspace.svelte'
+import { workspaceState, getProjectForWorktree, selectWorktree } from './workspace.svelte'
 import {
   initAgentSession,
   removeAgentSession,
@@ -854,7 +854,10 @@ export function focusSessionByPtyId(ptySessionId: string): boolean {
       const panes = allPanes(tab.rootSplit)
       const pane = panes.find((p) => p.sessionId === ptySessionId)
       if (pane) {
-        workspaceState.selectedWorktreePath = path
+        // Use selectWorktree to fully update project context (sidebar, git info, etc.)
+        selectWorktree(path).catch((err) => {
+          console.error('[tabs] selectWorktree failed after focusSession:', err)
+        })
         activeTabId[path] = tab.id
         tab.focusedPaneId = pane.id
         return true

--- a/src/renderer/src/lib/stores/workspace.svelte.ts
+++ b/src/renderer/src/lib/stores/workspace.svelte.ts
@@ -109,13 +109,21 @@ let attachQueue: Promise<void> = Promise.resolve()
 
 export async function attachProject(path: string): Promise<void> {
   const result = attachQueue.then(() => attachProjectImpl(path))
-  attachQueue = result.then(() => undefined).catch(() => {})
+  attachQueue = result
+    .then(() => undefined)
+    .catch((err) => {
+      console.error('[workspace] attachProject queue error:', err)
+    })
   await result
 }
 
 export async function restoreProjects(paths: string[], activeWorktreePath?: string): Promise<void> {
   const result = attachQueue.then(() => restoreProjectsImpl(paths, activeWorktreePath))
-  attachQueue = result.then(() => undefined).catch(() => {})
+  attachQueue = result
+    .then(() => undefined)
+    .catch((err) => {
+      console.error('[workspace] restoreProjects queue error:', err)
+    })
   await result
 }
 
@@ -156,7 +164,7 @@ async function restoreProjectsImpl(paths: string[], activeWorktreePath?: string)
   }
 
   const batchOrder = new Map<string, number>()
-  const results = await Promise.all(
+  const settled = await Promise.allSettled(
     uniquePaths.map((path, index) =>
       attachProjectImpl(path, {
         selectIfEmpty: false,
@@ -165,6 +173,18 @@ async function restoreProjectsImpl(paths: string[], activeWorktreePath?: string)
       }),
     ),
   )
+  const results = settled.map((s) => (s.status === 'fulfilled' ? s.value : undefined))
+  const failures: string[] = []
+  for (let i = 0; i < settled.length; i++) {
+    const s = settled[i]
+    if (s.status === 'rejected') {
+      console.error(`[workspace] failed to restore project "${uniquePaths[i]}":`, s.reason)
+      failures.push(uniquePaths[i].split('/').pop() || uniquePaths[i])
+    }
+  }
+  if (failures.length > 0) {
+    addToast(`Failed to restore: ${failures.join(', ')}`)
+  }
 
   let targetPath = activeWorktreePath
   if (!targetPath || !getProjectForWorktree(targetPath)) {
@@ -225,16 +245,25 @@ async function attachProjectImpl(
   }
 
   // Start git watcher if git repo
-  if (info.isGitRepo && info.repoRoot) {
-    await window.api.gitWatch(info.repoRoot, info)
+  try {
+    if (info.isGitRepo && info.repoRoot) {
+      await window.api.gitWatch(info.repoRoot, info)
+    }
+  } catch (err) {
+    console.error(`[workspace] gitWatch failed for "${projectPath}":`, err)
+    addToast(`Git watcher failed for ${name} — status may not update`)
   }
 
   // Auto-detect .canopy/config.json for task tracker
-  if (info.repoRoot) {
-    await loadRepoConfig(info.repoRoot)
-    if (getRepoConfig() && !getHasCredentials()) {
-      addToast('Tracker requires authentication — configure token in Preferences')
+  try {
+    if (info.repoRoot) {
+      await loadRepoConfig(info.repoRoot)
+      if (getRepoConfig() && !getHasCredentials()) {
+        addToast('Tracker requires authentication — configure token in Preferences')
+      }
     }
+  } catch (err) {
+    console.error(`[workspace] loadRepoConfig failed for "${projectPath}":`, err)
   }
 
   // Restore saved layouts BEFORE selecting worktree so that ensureDefaultTab


### PR DESCRIPTION
## What
Prevents projects from disappearing from the sidebar after window restore by isolating per-project failures and improving error visibility.

## Why
When restoring multiple projects on startup, `restoreProjectsImpl` used `Promise.all` — if any single project failed (e.g. git detection, workspace upsert), the entire batch rejected silently. Projects that threw before being pushed to the array were lost from the sidebar, while their agent sessions could still appear in the notch overlay. Additionally, `focusSessionByPtyId` (notch click handler) set `selectedWorktreePath` directly without updating the full workspace context.

## How to test
1. Attach 3+ projects to a single window
2. Quit and reopen the app
3. Verify all projects appear in the sidebar
4. Click an agent in the notch overlay — verify the sidebar highlights the correct project and git info updates
5. To test error path: temporarily break `gitDetect` for one project path — verify other projects still restore and a toast appears for the failed one

## Checklist
- [x] Follows conventional commit format
- [x] TypeScript compiles (`npm run typecheck`)
- [x] Linter passes (`npm run lint`)
- [ ] Covered by tests
- [x] No new dependencies