### PR TITLE
fix(git,ui): resilient git detection and full-width preference selects

### DIFF
--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -119,6 +119,7 @@ export class GitRepository {
                 })
                 .andThen((isDirty) =>
                   GitRepository.getAheadBehind(repoRoot)
+                    // No warn — getAheadBehind fails routinely when there is no upstream
                     .orElse(() => okAsync<{ ahead: number; behind: number } | null, GitError>(null))
                     .map((aheadBehind) => ({
                       isGitRepo: true as const,

--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -98,14 +98,25 @@ export class GitRepository {
       path: dirPath,
     })).andThen((raw) => {
       const repoRoot = raw.trim()
+      // Sub-commands use orElse so failures (empty repo, no upstream, etc.)
+      // don't cause detect() to report isGitRepo: false
       return GitRepository.getBranch(repoRoot)
-        .orElse(() => okAsync<string | null, GitError>(null))
+        .orElse((e) => {
+          console.warn(`[git] getBranch failed for "${repoRoot}":`, e)
+          return okAsync<string | null, GitError>(null)
+        })
         .andThen((branch) =>
           GitRepository.listWorktrees(repoRoot)
-            .orElse(() => okAsync<GitWorktreeInfo[], GitError>([]))
+            .orElse((e) => {
+              console.warn(`[git] listWorktrees failed for "${repoRoot}":`, e)
+              return okAsync<GitWorktreeInfo[], GitError>([])
+            })
             .andThen((worktrees) =>
               GitRepository.isDirty(repoRoot)
-                .orElse(() => okAsync<boolean, GitError>(false))
+                .orElse((e) => {
+                  console.warn(`[git] isDirty failed for "${repoRoot}":`, e)
+                  return okAsync<boolean, GitError>(false)
+                })
                 .andThen((isDirty) =>
                   GitRepository.getAheadBehind(repoRoot)
                     .orElse(() => okAsync<{ ahead: number; behind: number } | null, GitError>(null))

--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -98,20 +98,28 @@ export class GitRepository {
       path: dirPath,
     })).andThen((raw) => {
       const repoRoot = raw.trim()
-      return GitRepository.getBranch(repoRoot).andThen((branch) =>
-        GitRepository.listWorktrees(repoRoot).andThen((worktrees) =>
-          GitRepository.isDirty(repoRoot).andThen((isDirty) =>
-            GitRepository.getAheadBehind(repoRoot).map((aheadBehind) => ({
-              isGitRepo: true as const,
-              repoRoot,
-              branch,
-              worktrees,
-              isDirty,
-              aheadBehind,
-            })),
-          ),
-        ),
-      )
+      return GitRepository.getBranch(repoRoot)
+        .orElse(() => okAsync<string | null, GitError>(null))
+        .andThen((branch) =>
+          GitRepository.listWorktrees(repoRoot)
+            .orElse(() => okAsync<GitWorktreeInfo[], GitError>([]))
+            .andThen((worktrees) =>
+              GitRepository.isDirty(repoRoot)
+                .orElse(() => okAsync<boolean, GitError>(false))
+                .andThen((isDirty) =>
+                  GitRepository.getAheadBehind(repoRoot)
+                    .orElse(() => okAsync<{ ahead: number; behind: number } | null, GitError>(null))
+                    .map((aheadBehind) => ({
+                      isGitRepo: true as const,
+                      repoRoot,
+                      branch,
+                      worktrees,
+                      isDirty,
+                      aheadBehind,
+                    })),
+                ),
+            ),
+        )
     })
   }
 

--- a/src/renderer/src/components/preferences/TaskBranchNamingPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskBranchNamingPrefs.svelte
@@ -118,7 +118,6 @@
           templateInput = branchTemplate.template
           updatePreview()
         }}
-        maxWidth="240px"
       />
     </div>
     {#if templateScope !== 'default' && !config?.boardOverrides[templateScope]?.branchTemplate}
@@ -178,13 +177,14 @@
   .select-row {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 8px;
     font-size: 13px;
   }
 
   .select-label {
     color: var(--c-text-secondary);
-    min-width: 110px;
+    width: 90px;
+    flex-shrink: 0;
   }
 
   .field-label {
@@ -220,13 +220,14 @@
   .preview-row {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 8px;
   }
 
   .preview-label {
     font-size: 12px;
     color: var(--c-text-secondary);
-    min-width: 110px;
+    width: 90px;
+    flex-shrink: 0;
   }
 
   .preview-value {

--- a/src/renderer/src/components/preferences/TaskPRNamingPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskPRNamingPrefs.svelte
@@ -107,7 +107,6 @@
           prScope = v
           initialized = false
         }}
-        maxWidth="240px"
       />
     </div>
   {/if}
@@ -171,13 +170,14 @@
   .select-row {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 8px;
     font-size: 13px;
   }
 
   .select-label {
     color: var(--c-text-secondary);
-    min-width: 110px;
+    width: 90px;
+    flex-shrink: 0;
   }
 
   .field {

--- a/src/renderer/src/components/shared/CustomSelect.svelte
+++ b/src/renderer/src/components/shared/CustomSelect.svelte
@@ -20,7 +20,7 @@
     maxWidth?: string
   }
 
-  let { value, options, groups, onchange, id, maxWidth = '240px' }: Props = $props()
+  let { value, options, groups, onchange, id, maxWidth = 'none' }: Props = $props()
 
   let open = $state(false)
   let focusedIndex = $state(-1)


### PR DESCRIPTION
## What
Git repo detection no longer fails when sub-commands error, and CustomSelect components in preferences now stretch to full width matching inputs.

## Why
`GitRepository.detect()` chained sub-commands (`getBranch`, `listWorktrees`, `isDirty`, `getAheadBehind`) with `andThen`, so if any failed (e.g. no upstream branch), the entire detection returned `isGitRepo: false` — showing "init" instead of recognizing the repo. Preference selects were capped at 240px while inputs were full width, causing visual misalignment.

## How to test
1. Open a repo with no upstream tracking branch → should detect as git repo (no "init" button)
2. Open Preferences → Task Tracker → verify selects are full width and aligned with inputs/labels
3. Check other preference tabs (Appearance, General) for select width consistency

## Screenshots / recordings
_Before_: Select inputs capped at 240px, misaligned with text inputs
_After_: Selects stretch to full width, labels aligned at consistent 90px

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run svelte-check` passes
- [x] No UI regressions in other preference tabs
- [ ] Manual QA on macOS