### PR TITLE
feat(ci): auto-track claude code releases for compatibility

### DIFF
--- a/.github/claude-code-version.json
+++ b/.github/claude-code-version.json
@@ -1,0 +1,4 @@
+{
+  "lastCheckedVersion": "v2.1.97",
+  "lastCheckedAt": "2026-04-09T00:00:00Z"
+}

--- a/.github/prompts/claude-code-compat.md
+++ b/.github/prompts/claude-code-compat.md
@@ -1,0 +1,149 @@
+# Claude Code Compatibility Analysis
+
+You are analyzing new Claude Code CLI releases to determine whether the **Canopy** desktop application (Electron + Svelte 5) needs code changes to stay compatible or to adopt new features.
+
+## Context
+
+The workflow has provided these values at the top of the prompt:
+
+- **FROM_VERSION** — the last version we checked (exclusive lower bound)
+- **TO_VERSION** — the latest available release (inclusive upper bound)
+- **EXISTING_PR** — PR number if a compatibility PR is already open (empty if none)
+- **REPO** — this repository (owner/repo format)
+
+The **changelog repo** is `marckrenn/claude-code-changelog` — an unofficial archive of Claude Code system prompts, flags, and metadata.
+
+The **target branch** for PRs is `chore/claude-code-compat`.
+
+Release notes for each new version are appended below under `## Release Notes`.
+
+## Your task
+
+### 1. Understand the releases
+
+Read the release notes provided below. For each version, identify:
+
+- New or removed **feature flags**
+- Changed or removed **environment variables** and **config keys**
+- New **hooks**, **permission models**, or **tool capabilities**
+- **System prompt changes** that affect how Claude Code behaves
+- **Bug fixes** that may affect how we invoke Claude Code
+- **SDK changes** related to `@anthropic-ai/claude-agent-sdk`
+
+### 2. Fetch detailed diffs (self-serve)
+
+For deeper analysis, fetch diffs from the changelog repo yourself using the FROM_VERSION and TO_VERSION values from the prompt header:
+
+```bash
+# Compare two tags to see all file changes
+gh api repos/marckrenn/claude-code-changelog/compare/{FROM_VERSION}...{TO_VERSION} --jq '.files[] | "\(.filename) (\(.status))"'
+
+# Read a specific file at a given tag
+gh api repos/marckrenn/claude-code-changelog/contents/meta/flags.md?ref={TO_VERSION} --jq '.content' | base64 -d
+
+# Read metadata
+gh api repos/marckrenn/claude-code-changelog/contents/meta/metadata.md?ref={TO_VERSION} --jq '.content' | base64 -d
+```
+
+Focus on files under `meta/` (flags, metadata, CLI surface) and notable system prompt changes.
+
+### 3. Check SDK updates
+
+Check if a new `@anthropic-ai/claude-agent-sdk` version is available:
+
+```bash
+npm view @anthropic-ai/claude-agent-sdk versions --json
+```
+
+Cross-reference with what the changelog mentions. If a relevant update exists, bump the version in `package.json`.
+
+### 4. Scan the Canopy codebase
+
+**Known integration points** (start here):
+
+- `.github/workflows/` — Claude Code action configurations (`anthropics/claude-code-action@v1`), model args, allowed tools
+- `.github/prompts/` — prompt templates passed to Claude Code action
+- `.claude/` — harness settings (`settings.json`), skills
+- `src/main/changelog/` — changelog fetching module
+- `CLAUDE.md`, `AGENTS.md` — agent instruction files
+
+**Then discover more** — search broadly for additional references:
+
+```bash
+grep -r "claude" --include="*.ts" --include="*.yml" --include="*.md" --include="*.json" -l .
+grep -r "anthropic" --include="*.ts" --include="*.yml" --include="*.json" -l .
+grep -r "claude-code" -l .
+```
+
+### 5. Apply changes
+
+Be **proactive** — not just compatibility fixes but also:
+
+- Adopt new Claude Code features that benefit our workflows (new hooks, better permission models, improved tool specs)
+- Update `claude_args` if new CLI flags are available and useful
+- Update prompts if system prompt behavior changes affect our instructions
+- Update `CLAUDE.md` or `AGENTS.md` if new conventions or capabilities are relevant
+- Bump SDK version if appropriate
+
+For each change, make a **targeted, minimal edit**. Do not reformat or restructure code beyond what the change requires.
+
+### 6. Create or update the PR
+
+Use the FROM_VERSION, TO_VERSION, and EXISTING_PR values from the prompt header.
+
+**If no existing PR** (EXISTING_PR is empty):
+
+1. Create the branch: `git checkout -b chore/claude-code-compat`
+2. Commit changes with descriptive messages (one commit per logical change group, use `chore:` or `fix:` prefix)
+3. Push: `git push origin chore/claude-code-compat`
+4. Create PR targeting `next` with this structure:
+
+```
+Title: chore(deps): claude code compatibility update ({FROM_VERSION} → {TO_VERSION})
+
+Body:
+## Claude Code Compatibility Update
+
+### Versions analyzed
+[List each version analyzed]
+
+### Relevant changes
+[For each version: key changes that affected our codebase]
+
+### Modifications made
+[For each file changed: what was modified and why]
+
+### SDK changes
+[SDK version bump details, or "No SDK changes needed"]
+
+### Risk assessment
+[Low/Medium/High — explain any risks or breaking changes]
+```
+
+**If existing PR** (EXISTING_PR is a PR number):
+
+1. Checkout the existing branch: `git fetch origin chore/claude-code-compat && git checkout chore/claude-code-compat`
+2. Commit incremental changes
+3. Push: `git push origin chore/claude-code-compat`
+4. Update the PR title and description to cover the expanded version range using `gh pr edit`
+
+### 7. If no changes needed
+
+If after analysis you determine no code changes are required:
+
+1. Do NOT create a branch or PR
+2. Write a summary to `$GITHUB_STEP_SUMMARY`:
+
+```bash
+cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+## Claude Code Compatibility Check
+
+Analyzed versions: {FROM_VERSION} → {TO_VERSION}
+
+**No code changes needed.** The release changes do not affect Canopy's integration.
+EOF
+```
+
+## Tone
+
+Be precise and factual. State what you found, what you changed, and why. No filler or commentary beyond what is needed to explain each decision.

