### PR TITLE
feat(window): include active tab name in window title

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -3069,36 +3069,6 @@ MIT
 
 The following npm package may be included in this product:
 
- - readdirp@5.0.0
-
-This package contains the following license:
-
-MIT License
-
-Copyright (c) 2012-2019 Thorsten Lorenz, Paul Miller (https://paulmillr.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------------
-
-The following npm package may be included in this product:
-
  - acorn@8.16.0
 
 This package contains the following license:
@@ -4253,36 +4223,6 @@ BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
 ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
------------
-
-The following npm package may be included in this product:
-
- - chokidar@5.0.0
-
-This package contains the following license:
-
-The MIT License (MIT)
-
-Copyright (c) 2012 Paul Miller (https://paulmillr.com), Elan Shanker
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
 -----------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3261,9 +3261,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3283,9 +3280,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3307,9 +3301,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3329,9 +3320,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3353,9 +3341,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3375,9 +3360,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/renderer/src/components/Titlebar.svelte
+++ b/src/renderer/src/components/Titlebar.svelte
@@ -1,13 +1,24 @@
 <script lang="ts">
   import { workspaceState } from '../lib/stores/workspace.svelte'
+  import { tabsByWorktree, activeTabId, getTabDisplayName } from '../lib/stores/tabs.svelte'
   import TitlebarMenu from './TitlebarMenu.svelte'
 
   const isMac = navigator.userAgent.includes('Mac')
+
+  let activeTabName = $derived.by(() => {
+    const path = workspaceState.selectedWorktreePath
+    if (!path) return null
+    const tabId = activeTabId[path]
+    if (!tabId) return null
+    const tab = (tabsByWorktree[path] ?? []).find((t) => t.id === tabId)
+    return tab ? getTabDisplayName(tab) : null
+  })
 
   $effect(() => {
     if (workspaceState.workspace) {
       let title = workspaceState.workspace.name
       if (workspaceState.branch) title += ` — ${workspaceState.branch}`
+      if (activeTabName) title += ` — ${activeTabName}`
       if (workspaceState.isDirty) title += ' *'
       document.title = title
     } else {
@@ -27,6 +38,9 @@
       {workspaceState.workspace.name}
       {#if workspaceState.branch}
         <span class="branch">{workspaceState.branch}</span>
+      {/if}
+      {#if activeTabName}
+        <span class="tab-name">{activeTabName}</span>
       {/if}
       {#if workspaceState.isDirty}
         <span class="dirty">*</span>
@@ -80,6 +94,15 @@
   }
 
   .branch::before {
+    content: '\2014\00a0';
+  }
+
+  .tab-name {
+    color: var(--c-text-muted);
+    margin-left: 6px;
+  }
+
+  .tab-name::before {
     content: '\2014\00a0';
   }
 


### PR DESCRIPTION
## What
Appends the active tab's display name to the window title, producing: `<project> — <branch> — <tab name>`.

## Why
Time tracking apps (e.g., Toggl, RescueTime) read window titles to auto-categorize activity. Adding the active tab name gives these tools richer context about what's happening inside Canopy.

## How to test
1. `npm run dev`
2. Open a workspace — title should show `<project> — <branch>`
3. Open/switch tabs — title should update with the tab name (e.g., `— Shell`, `— Claude`)
4. Close all tabs — tab name segment disappears
5. Verify the visual titlebar and `document.title` stay in sync

## Screenshots / recordings
UI change: new tab name segment in the titlebar, styled identically to the branch segment.

## Checklist
- [x] Typechecks pass (`npm run typecheck`)
- [x] No new dependencies
- [x] Follows existing code patterns (Svelte 5 runes, CSS variables)
- [ ] Tests added/updated