### PR TITLE
fix(git): refresh worktree list on branch checkout

### DIFF
--- a/src/main/git/GitWatcher.ts
+++ b/src/main/git/GitWatcher.ts
@@ -106,6 +106,7 @@ export class GitWatcher {
 
     if (changedPath === headPath) {
       this.pendingRefresh.branch = true
+      this.pendingRefresh.worktrees = true
       this.pendingRefresh.aheadBehind = true
       return
     }


### PR DESCRIPTION
## What
Refresh the worktree list when `.git/HEAD` changes so the Projects sidebar section shows the updated branch name after checkout.

## Why
When switching branches via terminal, `GitWatcher` flagged `branch` and `aheadBehind` for refresh but not `worktrees`. The GitSection (using `workspaceState.branch`) updated correctly, but the ProjectTreeSection (using `project.worktrees[].branch`) kept showing stale branch names.

Closes #108

## How to test
1. Open a repo in Canopy
2. Switch branch from the terminal (e.g. `git checkout -b test-branch`)
3. Verify the branch name updates in both the Projects section header and the Git section

## Checklist
- [x] Tested manually
- [ ] Added/updated tests
- [ ] Updated documentation
- [x] No breaking changes