### PR TITLE
fix(git): sanitize branch and worktree names to strip unsafe characters

### DIFF
--- a/src/main/taskTracker/branchTemplate.ts
+++ b/src/main/taskTracker/branchTemplate.ts
@@ -61,7 +61,7 @@ function slugify(text: string, maxLength = 50): string {
 function sanitizeBranchName(name: string): string {
   return name
     .replace(/\.\./g, '.')
-    .replace(/[~^:?*[\]\\@{}\s]/g, '-')
+    .replace(/[~^:?*[\]\\@{}#\s]/g, '-')
     .replace(/\/{2,}/g, '/')
     .replace(/^\/|\/$/g, '')
     .replace(/-+/g, '-')

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -11,6 +11,7 @@
   import { agentSessions } from '../../lib/agents/agentState.svelte'
   import { fetchAndFormatTaskContext } from '../../lib/taskTracker/taskContext'
   import { setActiveTask } from '../../lib/stores/taskTracker.svelte'
+  import { safeDirName } from '../../lib/sanitize'
 
   interface Task {
     key: string
@@ -122,7 +123,7 @@
 
     const baseDir = getPref('worktrees.baseDir', '~/canopy/worktrees')
     const projectName = repoRoot.split(/[/\\]/).pop() || 'project'
-    const safeBranchName = resolvedBranchName.replace(/\//g, '-')
+    const safeBranchName = safeDirName(resolvedBranchName)
     const worktreeDir = `${baseDir}/${projectName}/${safeBranchName}`
     const homedir = await window.api.getHomedir()
     const worktreePath = worktreeDir.startsWith('~/')

--- a/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
+++ b/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
@@ -8,6 +8,7 @@
   import { getPref, prefs } from '../../lib/stores/preferences.svelte'
   import { openTool } from '../../lib/stores/tabs.svelte'
   import { getTheme } from '../../lib/terminal/themes'
+  import { safeDirName } from '../../lib/sanitize'
 
   let {
     onClose,
@@ -55,7 +56,7 @@
   let worktreeDir = $derived.by(() => {
     if (!newBranchName) return ''
     const baseDir = getPref('worktrees.baseDir', '~/canopy/worktrees')
-    const safeName = newBranchName.replace(/\//g, '-')
+    const safeName = safeDirName(newBranchName)
     return `${baseDir}/${projectName}/${safeName}`
   })
 

--- a/src/renderer/src/lib/sanitize.ts
+++ b/src/renderer/src/lib/sanitize.ts
@@ -1,8 +1,10 @@
 /** Strip chars unsafe for directory names; collapse repeated dashes */
 export function safeDirName(name: string): string {
-  return name
-    .replace(/\//g, '-')
-    .replace(/[#~^:?*[\]\\@{}<>|"'!$&()`;,\s]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
+  return (
+    name
+      .replace(/\//g, '-')
+      .replace(/[#~^:?*[\]\\@{}<>|"'!$&()`;,\s]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || 'unnamed'
+  )
 }

--- a/src/renderer/src/lib/sanitize.ts
+++ b/src/renderer/src/lib/sanitize.ts
@@ -1,0 +1,8 @@
+/** Strip chars unsafe for directory names; collapse repeated dashes */
+export function safeDirName(name: string): string {
+  return name
+    .replace(/\//g, '-')
+    .replace(/[#~^:?*[\]\\@{}<>|"'!$&()`;,\s]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}


### PR DESCRIPTION
## What

Sanitize branch names and worktree directory names to strip characters like `#` that are unsafe for filesystem paths. Adds a shared `safeDirName()` helper for worktree path construction.

## Why

Task keys from trackers (YouTrack, Jira) can contain `#` and other characters that are valid in the tracker but break worktree directory creation. These characters cannot be modified in the task service, so they must be stripped during branch/path construction.

## How to test

1. Configure a task tracker connection with a task key containing `#` (e.g. `PROJECT#123`)
2. Create a worktree from that task via the task picker
3. Verify the branch name replaces `#` with `-` (e.g. `feat/PROJECT-123-task-title`)
4. Verify the worktree directory path has no unsafe characters
5. Also test manual worktree creation with a branch name containing special chars

## Checklist

- [x] Code follows project conventions (single quotes, no semicolons, 2-space indent)
- [x] TypeScript compiles without errors
- [x] svelte-check passes
- [x] ESLint passes
- [ ] Tested manually in the app