### PR TITLE
fix(session): reliably persist window configs on quit

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -774,9 +774,19 @@ app.on('before-quit', (event) => {
     }
   }
 
+  // Always save window configs before any async quit path.
+  // The tmux-ask branch below returns early and re-enters via app.quit(),
+  // so this is the only reliable place to persist.
+  const configs = windowManager.getAllWindowConfigs()
+  if (configs.length > 0) {
+    preferencesStore.set('openWindowConfigs', JSON.stringify(configs))
+  } else {
+    preferencesStore.delete('openWindowConfigs')
+  }
+
   // Handle tmux close policy synchronously before any async work
   const tmuxClosePolicy = preferencesStore.get('tmux.closePolicy') ?? 'detach'
-  if (tmuxClosePolicy === 'ask') {
+  if (tmuxClosePolicy === 'ask' && !windowManager.isQuitting) {
     // preventDefault must be called synchronously — cannot await before this
     event.preventDefault()
     tmuxManager
@@ -805,13 +815,6 @@ app.on('before-quit', (event) => {
         app.quit()
       })
     return
-  }
-
-  const configs = windowManager.getAllWindowConfigs()
-  if (configs.length > 0) {
-    preferencesStore.set('openWindowConfigs', JSON.stringify(configs))
-  } else {
-    preferencesStore.delete('openWindowConfigs')
   }
 
   if (tmuxClosePolicy === 'kill') {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -80,6 +80,15 @@ export function registerIpcHandlers(
     }
   }
 
+  function persistWindowConfigs(): void {
+    const configs = windowManager.getAllWindowConfigs()
+    if (configs.length > 0) {
+      preferencesStore.set('openWindowConfigs', JSON.stringify(configs))
+    } else {
+      preferencesStore.delete('openWindowConfigs')
+    }
+  }
+
   // --- PTY ---
 
   ipcMain.handle(
@@ -449,16 +458,12 @@ export function registerIpcHandlers(
 
   ipcMain.handle('app:setWorkspacePath', (event, payload: { path: string }) => {
     windowManager.addWorkspacePath(event.sender.id, payload.path)
-    const configs = windowManager.getAllWindowConfigs()
-    if (configs.length > 0) {
-      preferencesStore.set('openWindowConfigs', JSON.stringify(configs))
-    } else {
-      preferencesStore.delete('openWindowConfigs')
-    }
+    persistWindowConfigs()
   })
 
   ipcMain.handle('app:setActiveWorktree', (event, payload: { path: string }) => {
     windowManager.setActiveWorktree(event.sender.id, payload.path)
+    persistWindowConfigs()
   })
 
   ipcMain.handle(
@@ -472,12 +477,7 @@ export function registerIpcHandlers(
     const senderId = event.sender.id
     windowManager.removeWorkspacePath(senderId, payload.path)
     windowManager.disposeGitWatcher(senderId, payload.path)
-    const configs = windowManager.getAllWindowConfigs()
-    if (configs.length > 0) {
-      preferencesStore.set('openWindowConfigs', JSON.stringify(configs))
-    } else {
-      preferencesStore.delete('openWindowConfigs')
-    }
+    persistWindowConfigs()
   })
 
   ipcMain.handle('app:focusWindowForPath', (event, payload: { path: string }) => {

--- a/src/renderer/src/lib/stores/workspace.svelte.ts
+++ b/src/renderer/src/lib/stores/workspace.svelte.ts
@@ -138,6 +138,7 @@ function getDefaultWorktreePath(project: ProjectState): string {
 }
 
 function reorderProjects(batchOrder: Map<string, number>): void {
+  const before = projects.length
   const ordered = [...projects]
     .map((project, index) => ({
       project,
@@ -154,6 +155,12 @@ function reorderProjects(batchOrder: Map<string, number>): void {
     .map((entry) => entry.project)
 
   projects.splice(0, projects.length, ...ordered)
+  if (projects.length !== before) {
+    console.error(
+      `[workspace] reorder lost projects: ${before} -> ${projects.length}`,
+      ordered.map(getProjectKey),
+    )
+  }
 }
 
 async function restoreProjectsImpl(paths: string[], activeWorktreePath?: string): Promise<void> {
@@ -175,13 +182,22 @@ async function restoreProjectsImpl(paths: string[], activeWorktreePath?: string)
   )
   const results = settled.map((s) => (s.status === 'fulfilled' ? s.value : undefined))
   const failures: string[] = []
+  const skipped: string[] = []
   for (let i = 0; i < settled.length; i++) {
     const s = settled[i]
     if (s.status === 'rejected') {
       console.error(`[workspace] failed to restore project "${uniquePaths[i]}":`, s.reason)
       failures.push(uniquePaths[i].split('/').pop() || uniquePaths[i])
+    } else if (!s.value) {
+      skipped.push(uniquePaths[i])
     }
   }
+  if (skipped.length > 0) {
+    console.warn('[workspace] restore skipped (dedup/focus):', skipped)
+  }
+  console.debug(
+    `[workspace] restore done: ${results.filter(Boolean).length} ok, ${failures.length} failed, ${skipped.length} skipped, ${projects.length} in sidebar`,
+  )
   if (failures.length > 0) {
     addToast(`Failed to restore: ${failures.join(', ')}`)
   }
@@ -228,8 +244,8 @@ async function attachProjectImpl(
   })
   await window.api.touchWorkspace(ws.id)
 
-  // Register with main process for dedup
-  window.api.setWorkspacePath(projectPath)
+  // Register with main process for dedup + config persistence
+  await window.api.setWorkspacePath(projectPath)
 
   // Add to projects
   const project: ProjectState = {
@@ -239,6 +255,7 @@ async function attachProjectImpl(
     worktrees: info.worktrees,
   }
   projects.push(project)
+  console.debug(`[workspace] attached "${name}" (${projectPath}), total: ${projects.length}`)
   if (batchOrder && restoreIndex !== undefined) {
     batchOrder.set(projectPath, restoreIndex)
     reorderProjects(batchOrder)
@@ -297,6 +314,7 @@ export async function detachProject(path: string): Promise<void> {
   if (idx < 0) return
 
   const project = projects[idx]
+  console.warn(`[workspace] detaching "${project.workspace.name}" (${path})`)
 
   // Unwatch git
   if (project.isGitRepo && project.repoRoot) {


### PR DESCRIPTION
## What

Ensures window configs (attached projects, active worktree) are always saved before the app quits, regardless of tmux close policy. Adds diagnostic logging to the project restore lifecycle.

## Why

When `tmux.closePolicy` was set to `'ask'`, the `before-quit` handler returned early before reaching the config save, then re-entered via `app.quit()` in an infinite loop — configs were never persisted. Additionally, `setActiveWorktree` changes were only saved at quit time (not eagerly), so a crash or forced kill would lose the active worktree selection.

Separately, projects can silently disappear from the sidebar after restore with no error toast and no console trace, making the root cause hard to diagnose. Diagnostic logging is added to catch this.

## How to test

1. Attach 4+ projects to a single window
2. Quit and reopen — verify all projects appear in the sidebar
3. Set tmux policy to `ask`, quit with active tmux sessions — verify the dialog appears once (not in a loop) and all projects restore on next launch
4. Open DevTools console during restore — verify `[workspace]` debug/warn logs appear with correct counts
5. Switch between worktrees, quit, reopen — verify the correct worktree is selected (tests `setActiveWorktree` eager save)

## Checklist

- [x] Follows conventional commit format
- [x] TypeScript compiles (`npm run typecheck`)
- [x] Linter passes (`npm run lint`)
- [ ] Covered by tests
- [x] No new dependencies