### PR TITLE
feat(window): restore window position, size, and state across restarts

### DIFF
--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -9,6 +9,7 @@ import type { AgentSessionManager } from './agents/AgentSessionManager'
 import type { BrowserManager } from './browser/BrowserManager'
 import { TmuxManager } from './pty/TmuxManager'
 import { isSafeExternalUrl } from './security/validateUrl'
+import type { WindowBounds, WindowConfig, WindowState } from './windowBounds'
 
 export class WindowManager {
   private windows = new Map<number, BrowserWindow>()
@@ -49,10 +50,19 @@ export class WindowManager {
     this.windowDisposeCallback = cb
   }
 
-  createWindow(): BrowserWindow {
+  createWindow(options?: { bounds?: WindowBounds; windowState?: WindowState }): BrowserWindow {
+    const sizeDefaults = { width: 1200, height: 800 }
+    const boundsOpts = options?.bounds
+      ? {
+          x: options.bounds.x,
+          y: options.bounds.y,
+          width: options.bounds.width,
+          height: options.bounds.height,
+        }
+      : sizeDefaults
+
     const win = new BrowserWindow({
-      width: 1200,
-      height: 800,
+      ...boundsOpts,
       minWidth: 600,
       minHeight: 400,
       show: false,
@@ -95,6 +105,8 @@ export class WindowManager {
     })
 
     win.on('ready-to-show', () => {
+      if (options?.windowState === 'maximized') win.maximize()
+      else if (options?.windowState === 'fullscreen') win.setFullScreen(true)
       if (!process.env.CANOPY_E2E || app.isPackaged) win.show()
     })
 
@@ -207,14 +219,21 @@ export class WindowManager {
   }
 
   /** Returns one entry per window, each containing all project paths for that window */
-  getAllWindowConfigs(): Array<{ paths: string[]; activeWorktreePath?: string }> {
-    const configs: Array<{ paths: string[]; activeWorktreePath?: string }> = []
+  getAllWindowConfigs(): WindowConfig[] {
+    const configs: WindowConfig[] = []
     for (const [wcId, paths] of this.workspacePaths) {
       const win = this.windows.get(wcId)
       if (win && !win.isDestroyed() && paths.size > 0) {
+        const isMax = win.isMaximized()
+        const isFs = win.isFullScreen()
+        const bounds = isMax || isFs ? win.getNormalBounds() : win.getBounds()
+        const windowState: WindowState = isFs ? 'fullscreen' : isMax ? 'maximized' : 'normal'
+
         configs.push({
           paths: [...paths],
           activeWorktreePath: this.activeWorktreePaths.get(wcId),
+          bounds,
+          windowState,
         })
       }
     }
@@ -274,6 +293,14 @@ export class WindowManager {
       if (!win.isDestroyed()) result.push(win)
     }
     return result
+  }
+
+  getLastFocusedBounds(): WindowBounds | null {
+    const focused = BrowserWindow.getFocusedWindow()
+    if (focused && !focused.isDestroyed()) return focused.getBounds()
+    const allWins = this.getAllWindows()
+    if (allWins.length > 0) return allWins[allWins.length - 1].getBounds()
+    return null
   }
 
   onAllWindowsClosed(callback: () => void): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,6 +27,8 @@ import { GitHubService } from './github/GitHubService'
 import semver from 'semver'
 import { isSafeExternalUrl } from './security/validateUrl'
 import { fetchChangelogRange, resolveUpdateChannel } from './changelog/fetchChangelog'
+import { validateBounds, cascadeBounds } from './windowBounds'
+import type { WindowConfig } from './windowBounds'
 import { performance } from 'perf_hooks'
 
 const PERF = process.env.CANOPY_PERF === '1'
@@ -250,7 +252,10 @@ function buildAppMenu(): void {
         {
           label: 'New Window',
           accelerator: 'CmdOrCtrl+Shift+N',
-          click: () => windowManager.createWindow(),
+          click: () =>
+            windowManager.createWindow({
+              bounds: cascadeBounds(windowManager.getLastFocusedBounds()),
+            }),
         },
         { type: 'separator' },
         ...(!isMac
@@ -622,14 +627,11 @@ app.whenReady().then(async () => {
   const reopenPref = preferencesStore.get('reopenLastWorkspace')
   if (reopenPref !== 'false') {
     const configsJson = preferencesStore.get('openWindowConfigs')
-    let windowConfigs: Array<{ paths: string[]; activeWorktreePath?: string }> = []
+    let windowConfigs: WindowConfig[] = []
 
     if (configsJson) {
       try {
-        windowConfigs = JSON.parse(configsJson) as Array<{
-          paths: string[]
-          activeWorktreePath?: string
-        }>
+        windowConfigs = JSON.parse(configsJson) as WindowConfig[]
       } catch {
         // Invalid JSON
       }
@@ -663,7 +665,11 @@ app.whenReady().then(async () => {
 
     if (windowConfigs.length > 0) {
       for (const config of windowConfigs) {
-        const win = windowManager.createWindow()
+        const bounds = config.bounds ? validateBounds(config.bounds) : undefined
+        const win = windowManager.createWindow({
+          bounds,
+          windowState: config.windowState,
+        })
         win.once('ready-to-show', () => {
           win.webContents.send('workspace:restoreWindow', {
             paths: config.paths,
@@ -723,12 +729,13 @@ app.whenReady().then(async () => {
     if (url) {
       handleCanopyUrl(url)
     } else {
-      windowManager.createWindow()
+      windowManager.createWindow({ bounds: cascadeBounds(windowManager.getLastFocusedBounds()) })
     }
   })
 
   app.on('activate', function () {
-    if (BrowserWindow.getAllWindows().length === 0) windowManager.createWindow()
+    if (BrowserWindow.getAllWindows().length === 0)
+      windowManager.createWindow({ bounds: cascadeBounds(windowManager.getLastFocusedBounds()) })
   })
 })
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -31,6 +31,7 @@ import type { RepoConfigManager } from '../taskTracker/RepoConfigManager'
 import type { KeychainTokenStore } from '../taskTracker/KeychainTokenStore'
 import type { TaskTrackerProvider, TrackerTask } from '../taskTracker/types'
 import { taskTrackerErrorMessage } from '../taskTracker/errors'
+import { cascadeBounds } from '../windowBounds'
 import { gitErrorMessage } from '../git/errors'
 
 function unwrapOrThrow<T, E>(result: Result<T, E>, toMessage: (e: E) => string): T {
@@ -453,7 +454,9 @@ export function registerIpcHandlers(
   // --- App: Multi-window ---
 
   ipcMain.handle('app:newWindow', () => {
-    windowManager.createWindow()
+    windowManager.createWindow({
+      bounds: cascadeBounds(windowManager.getLastFocusedBounds()),
+    })
   })
 
   ipcMain.handle('app:setWorkspacePath', (event, payload: { path: string }) => {

--- a/src/main/windowBounds.ts
+++ b/src/main/windowBounds.ts
@@ -1,0 +1,89 @@
+import { screen } from 'electron'
+
+export interface WindowBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export type WindowState = 'normal' | 'maximized' | 'fullscreen'
+
+export interface WindowConfig {
+  paths: string[]
+  activeWorktreePath?: string
+  bounds?: WindowBounds
+  windowState?: WindowState
+}
+
+const MIN_WIDTH = 600
+const MIN_HEIGHT = 400
+const MIN_VISIBLE_PX = 100
+const CASCADE_OFFSET = 30
+
+function computeOverlap(
+  a: { x: number; y: number; width: number; height: number },
+  b: { x: number; y: number; width: number; height: number },
+): { overlapX: number; overlapY: number } {
+  const overlapX = Math.max(0, Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x))
+  const overlapY = Math.max(0, Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y))
+  return { overlapX, overlapY }
+}
+
+function centerOnPrimary(width: number, height: number): WindowBounds {
+  const primary = screen.getPrimaryDisplay().workArea
+  const w = Math.min(width, primary.width)
+  const h = Math.min(height, primary.height)
+  return {
+    x: primary.x + Math.round((primary.width - w) / 2),
+    y: primary.y + Math.round((primary.height - h) / 2),
+    width: w,
+    height: h,
+  }
+}
+
+/** Validate saved bounds against current display layout. Returns usable bounds. */
+export function validateBounds(bounds: WindowBounds): WindowBounds {
+  const width = Math.max(bounds.width, MIN_WIDTH)
+  const height = Math.max(bounds.height, MIN_HEIGHT)
+  const candidate = { x: bounds.x, y: bounds.y, width, height }
+
+  const displays = screen.getAllDisplays()
+  for (const display of displays) {
+    const { overlapX, overlapY } = computeOverlap(candidate, display.workArea)
+    if (overlapX >= MIN_VISIBLE_PX && overlapY >= MIN_VISIBLE_PX) {
+      return candidate
+    }
+  }
+
+  return centerOnPrimary(width, height)
+}
+
+/** Compute cascaded bounds offset from the last focused window. */
+export function cascadeBounds(lastBounds: WindowBounds | null): WindowBounds | undefined {
+  if (!lastBounds) return undefined
+
+  const candidate: WindowBounds = {
+    x: lastBounds.x + CASCADE_OFFSET,
+    y: lastBounds.y + CASCADE_OFFSET,
+    width: lastBounds.width,
+    height: lastBounds.height,
+  }
+
+  const displays = screen.getAllDisplays()
+  for (const display of displays) {
+    const { overlapX, overlapY } = computeOverlap(candidate, display.workArea)
+    if (overlapX >= MIN_VISIBLE_PX && overlapY >= MIN_VISIBLE_PX) {
+      return candidate
+    }
+  }
+
+  // Cascaded position is off-screen — wrap to top-left of primary workArea
+  const primary = screen.getPrimaryDisplay().workArea
+  return {
+    x: primary.x,
+    y: primary.y,
+    width: Math.min(candidate.width, primary.width),
+    height: Math.min(candidate.height, primary.height),
+  }
+}


### PR DESCRIPTION
## What

Save and restore window bounds (x, y, width, height) and state (maximized, fullscreen) across app restarts. New windows cascade +30px from the last focused window instead of stacking on top.

## Why

Windows always opened at hardcoded 1200x800 centered, losing the user's layout on every restart. This is a standard desktop app expectation.

## How to test

1. Launch app, move and resize the window to a non-default position, quit, relaunch — window should restore exact position and size
2. Maximize the window, quit, relaunch — should open maximized with correct underlying bounds
3. Enter fullscreen, quit, relaunch — should open in fullscreen
4. Open 2+ windows at different positions, quit, relaunch — each restores independently
5. Save with external monitor, disconnect it, relaunch — window centers on primary display
6. Press Cmd+Shift+N (New Window) — new window should appear offset +30px from current
7. Verify first launch (no saved configs) still opens default centered 1200x800

## Checklist

- [x] Typechecks pass (`npm run typecheck`)
- [x] Svelte check passes (`npm run svelte-check`)
- [x] No UI changes (main process only)
- [x] Backward compatible with existing `openWindowConfigs` data (new fields are optional)
- [ ] Manual QA on macOS
- [ ] Manual QA on Windows
- [ ] Manual QA on Linux