--- a/.github/workflows/claude-code-compat.yml
+++ b/.github/workflows/claude-code-compat.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: claude-code-compat
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check:
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -159,7 +158,7 @@ jobs:
           claude_args: |
             --model opus[1m]
             --effort max
-            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git checkout:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git status:*),Bash(git fetch:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh api:*),Bash(npm view:*),Bash(npm run lint:*),Bash(npm run format:*)"
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git checkout chore/claude-code-compat),Bash(git checkout -b chore/claude-code-compat),Bash(git add:*),Bash(git commit:*),Bash(git push origin chore/claude-code-compat),Bash(git push origin chore/claude-code-compat:*),Bash(git diff:*),Bash(git status:*),Bash(git fetch origin:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh api repos/marckrenn/claude-code-changelog/:*),Bash(npm view:*)"
           settings: |
             {
               "env": {
@@ -179,11 +178,14 @@ jobs:
           git pull origin next --rebase
 
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          printf '{\n  "lastCheckedVersion": "%s",\n  "lastCheckedAt": "%s"\n}\n' \
-            "$TO_VERSION" "$TIMESTAMP" > .github/claude-code-version.json
+          jq -n --arg v "$TO_VERSION" --arg t "$TIMESTAMP" \
+            '{lastCheckedVersion: $v, lastCheckedAt: $t}' \
+            > .github/claude-code-version.json
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .github/claude-code-version.json
-          git commit -m "ci: update claude-code version tracker [skip ci]" || echo "No changes to commit"
-          git push origin next
+          if ! git diff --cached --quiet; then
+            git commit -m "ci: update claude-code version tracker [skip ci]"
+            git push origin next
+          fi

--- a/.github/workflows/claude-code-compat.yml
+++ b/.github/workflows/claude-code-compat.yml
@@ -1,0 +1,189 @@
+name: Claude Code Compatibility Check
+
+on:
+  schedule:
+    # Twice daily at 06:17 and 18:17 UTC (offset from :00/:30)
+    - cron: '17 6,18 * * *'
+  workflow_dispatch:
+    inputs:
+      from_version:
+        description: 'Force check from this version (e.g., v2.1.90). Overrides tracked version.'
+        required: false
+        type: string
+
+concurrency:
+  group: claude-code-compat
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: next
+          fetch-depth: 1
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - uses: volta-cli/action@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ── Version check (early exit if nothing new) ─────────────
+      - name: Read tracked version
+        id: tracked
+        run: |
+          if [ -f .github/claude-code-version.json ]; then
+            VERSION=$(jq -r '.lastCheckedVersion' .github/claude-code-version.json)
+          else
+            VERSION="v0.0.0"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch latest release from changelog repo
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST=$(gh api repos/marckrenn/claude-code-changelog/releases/latest --jq '.tag_name')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Determine version range
+        id: range
+        run: |
+          if [ -n "${{ inputs.from_version }}" ]; then
+            FROM="${{ inputs.from_version }}"
+          else
+            FROM="${{ steps.tracked.outputs.version }}"
+          fi
+          TO="${{ steps.latest.outputs.version }}"
+
+          if [ "$FROM" = "$TO" ]; then
+            echo "new_releases=false" >> "$GITHUB_OUTPUT"
+            echo "No new releases (tracked: $FROM, latest: $TO)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "new_releases=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "from=$FROM" >> "$GITHUB_OUTPUT"
+          echo "to=$TO" >> "$GITHUB_OUTPUT"
+
+      # ── Enumerate and fetch release notes ─────────────────────
+      - name: Fetch release notes for new versions
+        if: steps.range.outputs.new_releases == 'true'
+        id: releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FROM_VERSION: ${{ steps.range.outputs.from }}
+          TO_VERSION: ${{ steps.range.outputs.to }}
+        run: |
+          # Fetch all release tags, filter to those between FROM and TO
+          RELEASES=$(gh api repos/marckrenn/claude-code-changelog/releases --paginate --jq '.[].tag_name')
+
+          # Filter versions: keep only those > FROM and <= TO
+          FILTERED=$(echo "$RELEASES" | while read -r tag; do
+            if [ "$(printf '%s\n%s' "$FROM_VERSION" "$tag" | sort -V | head -1)" = "$FROM_VERSION" ] && \
+               [ "$tag" != "$FROM_VERSION" ] && \
+               [ "$(printf '%s\n%s' "$tag" "$TO_VERSION" | sort -V | head -1)" = "$tag" ]; then
+              echo "$tag"
+            fi
+          done | sort -V)
+
+          echo "Versions to analyze:"
+          echo "$FILTERED"
+
+          # Fetch release body for each version and write to file
+          > /tmp/release-notes.md
+          for tag in $FILTERED; do
+            echo "Fetching release notes for $tag..."
+            BODY=$(gh api "repos/marckrenn/claude-code-changelog/releases/tags/$tag" --jq '.body // "No release notes."')
+            {
+              echo "### ${tag}"
+              echo ""
+              echo "$BODY"
+              echo ""
+              echo "---"
+              echo ""
+            } >> /tmp/release-notes.md
+          done
+
+          echo "$FILTERED" > /tmp/version-list.txt
+          COUNT=$(echo "$FILTERED" | grep -c . || true)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      # ── Check for existing PR ─────────────────────────────────
+      - name: Check for existing compatibility PR
+        if: steps.range.outputs.new_releases == 'true'
+        id: existing_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list --head chore/claude-code-compat --state open --json number --jq '.[0].number // empty')
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      # ── Read prompt ───────────────────────────────────────────
+      - name: Read analysis prompt
+        if: steps.range.outputs.new_releases == 'true'
+        id: prompt
+        run: |
+          echo "content<<PROMPT_DELIM_EOF" >> "$GITHUB_OUTPUT"
+          cat .github/prompts/claude-code-compat.md >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "## Release Notes" >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          cat /tmp/release-notes.md >> "$GITHUB_OUTPUT"
+          echo "PROMPT_DELIM_EOF" >> "$GITHUB_OUTPUT"
+
+      # ── Run Claude Code analysis ──────────────────────────────
+      - name: Run compatibility analysis
+        if: steps.range.outputs.new_releases == 'true'
+        id: analysis
+        uses: anthropics/claude-code-action@v1
+        with:
+          allowed_bots: 'claude,dependabot'
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            FROM_VERSION: ${{ steps.range.outputs.from }}
+            TO_VERSION: ${{ steps.range.outputs.to }}
+            EXISTING_PR: ${{ steps.existing_pr.outputs.number }}
+
+            ${{ steps.prompt.outputs.content }}
+          claude_args: |
+            --model opus[1m]
+            --effort max
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git checkout:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git status:*),Bash(git fetch:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh api:*),Bash(npm view:*),Bash(npm run lint:*),Bash(npm run format:*)"
+          settings: |
+            {
+              "env": {
+                "ANTHROPIC_AUTH_TOKEN": "${{ secrets.ANTHROPIC_AUTH_TOKEN }}",
+                "ANTHROPIC_BASE_URL": "${{ secrets.ANTHROPIC_BASE_URL }}"
+              }
+            }
+
+      # ── Update version tracker ────────────────────────────────
+      - name: Update version tracker
+        if: steps.range.outputs.new_releases == 'true'
+        env:
+          TO_VERSION: ${{ steps.range.outputs.to }}
+        run: |
+          # Claude may have switched branches — return to next
+          git checkout next
+          git pull origin next --rebase
+
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          printf '{\n  "lastCheckedVersion": "%s",\n  "lastCheckedAt": "%s"\n}\n' \
+            "$TO_VERSION" "$TIMESTAMP" > .github/claude-code-version.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/claude-code-version.json
+          git commit -m "ci: update claude-code version tracker [skip ci]" || echo "No changes to commit"
+          git push origin next

