### PR TITLE
fix(diff): sticky header, untracked files, scroll and layout issues

### DIFF
--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -20,6 +20,42 @@ function gitCall<T>(command: string, promise: Promise<T>): ResultAsync<T, GitErr
   return fromExternalCall(promise, (e) => gitErr(command, e))
 }
 
+function buildUntrackedDiffFile(
+  repoRoot: string,
+  filePath: string,
+): ResultAsync<DiffFile, GitError> {
+  return fromExternalCall(readFile(join(repoRoot, filePath), 'utf-8'), (e) =>
+    gitErr('readFile', e),
+  ).map((content) => {
+    const lines = content.split('\n')
+    if (lines[lines.length - 1] === '') lines.pop()
+    const changes = lines.map((line, i) => ({
+      type: 'add' as const,
+      content: line,
+      newLine: i + 1,
+    }))
+    return {
+      path: filePath,
+      status: 'added' as const,
+      hunks:
+        changes.length > 0
+          ? [
+              {
+                oldStart: 0,
+                oldLines: 0,
+                newStart: 1,
+                newLines: changes.length,
+                header: `@@ -0,0 +1,${changes.length} @@`,
+                changes,
+              },
+            ]
+          : [],
+      additions: changes.length,
+      deletions: 0,
+    }
+  })
+}
+
 export interface GitCommitResult {
   hash: string
   summary: string
@@ -359,39 +395,12 @@ export class GitRepository {
 
         return fromExternalCall(
           Promise.all(
-            files.map(async (file): Promise<DiffFile | null> => {
-              try {
-                const content = await readFile(join(repoRoot, file), 'utf-8')
-                const lines = content.split('\n')
-                if (lines[lines.length - 1] === '') lines.pop()
-                const changes = lines.map((line, i) => ({
-                  type: 'add' as const,
-                  content: line,
-                  newLine: i + 1,
-                }))
-                return {
-                  path: file,
-                  status: 'added' as const,
-                  hunks:
-                    changes.length > 0
-                      ? [
-                          {
-                            oldStart: 0,
-                            oldLines: 0,
-                            newStart: 1,
-                            newLines: changes.length,
-                            header: `@@ -0,0 +1,${changes.length} @@`,
-                            changes,
-                          },
-                        ]
-                      : [],
-                  additions: changes.length,
-                  deletions: 0,
-                }
-              } catch {
-                return null
-              }
-            }),
+            files.map((file) =>
+              buildUntrackedDiffFile(repoRoot, file).match(
+                (f) => f as DiffFile | null,
+                () => null,
+              ),
+            ),
           ).then((results) => results.filter((f): f is DiffFile => f !== null)),
           (e) => gitErr('ls-files', e),
         ).map((untrackedDiffFiles) => ({
@@ -414,38 +423,7 @@ export class GitRepository {
         if (raw.trim()) return okAsync<ParsedDiff, GitError>(parseDiff(raw))
 
         // No tracked diff — file may be untracked, read its content directly
-        return fromExternalCall(
-          readFile(join(repoRoot, filePath), 'utf-8').then((content) => {
-            const lines = content.split('\n')
-            if (lines[lines.length - 1] === '') lines.pop()
-            const changes = lines.map((line, i) => ({
-              type: 'add' as const,
-              content: line,
-              newLine: i + 1,
-            }))
-            const file: DiffFile = {
-              path: filePath,
-              status: 'added',
-              hunks:
-                changes.length > 0
-                  ? [
-                      {
-                        oldStart: 0,
-                        oldLines: 0,
-                        newStart: 1,
-                        newLines: changes.length,
-                        header: `@@ -0,0 +1,${changes.length} @@`,
-                        changes,
-                      },
-                    ]
-                  : [],
-              additions: changes.length,
-              deletions: 0,
-            }
-            return { files: [file] } as ParsedDiff
-          }),
-          (e) => gitErr('diff', e),
-        )
+        return buildUntrackedDiffFile(repoRoot, filePath).map((f) => ({ files: [f] }))
       })
   }
 

--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -1,7 +1,9 @@
 import { ok, err, okAsync, type Result, type ResultAsync } from 'neverthrow'
 import simpleGit from 'simple-git'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
 import type { GitError } from './errors'
-import type { ParsedDiff } from './types'
+import type { ParsedDiff, DiffFile } from './types'
 import { parseDiff } from './diffParser'
 import { fromExternalCall, errorMessage } from '../errors'
 
@@ -336,14 +338,67 @@ export class GitRepository {
 
   static getDiffParsed(repoRoot: string): ResultAsync<ParsedDiff, GitError> {
     const git = simpleGit(repoRoot)
-    return gitCall('diff', git.diff(['HEAD']))
+
+    const trackedDiff = gitCall('diff', git.diff(['HEAD']))
       .orElse((e) => {
-        if (e._tag === 'GitCommandFailed') {
-          return gitCall('diff', git.diff())
-        }
+        if (e._tag === 'GitCommandFailed') return gitCall('diff', git.diff())
         return okAsync<string, GitError>('')
       })
       .map((raw) => parseDiff(raw))
+
+    const untrackedFiles = gitCall(
+      'ls-files',
+      git.raw(['ls-files', '--others', '--exclude-standard']),
+    )
+      .map((raw) => raw.trim().split('\n').filter(Boolean))
+      .orElse(() => okAsync<string[], GitError>([]))
+
+    return trackedDiff.andThen((parsed) =>
+      untrackedFiles.andThen((files) => {
+        if (files.length === 0) return okAsync<ParsedDiff, GitError>(parsed)
+
+        return fromExternalCall(
+          Promise.all(
+            files.map(async (file): Promise<DiffFile | null> => {
+              try {
+                const content = await readFile(join(repoRoot, file), 'utf-8')
+                const lines = content.split('\n')
+                if (lines[lines.length - 1] === '') lines.pop()
+                const changes = lines.map((line, i) => ({
+                  type: 'add' as const,
+                  content: line,
+                  newLine: i + 1,
+                }))
+                return {
+                  path: file,
+                  status: 'added' as const,
+                  hunks:
+                    changes.length > 0
+                      ? [
+                          {
+                            oldStart: 0,
+                            oldLines: 0,
+                            newStart: 1,
+                            newLines: changes.length,
+                            header: `@@ -0,0 +1,${changes.length} @@`,
+                            changes,
+                          },
+                        ]
+                      : [],
+                  additions: changes.length,
+                  deletions: 0,
+                }
+              } catch {
+                return null
+              }
+            }),
+          ).then((results) => results.filter((f): f is DiffFile => f !== null)),
+          (e) => gitErr('ls-files', e),
+        ).map((untrackedDiffFiles) => ({
+          files: [...parsed.files, ...untrackedDiffFiles],
+        }))
+      }),
+    )
   }
 
   static getFileDiff(repoRoot: string, filePath: string): ResultAsync<ParsedDiff, GitError> {
@@ -355,7 +410,43 @@ export class GitRepository {
         }
         return okAsync<string, GitError>('')
       })
-      .map((raw) => parseDiff(raw))
+      .andThen((raw) => {
+        if (raw.trim()) return okAsync<ParsedDiff, GitError>(parseDiff(raw))
+
+        // No tracked diff — file may be untracked, read its content directly
+        return fromExternalCall(
+          readFile(join(repoRoot, filePath), 'utf-8').then((content) => {
+            const lines = content.split('\n')
+            if (lines[lines.length - 1] === '') lines.pop()
+            const changes = lines.map((line, i) => ({
+              type: 'add' as const,
+              content: line,
+              newLine: i + 1,
+            }))
+            const file: DiffFile = {
+              path: filePath,
+              status: 'added',
+              hunks:
+                changes.length > 0
+                  ? [
+                      {
+                        oldStart: 0,
+                        oldLines: 0,
+                        newStart: 1,
+                        newLines: changes.length,
+                        header: `@@ -0,0 +1,${changes.length} @@`,
+                        changes,
+                      },
+                    ]
+                  : [],
+              additions: changes.length,
+              deletions: 0,
+            }
+            return { files: [file] } as ParsedDiff
+          }),
+          (e) => gitErr('diff', e),
+        )
+      })
   }
 
   static stageFile(repoRoot: string, filePath: string): ResultAsync<void, GitError> {

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -700,7 +700,7 @@
   }
 
   .file-header:hover {
-    background: color-mix(in srgb, white 8%, var(--c-bg-elevated));
+    background: color-mix(in srgb, var(--c-text) 8%, var(--c-bg-elevated));
   }
 
   .chevron {

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -102,6 +102,9 @@
               // IntersectionObserverEntry.target is always Element, safe to cast
               const path = (entry.target as HTMLElement).dataset.filepath
               if (path) {
+                const target = workspaceState.diffScrollTarget
+                // During programmatic scroll, only accept the target file
+                if (target && path !== target.path) continue
                 workspaceState.diffScrollTarget = null
                 workspaceState.diffVisibleFile = path
               }
@@ -418,129 +421,135 @@
     {:else if files.length === 0}
       <div class="empty-state">No uncommitted changes</div>
     {:else}
-      {#each files as file, fileIndex (file.path)}
-        <div
-          class="file-section"
-          class:file-focused={focusedFileIndex === fileIndex}
-          id="diff-file-{file.path}"
-          data-filepath={file.path}
-          onpointerenter={() => (hoveredFilePath = file.path)}
-          onpointerleave={() => (hoveredFilePath = null)}
-        >
-          <div class="file-header" onclick={() => toggleCollapse(file.path)}>
-            <span class="chevron" class:chevron-open={!collapsedFiles.has(file.path)}>
-              <ChevronRight size={12} />
-            </span>
-            <span class="file-status {statusClass(file.status)}">{statusLabel(file.status)}</span>
-            <span class="file-path" title={file.path}>{file.path}</span>
-            <span class="stats-bar">
-              {#if file.additions > 0}
-                <span class="stats-bar-add" style="width: {statsBarAddWidth(file)}px"></span>
+      <div class="diff-scroll-content">
+        {#each files as file, fileIndex (file.path)}
+          <div
+            class="file-section"
+            class:file-focused={focusedFileIndex === fileIndex}
+            id="diff-file-{file.path}"
+            data-filepath={file.path}
+            onpointerenter={() => (hoveredFilePath = file.path)}
+            onpointerleave={() => (hoveredFilePath = null)}
+          >
+            <div class="file-header" onclick={() => toggleCollapse(file.path)}>
+              <span class="chevron" class:chevron-open={!collapsedFiles.has(file.path)}>
+                <ChevronRight size={12} />
+              </span>
+              <span class="file-status {statusClass(file.status)}">{statusLabel(file.status)}</span>
+              <span class="file-path" title={file.path}>{file.path}</span>
+              <span class="stats-bar">
+                {#if file.additions > 0}
+                  <span class="stats-bar-add" style="width: {statsBarAddWidth(file)}px"></span>
+                {/if}
+                {#if file.deletions > 0}
+                  <span class="stats-bar-del" style="width: {statsBarDelWidth(file)}px"></span>
+                {/if}
+              </span>
+              <span class="file-stats">
+                <span class="stat-add">+{file.additions}</span>
+                <span class="stat-del">&minus;{file.deletions}</span>
+              </span>
+              {#if hoveredFilePath === file.path}
+                <button
+                  class="copy-diff-btn"
+                  title="Copy diff"
+                  aria-label="Copy diff to clipboard"
+                  onclick={(e) => {
+                    e.stopPropagation()
+                    copyDiff(file)
+                  }}
+                >
+                  <Copy size={12} />
+                </button>
               {/if}
-              {#if file.deletions > 0}
-                <span class="stats-bar-del" style="width: {statsBarDelWidth(file)}px"></span>
-              {/if}
-            </span>
-            <span class="file-stats">
-              <span class="stat-add">+{file.additions}</span>
-              <span class="stat-del">&minus;{file.deletions}</span>
-            </span>
-            {#if hoveredFilePath === file.path}
-              <button
-                class="copy-diff-btn"
-                title="Copy diff"
-                aria-label="Copy diff to clipboard"
-                onclick={(e) => {
-                  e.stopPropagation()
-                  copyDiff(file)
-                }}
-              >
-                <Copy size={12} />
-              </button>
-            {/if}
-          </div>
+            </div>
 
-          {#if !collapsedFiles.has(file.path)}
-            {#if file.hunks.length === 0}
-              <div class="no-hunks">Binary file or empty diff</div>
-            {:else}
-              {#each file.hunks as hunk (hunk.header)}
-                <div class="hunk">
-                  <div class="hunk-header">
-                    <span class="gutter old-gutter"></span>
-                    <span class="gutter new-gutter"></span>
-                    <span class="hunk-text">{hunk.header}</span>
-                  </div>
-                  {#each hunk.changes as change, i (`${i}-${change.type}`)}
-                    <div
-                      class="diff-line {change.type}"
-                      class:search-match={lineMatchesSearch(change.content)}
-                    >
-                      {#if hasAgent}
-                        <button
-                          class="comment-trigger"
-                          title="Add review comment"
-                          aria-label="Add review comment"
-                          onclick={() =>
-                            openComment(file.path, `${hunk.header}:${i}`, getLineNum(change))}
-                          >+</button
-                        >
-                      {/if}
-                      <span class="gutter old-gutter"
-                        >{change.type !== 'add' && change.oldLine != null
-                          ? change.oldLine
-                          : ''}</span
-                      >
-                      <span class="gutter new-gutter"
-                        >{change.type !== 'delete' && change.newLine != null
-                          ? change.newLine
-                          : ''}</span
-                      >
-                      <span class="line-prefix"
-                        >{change.type === 'add' ? '+' : change.type === 'delete' ? '-' : ' '}</span
-                      >
-                      {#if searchQuery && lineMatchesSearch(change.content)}
-                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                        <span class="line-content">{@html highlightMatch(change.content)}</span>
-                      {:else}
-                        <span class="line-content">{change.content}</span>
-                      {/if}
+            {#if !collapsedFiles.has(file.path)}
+              {#if file.hunks.length === 0}
+                <div class="no-hunks">Binary file or empty diff</div>
+              {:else}
+                {#each file.hunks as hunk (hunk.header)}
+                  <div class="hunk">
+                    <div class="hunk-header">
+                      <span class="gutter old-gutter"></span>
+                      <span class="gutter new-gutter"></span>
+                      <span class="hunk-text">{hunk.header}</span>
                     </div>
-                    {#if commentKey === `${file.path}:${hunk.header}:${i}`}
-                      <div class="comment-form">
-                        <textarea
-                          class="comment-input"
-                          placeholder="Comment for agent — {file.path}:{getLineNum(change)}"
-                          bind:value={commentText}
-                          onkeydown={(e) => {
-                            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) sendComment()
-                            if (e.key === 'Escape') closeComment()
-                          }}
-                        ></textarea>
-                        <div class="comment-footer">
-                          <span class="comment-hint">
-                            {navigator.userAgent.includes('Mac') ? '⌘' : 'Ctrl'}+Enter to send
-                          </span>
-                          <div class="comment-actions">
-                            <button class="comment-cancel" onclick={closeComment}>Cancel</button>
-                            <button
-                              class="comment-send"
-                              onclick={sendComment}
-                              disabled={!commentText.trim()}
-                            >
-                              Send
-                            </button>
+                    {#each hunk.changes as change, i (`${i}-${change.type}`)}
+                      <div
+                        class="diff-line {change.type}"
+                        class:search-match={lineMatchesSearch(change.content)}
+                      >
+                        {#if hasAgent}
+                          <button
+                            class="comment-trigger"
+                            title="Add review comment"
+                            aria-label="Add review comment"
+                            onclick={() =>
+                              openComment(file.path, `${hunk.header}:${i}`, getLineNum(change))}
+                            >+</button
+                          >
+                        {/if}
+                        <span class="gutter old-gutter"
+                          >{change.type !== 'add' && change.oldLine != null
+                            ? change.oldLine
+                            : ''}</span
+                        >
+                        <span class="gutter new-gutter"
+                          >{change.type !== 'delete' && change.newLine != null
+                            ? change.newLine
+                            : ''}</span
+                        >
+                        <span class="line-prefix"
+                          >{change.type === 'add'
+                            ? '+'
+                            : change.type === 'delete'
+                              ? '-'
+                              : ' '}</span
+                        >
+                        {#if searchQuery && lineMatchesSearch(change.content)}
+                          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                          <span class="line-content">{@html highlightMatch(change.content)}</span>
+                        {:else}
+                          <span class="line-content">{change.content}</span>
+                        {/if}
+                      </div>
+                      {#if commentKey === `${file.path}:${hunk.header}:${i}`}
+                        <div class="comment-form">
+                          <textarea
+                            class="comment-input"
+                            placeholder="Comment for agent — {file.path}:{getLineNum(change)}"
+                            bind:value={commentText}
+                            onkeydown={(e) => {
+                              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) sendComment()
+                              if (e.key === 'Escape') closeComment()
+                            }}
+                          ></textarea>
+                          <div class="comment-footer">
+                            <span class="comment-hint">
+                              {navigator.userAgent.includes('Mac') ? '⌘' : 'Ctrl'}+Enter to send
+                            </span>
+                            <div class="comment-actions">
+                              <button class="comment-cancel" onclick={closeComment}>Cancel</button>
+                              <button
+                                class="comment-send"
+                                onclick={sendComment}
+                                disabled={!commentText.trim()}
+                              >
+                                Send
+                              </button>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    {/if}
-                  {/each}
-                </div>
-              {/each}
+                      {/if}
+                    {/each}
+                  </div>
+                {/each}
+              {/if}
             {/if}
-          {/if}
-        </div>
-      {/each}
+          </div>
+        {/each}
+      </div>
     {/if}
   </div>
 </div>
@@ -663,6 +672,11 @@
     line-height: 1.5;
   }
 
+  .diff-scroll-content {
+    width: fit-content;
+    min-width: 100%;
+  }
+
   .file-section {
     border-bottom: 1px solid var(--c-border-subtle);
   }
@@ -686,7 +700,7 @@
   }
 
   .file-header:hover {
-    background: var(--c-active);
+    background: color-mix(in srgb, white 8%, var(--c-bg-elevated));
   }
 
   .chevron {


### PR DESCRIPTION
## What
Fixes four issues in the Diff view and Changes panel:
- Sticky file header becoming transparent on hover (revealing code underneath)
- Untracked files not appearing in Changes panel
- Wrong file highlight in Changes panel after click-to-scroll
- Empty space on right side of diff lines when window is narrow

## Why
Users reported visual glitches and missing files in the Changes panel compared to tools like LazyGit. The `git diff HEAD` command only shows tracked files, and `var(--c-active)` is `rgba(255,255,255,0.08)` which is nearly transparent.

## How to test
1. Create some untracked files and modify tracked files — verify all appear in Changes with `+` (Added) status
2. Hover over a sticky file header while scrolled down — should remain opaque, no code bleeding through
3. Click a second file in Changes panel — highlight should move to that file, not stay on the first
4. Shrink the window horizontally — diff line backgrounds (green/red) should extend full scrollable width with no empty gaps

## Checklist
- [x] Code compiles without errors (`typecheck` + `svelte-check` pass)
- [x] No new lint warnings
- [ ] Tests added/updated
- [ ] Docs updated