### PR TITLE
fix(diff): replace emoji icons, fix tab flash, comment form polish

### DIFF
--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
+  import { RotateCw, Check, X } from 'lucide-svelte'
   import { openDiffTab } from '../../lib/stores/tabs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import type { DiffFile, ParsedDiff } from '../../lib/types/diff'
@@ -135,7 +136,11 @@
   <div class="panel-header">
     <span class="panel-title">Changes</span>
     <button class="refresh-btn" onclick={refresh} title="Refresh" disabled={loading}>
-      {loading ? '...' : '\u21BB'}
+      {#if loading}
+        <span class="refresh-loading">...</span>
+      {:else}
+        <RotateCw size={13} />
+      {/if}
     </button>
   </div>
 
@@ -221,12 +226,12 @@
               <button
                 class="action-btn stage"
                 onclick={(e) => handleStage(e, file.path)}
-                title="Stage">&#x2713;</button
+                title="Stage"><Check size={12} /></button
               >
               <button
                 class="action-btn revert"
                 onclick={(e) => handleRevert(e, file.path)}
-                title="Revert">&#x2717;</button
+                title="Revert"><X size={12} /></button
               >
             </span>
           {/if}
@@ -274,10 +279,11 @@
     border: none;
     color: var(--c-text-muted);
     cursor: pointer;
-    font-size: 14px;
     padding: 2px 4px;
     border-radius: 4px;
-    font-family: inherit;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .refresh-btn:hover {
@@ -476,10 +482,11 @@
     background: none;
     border: none;
     cursor: pointer;
-    font-size: 12px;
-    padding: 0 3px;
+    padding: 1px 3px;
     border-radius: 3px;
-    font-family: inherit;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .action-btn.stage {

--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -320,7 +320,6 @@
     overflow: hidden;
     flex: 1;
     min-width: 20px;
-    align-self: center;
   }
 
   .summary-bar-add {

--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -300,22 +300,27 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 2px 12px 6px;
+    padding: 2px 12px 6px 12px;
     flex-shrink: 0;
+    overflow: hidden;
   }
 
   .summary-text {
     font-size: 11px;
     color: var(--c-text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 
   .summary-bar {
     display: flex;
-    align-items: center;
+    align-items: stretch;
     height: 6px;
     border-radius: 2px;
     overflow: hidden;
-    flex-shrink: 0;
+    flex: 1;
+    min-width: 20px;
+    align-self: center;
   }
 
   .summary-bar-add {
@@ -398,7 +403,7 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 3px 12px;
+    padding: 3px 8px 3px 12px;
     cursor: pointer;
     font-size: 12px;
     line-height: 1.4;
@@ -476,6 +481,8 @@
     display: flex;
     gap: 2px;
     flex-shrink: 0;
+    width: 44px;
+    justify-content: flex-end;
   }
 
   .action-btn {

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
+  import { Search, RotateCw, ChevronRight, Copy } from 'lucide-svelte'
   import { getAiSessions, focusSessionByPtyId } from '../../lib/stores/tabs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import type { DiffChange, DiffFile } from '../../lib/types/diff'
@@ -398,7 +399,7 @@
       </div>
     {/if}
     <button class="toolbar-btn" onclick={toggleSearch} title="Search" aria-label="Search in diff">
-      &#x1F50D;
+      <Search size={14} />
     </button>
     <button
       class="toolbar-btn"
@@ -407,7 +408,7 @@
       aria-label="Refresh diff"
       disabled={loading}
     >
-      &#x21BB;
+      <RotateCw size={14} />
     </button>
   </div>
 
@@ -427,8 +428,9 @@
           onpointerleave={() => (hoveredFilePath = null)}
         >
           <div class="file-header" onclick={() => toggleCollapse(file.path)}>
-            <span class="chevron" class:chevron-open={!collapsedFiles.has(file.path)}>&#x25B8;</span
-            >
+            <span class="chevron" class:chevron-open={!collapsedFiles.has(file.path)}>
+              <ChevronRight size={12} />
+            </span>
             <span class="file-status {statusClass(file.status)}">{statusLabel(file.status)}</span>
             <span class="file-path" title={file.path}>{file.path}</span>
             <span class="stats-bar">
@@ -453,7 +455,7 @@
                   copyDiff(file)
                 }}
               >
-                &#x1F4CB;
+                <Copy size={12} />
               </button>
             {/if}
           </div>
@@ -628,9 +630,11 @@
     border: none;
     color: var(--c-text-muted);
     cursor: pointer;
-    font-size: 14px;
     padding: 2px 6px;
     border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .toolbar-btn:hover {
@@ -708,11 +712,11 @@
   }
 
   .chevron {
-    font-size: 10px;
     color: var(--c-text-muted);
     transition: transform 0.15s ease;
     flex-shrink: 0;
-    display: inline-block;
+    display: flex;
+    align-items: center;
   }
 
   .chevron.chevron-open {
@@ -787,10 +791,12 @@
     border: 1px solid var(--c-border);
     color: var(--c-text-muted);
     cursor: pointer;
-    font-size: 12px;
     padding: 2px 6px;
     border-radius: 4px;
     flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .copy-diff-btn:hover {

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -667,6 +667,10 @@
     border-bottom: 1px solid var(--c-border-subtle);
   }
 
+  .file-section.file-focused {
+    background: color-mix(in srgb, var(--c-accent) 5%, transparent);
+  }
+
   .file-header {
     display: flex;
     align-items: center;

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -226,8 +226,8 @@
     }
   }
 
-  function openComment(filePath: string, line: number): void {
-    const key = `${filePath}:${line}`
+  function openComment(filePath: string, changeId: string, line: number): void {
+    const key = `${filePath}:${changeId}`
     if (commentKey === key) {
       closeComment()
       return
@@ -481,7 +481,9 @@
                           class="comment-trigger"
                           title="Add review comment"
                           aria-label="Add review comment"
-                          onclick={() => openComment(file.path, getLineNum(change))}>+</button
+                          onclick={() =>
+                            openComment(file.path, `${hunk.header}:${i}`, getLineNum(change))}
+                          >+</button
                         >
                       {/if}
                       <span class="gutter old-gutter"
@@ -504,53 +506,30 @@
                         <span class="line-content">{change.content}</span>
                       {/if}
                     </div>
-                    {#if commentKey === `${file.path}:${getLineNum(change)}`}
+                    {#if commentKey === `${file.path}:${hunk.header}:${i}`}
                       <div class="comment-form">
-                        <div class="comment-card">
-                          <div class="comment-card-header">
-                            <svg
-                              class="comment-icon"
-                              width="14"
-                              height="14"
-                              viewBox="0 0 16 16"
-                              fill="currentColor"
+                        <textarea
+                          class="comment-input"
+                          placeholder="Comment for agent — {file.path}:{getLineNum(change)}"
+                          bind:value={commentText}
+                          onkeydown={(e) => {
+                            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) sendComment()
+                            if (e.key === 'Escape') closeComment()
+                          }}
+                        ></textarea>
+                        <div class="comment-footer">
+                          <span class="comment-hint">
+                            {navigator.userAgent.includes('Mac') ? '⌘' : 'Ctrl'}+Enter to send
+                          </span>
+                          <div class="comment-actions">
+                            <button class="comment-cancel" onclick={closeComment}>Cancel</button>
+                            <button
+                              class="comment-send"
+                              onclick={sendComment}
+                              disabled={!commentText.trim()}
                             >
-                              <path
-                                d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"
-                              />
-                            </svg>
-                            <span class="comment-label">Review comment</span>
-                            <span class="comment-file-ref">{file.path}:{getLineNum(change)}</span>
-                          </div>
-                          <textarea
-                            class="comment-input"
-                            placeholder="Describe what should be changed..."
-                            bind:value={commentText}
-                            onkeydown={(e) => {
-                              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) sendComment()
-                              if (e.key === 'Escape') closeComment()
-                            }}
-                          ></textarea>
-                          <div class="comment-footer">
-                            <span class="comment-hint">
-                              {navigator.userAgent.includes('Mac') ? '\u2318' : 'Ctrl'}+Enter to
-                              send
-                            </span>
-                            <div class="comment-actions">
-                              <button class="comment-cancel" onclick={closeComment}>Cancel</button>
-                              <button
-                                class="comment-send"
-                                onclick={sendComment}
-                                disabled={!commentText.trim()}
-                              >
-                                <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                                  <path
-                                    d="M.989 8 .064 2.68a1.342 1.342 0 0 1 1.85-1.462l13.402 5.744a1.13 1.13 0 0 1 0 2.076L1.913 14.782a1.343 1.343 0 0 1-1.85-1.463Z"
-                                  />
-                                </svg>
-                                Send to Agent
-                              </button>
-                            </div>
+                              Send
+                            </button>
                           </div>
                         </div>
                       </div>
@@ -686,11 +665,6 @@
 
   .file-section {
     border-bottom: 1px solid var(--c-border-subtle);
-    border-left: 2px solid transparent;
-  }
-
-  .file-section.file-focused {
-    border-left: 2px solid var(--c-accent);
   }
 
   .file-header {
@@ -876,8 +850,12 @@
   }
 
   .comment-form {
-    padding: 10px 16px 10px 24px;
-    animation: comment-slide-in 0.25s cubic-bezier(0.16, 1, 0.3, 1) both;
+    margin: 4px 8px;
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+    background: var(--c-bg-elevated);
+    overflow: hidden;
+    animation: comment-slide-in 0.15s ease both;
   }
 
   @keyframes comment-slide-in {
@@ -891,132 +869,79 @@
     }
   }
 
-  .comment-card {
-    background: var(--c-bg-elevated);
-    border: 1px solid var(--c-border);
-    border-radius: 10px;
-    overflow: hidden;
-    box-shadow:
-      0 2px 8px rgba(0, 0, 0, 0.15),
-      0 1px 2px rgba(0, 0, 0, 0.1);
-  }
-
-  .comment-card-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 8px 12px;
-    background: var(--c-border-subtle);
-    border-bottom: 1px solid var(--c-border-subtle);
-  }
-
-  .comment-icon {
-    color: var(--c-accent);
-    flex-shrink: 0;
-  }
-
-  .comment-label {
-    font-size: 11px;
-    font-weight: 600;
-    color: var(--c-text-secondary);
-    letter-spacing: 0.2px;
-  }
-
-  .comment-file-ref {
-    font-size: 10px;
-    color: var(--c-text-faint);
-    margin-left: auto;
-    font-family: var(--font-mono, monospace);
-  }
-
   .comment-input {
     width: 100%;
-    min-height: 72px;
-    padding: 10px 12px;
+    min-height: 64px;
+    padding: 10px 16px;
     border: none;
-    background: transparent;
+    background: var(--c-bg-elevated);
     color: var(--c-text);
-    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
-    font-size: 13px;
+    font-family: inherit;
+    font-size: 12px;
     line-height: 1.5;
-    resize: vertical;
+    resize: none;
     outline: none;
+    box-sizing: border-box;
   }
 
   .comment-input::placeholder {
-    color: var(--c-text-faint);
+    color: var(--c-text-muted);
   }
 
   .comment-footer {
     display: flex;
     align-items: center;
-    padding: 6px 12px 8px;
+    padding: 6px 16px;
+    background: var(--c-bg-elevated);
     border-top: 1px solid var(--c-border-subtle);
-    background: var(--c-border-subtle);
   }
 
   .comment-hint {
-    font-size: 10px;
-    color: var(--c-text-faint);
+    font-size: 11px;
+    color: var(--c-text-secondary);
     flex: 1;
   }
 
   .comment-actions {
     display: flex;
-    gap: 6px;
+    gap: 4px;
   }
 
   .comment-cancel {
-    padding: 5px 12px;
-    border: none;
-    background: var(--c-active);
+    padding: 3px 10px;
+    border: 1px solid var(--c-border-subtle);
+    background: none;
     color: var(--c-text-muted);
-    border-radius: 6px;
-    font-size: 12px;
-    font-weight: 500;
+    border-radius: 4px;
+    font-size: 11px;
     cursor: pointer;
     font-family: inherit;
-    transition:
-      background 0.15s,
-      color 0.15s;
   }
 
   .comment-cancel:hover {
     color: var(--c-text);
-    background: var(--c-active);
+    background: var(--c-hover);
   }
 
   .comment-send {
-    padding: 5px 14px;
+    padding: 3px 10px;
     border: none;
     background: var(--c-accent);
     color: var(--c-bg);
-    border-radius: 6px;
-    font-size: 12px;
+    border-radius: 4px;
+    font-size: 11px;
     font-weight: 600;
     cursor: pointer;
     font-family: inherit;
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    transition:
-      filter 0.15s,
-      transform 0.1s;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   }
 
   .comment-send:hover {
-    filter: brightness(1.15);
-  }
-
-  .comment-send:active {
-    transform: scale(0.97);
+    filter: brightness(1.1);
   }
 
   .comment-send:disabled {
     opacity: 0.35;
     cursor: default;
-    transform: none;
     filter: none;
   }
 

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -589,7 +589,7 @@
   .right-resize-handle {
     width: 1px;
     cursor: col-resize;
-    background: var(--c-border-subtle);
+    background: transparent;
     flex-shrink: 0;
     position: relative;
   }

--- a/src/renderer/src/components/layout/RightPanel.svelte
+++ b/src/renderer/src/components/layout/RightPanel.svelte
@@ -29,7 +29,6 @@
         class:active={workspaceState.rightPanelTab === 'session'}
         role="tab"
         aria-selected={workspaceState.rightPanelTab === 'session'}
-        data-label="Session"
         onclick={() => (workspaceState.rightPanelTab = 'session')}
       >
         Session
@@ -39,7 +38,6 @@
         class:active={workspaceState.rightPanelTab === 'changes'}
         role="tab"
         aria-selected={workspaceState.rightPanelTab === 'changes'}
-        data-label="Changes"
         onclick={() => (workspaceState.rightPanelTab = 'changes')}
       >
         Changes

--- a/src/renderer/src/components/layout/RightPanel.svelte
+++ b/src/renderer/src/components/layout/RightPanel.svelte
@@ -29,6 +29,7 @@
         class:active={workspaceState.rightPanelTab === 'session'}
         role="tab"
         aria-selected={workspaceState.rightPanelTab === 'session'}
+        data-label="Session"
         onclick={() => (workspaceState.rightPanelTab = 'session')}
       >
         Session
@@ -38,6 +39,7 @@
         class:active={workspaceState.rightPanelTab === 'changes'}
         role="tab"
         aria-selected={workspaceState.rightPanelTab === 'changes'}
+        data-label="Changes"
         onclick={() => (workspaceState.rightPanelTab = 'changes')}
       >
         Changes
@@ -48,16 +50,18 @@
     </div>
   </div>
 
-  <div class="tab-content">
-    {#if workspaceState.rightPanelTab === 'session'}
-      {#if agentState}
-        <AgentInspector state={agentState} />
-      {:else}
-        <div class="empty-state">
-          <span class="empty-text">No active agent session</span>
-        </div>
-      {/if}
-    {:else if worktreePath}
+  <div class="tab-content" class:hidden={workspaceState.rightPanelTab !== 'session'}>
+    {#if agentState}
+      <AgentInspector state={agentState} />
+    {:else}
+      <div class="empty-state">
+        <span class="empty-text">No active agent session</span>
+      </div>
+    {/if}
+  </div>
+
+  <div class="tab-content" class:hidden={workspaceState.rightPanelTab !== 'changes'}>
+    {#if worktreePath}
       <ChangesPanel {worktreePath} bind:fileCount={changesFileCount} />
     {:else}
       <div class="empty-state">
@@ -111,23 +115,18 @@
     font-family: inherit;
     border-radius: 6px;
     transition:
-      background 0.2s cubic-bezier(0.25, 0.1, 0.25, 1),
-      color 0.15s,
-      box-shadow 0.2s cubic-bezier(0.25, 0.1, 0.25, 1);
+      background 0.15s ease,
+      color 0.15s ease;
   }
 
   .segment:hover:not(.active) {
     color: var(--c-text-secondary);
-    background: var(--c-border-subtle);
+    background: color-mix(in srgb, var(--c-bg-elevated) 50%, transparent);
   }
 
   .segment.active {
     background: var(--c-bg-elevated);
     color: var(--c-text);
-    font-weight: 600;
-    box-shadow:
-      0 1px 4px rgba(0, 0, 0, 0.3),
-      0 0.5px 1px rgba(0, 0, 0, 0.2);
   }
 
   .badge {
@@ -154,6 +153,10 @@
     flex: 1;
     overflow-y: auto;
     min-height: 0;
+  }
+
+  .tab-content.hidden {
+    display: none;
   }
 
   .empty-state {

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -152,8 +152,7 @@
   }
 
   .pane-wrapper.focused {
-    outline: 1px solid var(--c-focus-ring);
-    outline-offset: -1px;
+    outline: none;
   }
 
   .pane-content {

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -152,7 +152,8 @@
   }
 
   .pane-wrapper.focused {
-    outline: none;
+    outline: 1px solid var(--c-border);
+    outline-offset: -1px;
   }
 
   .pane-content {


### PR DESCRIPTION
## What
Replaces raw unicode/emoji characters with `lucide-svelte` icons in the diff view, fixes a tab-switch remount flash in RightPanel, fixes a double comment form bug, and polishes the comment form UI to match the app's design language.

## Why
- Emoji icons (🔍 ↻ ▸ 📋 ✓ ✗) were inconsistent with the rest of the app which uses lucide-svelte
- Switching Session↔Changes tabs destroyed and remounted `ChangesPanel` on every switch, causing a visible flash as data reloaded
- Clicking `+` on adjacent delete/add lines with the same line number opened two comment forms simultaneously (key collision on line number)
- The comment form had a heavy card design with its own header/icon that didn't match the surrounding diff UI

## Changes
- `ChangesPanel` / `DiffPane`: swap unicode chars for lucide icons (`RotateCw`, `Check`, `X`, `Search`, `ChevronRight`, `Copy`)
- `RightPanel`: always render both tab panels, toggle visibility with `display: none` — eliminates remount flash
- `DiffPane`: fix comment key from `filePath:lineNum` to `filePath:hunkHeader:changeIndex` — prevents collision between delete/add lines at the same number
- `DiffPane`: simplify comment form — remove card/header chrome, use flat inline design with consistent padding and readable hint text
- `DiffPane`: `file-focused` now uses background tint instead of `border-left` (prevents diff line backgrounds from bleeding over the border)
- `MainLayout`: resize handle transparent by default, shows on hover only
- `PaneWrapper`: remove focus outline that leaked a blue border around the diff pane

## How to test
1. Open a worktree with uncommitted changes
2. Open the Diff tab — verify icons (search, refresh, chevron, copy, stage/revert) render correctly
3. Switch between Session and Changes tabs — verify no flash/jump
4. In the diff, click `+` on a deleted line adjacent to an added line — verify only one comment form appears
5. Type a comment and send — verify it reaches the agent session
6. Press j/k in the diff view — verify focused file gets a subtle background highlight
7. Hover over the right panel resize handle — verify it only appears on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)