--- a/.github/workflows/claude-code-compat.yml
+++ b/.github/workflows/claude-code-compat.yml
@@ -132,13 +132,15 @@ jobs:
         if: steps.range.outputs.new_releases == 'true'
         id: prompt
         run: |
-          echo "content<<PROMPT_DELIM_EOF" >> "$GITHUB_OUTPUT"
+          # Randomized delimiter prevents injection via untrusted release notes
+          DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
+          echo "content<<${DELIM}" >> "$GITHUB_OUTPUT"
           cat .github/prompts/claude-code-compat.md >> "$GITHUB_OUTPUT"
           echo "" >> "$GITHUB_OUTPUT"
           echo "## Release Notes" >> "$GITHUB_OUTPUT"
           echo "" >> "$GITHUB_OUTPUT"
           cat /tmp/release-notes.md >> "$GITHUB_OUTPUT"
-          echo "PROMPT_DELIM_EOF" >> "$GITHUB_OUTPUT"
+          echo "${DELIM}" >> "$GITHUB_OUTPUT"
 
       # ── Run Claude Code analysis ──────────────────────────────
       - name: Run compatibility analysis
@@ -158,7 +160,7 @@ jobs:
           claude_args: |
             --model opus[1m]
             --effort max
-            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git checkout chore/claude-code-compat),Bash(git checkout -b chore/claude-code-compat),Bash(git add:*),Bash(git commit:*),Bash(git push origin chore/claude-code-compat),Bash(git push origin chore/claude-code-compat:*),Bash(git diff:*),Bash(git status:*),Bash(git fetch origin:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh api repos/marckrenn/claude-code-changelog/:*),Bash(npm view:*)"
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git checkout chore/claude-code-compat),Bash(git checkout -b chore/claude-code-compat),Bash(git add:*),Bash(git commit:*),Bash(git push origin chore/claude-code-compat),Bash(git diff:*),Bash(git status:*),Bash(git fetch origin:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh api repos/marckrenn/claude-code-changelog/:*),Bash(npm view:*)"
           settings: |
             {
               "env": {

--- a/.github/workflows/claude-code-compat.yml
+++ b/.github/workflows/claude-code-compat.yml
@@ -56,13 +56,17 @@ jobs:
 
       - name: Determine version range
         id: range
+        env:
+          INPUT_FROM_VERSION: ${{ inputs.from_version }}
+          TRACKED_VERSION: ${{ steps.tracked.outputs.version }}
+          LATEST_VERSION: ${{ steps.latest.outputs.version }}
         run: |
-          if [ -n "${{ inputs.from_version }}" ]; then
-            FROM="${{ inputs.from_version }}"
+          if [ -n "$INPUT_FROM_VERSION" ]; then
+            FROM="$INPUT_FROM_VERSION"
           else
-            FROM="${{ steps.tracked.outputs.version }}"
+            FROM="$TRACKED_VERSION"
           fi
-          TO="${{ steps.latest.outputs.version }}"
+          TO="$LATEST_VERSION"
 
           if [ "$FROM" = "$TO" ]; then
             echo "new_releases=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Adds a scheduled GitHub Actions workflow that monitors `marckrenn/claude-code-changelog` for new Claude Code CLI releases, analyzes whether Canopy needs adjustments, and opens a PR with proposed changes when relevant.

## Why

Claude Code is a core integration for our CI workflows (code review, PR validation, audits, bug triage) and our `@anthropic-ai/claude-agent-sdk` runtime dependency. New CLI releases can change feature flags, env vars, hooks, permission models, or system prompts in ways that affect how we invoke Claude or what we tell it to do. Today we'd only catch breakage reactively. This automation gives us a continuous feedback loop on upstream changes without manual monitoring.

## How to test

1. Manually dispatch the workflow from the Actions tab with `from_version=v2.1.95` to force a check against a recent past version.
2. Confirm the workflow fetches release notes for the missed versions and runs Claude Code analysis with the prompt from `.github/prompts/claude-code-compat.md`.
3. Verify it either creates a `chore/claude-code-compat` PR with structured analysis OR writes "no changes needed" to the step summary.
4. Verify `.github/claude-code-version.json` is updated and committed to `next` with a `[skip ci]` message.
5. Dispatch again with no input — should early-exit since the tracker now matches latest.
6. (Optional) When a new Claude Code release lands while the compat PR is still open, verify the workflow pushes incremental commits to the existing PR rather than creating a duplicate.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [ ] Keyboard accessible (all interactive elements reachable via keyboard)
- [ ] IPC follows \`feature:action\` naming and uses \`invoke\`/\`handle\`
- [ ] Renderer code does not import Node.js modules directly

_Feature-flag, keyboard, IPC, and renderer items are N/A — this is a CI-only change._