### PR TITLE
fix(diff): prevent layout jump when clicking refresh button

### DIFF
--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -136,11 +136,9 @@
   <div class="panel-header">
     <span class="panel-title">Changes</span>
     <button class="refresh-btn" onclick={refresh} title="Refresh" disabled={loading}>
-      {#if loading}
-        <span class="refresh-loading">...</span>
-      {:else}
+      <span class:spinning={loading} style="display:flex">
         <RotateCw size={13} />
-      {/if}
+      </span>
     </button>
   </div>
 
@@ -294,6 +292,19 @@
   .refresh-btn:disabled {
     opacity: 0.5;
     cursor: default;
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .spinning {
+    animation: spin 1s linear infinite;
   }
 
   .summary-line {

--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -307,6 +307,12 @@
     animation: spin 1s linear infinite;
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    .spinning {
+      animation: none;
+    }
+  }
+
   .summary-line {
     display: flex;
     align-items: center;


### PR DESCRIPTION
**What:** Replace the loading state text swap in the ChangesPanel refresh button with a CSS spin animation on the icon.

**Why:** Clicking the refresh icon caused a visible layout shift because the button was toggling between a `RotateCw` SVG icon and a `"..."` text span — two elements with different dimensions. This made the header content jump on click.

**How to test:**
1. Open a worktree with uncommitted changes so the Changes panel is populated
2. Click the refresh icon (↺) in the Changes panel header
3. Verify the header content no longer jumps — the icon should spin in place during the refresh

**Screenshots / recordings:** UI change (button behavior only, no visual layout change by design)

**Checklist:**
- [x] No breaking changes
- [ ] Tests added/updated
- [x] UI tested manually