### PR TITLE
feat(updater): configurable auto-update check frequency

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import os from 'os'
 import { readFileSync, realpathSync } from 'fs'
 import { join, resolve, sep } from 'path'
 import { autoUpdater } from 'electron-updater'
+import { match } from 'ts-pattern'
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import { PtyManager } from './pty/PtyManager'
 import { WsBridge } from './pty/WsBridge'
@@ -110,6 +111,26 @@ windowManager.setOnWindowDispose((paths) => {
 let manualCheckInProgress = false
 let updateInstalling = false
 let updateCheckInFlight = false
+let updateCheckIntervalTimer: ReturnType<typeof setInterval> | null = null
+
+type UpdateCheckFrequency = 'never' | 'hourly' | 'daily' | 'weekly'
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+const WEEK_MS = 7 * DAY_MS
+
+const normalizeUpdateCheckFrequency = (value: string | null): UpdateCheckFrequency =>
+  match(value)
+    .with('never', 'hourly', 'daily', 'weekly', (v) => v)
+    .otherwise(() => 'daily' as const)
+
+const getUpdateCheckIntervalMs = (frequency: UpdateCheckFrequency): number | null =>
+  match(frequency)
+    .with('hourly', () => HOUR_MS)
+    .with('daily', () => DAY_MS)
+    .with('weekly', () => WEEK_MS)
+    .with('never', () => null)
+    .exhaustive()
 
 const checkWithChannelResolution = async (): Promise<void> => {
   if (updateCheckInFlight) return
@@ -128,6 +149,21 @@ const checkWithChannelResolution = async (): Promise<void> => {
   } finally {
     updateCheckInFlight = false
   }
+}
+
+const scheduleRecurringUpdateCheck = (): void => {
+  if (updateCheckIntervalTimer) {
+    clearInterval(updateCheckIntervalTimer)
+    updateCheckIntervalTimer = null
+  }
+  const frequency = normalizeUpdateCheckFrequency(preferencesStore.get('update.checkFrequency'))
+  const intervalMs = getUpdateCheckIntervalMs(frequency)
+  if (intervalMs === null) return
+  updateCheckIntervalTimer = setInterval(() => {
+    checkWithChannelResolution().catch((err) => {
+      console.warn('Scheduled update check failed:', err)
+    })
+  }, intervalMs)
 }
 
 let agentSessionManager: AgentSessionManager | null = null
@@ -411,6 +447,12 @@ app.whenReady().then(async () => {
       preferencesStore.set('update.autoUpdate', enabled ? 'true' : 'false')
     })
 
+    ipcMain.handle('app:setUpdateCheckFrequency', (_e, frequency: string) => {
+      const normalized = normalizeUpdateCheckFrequency(frequency)
+      preferencesStore.set('update.checkFrequency', normalized)
+      scheduleRecurringUpdateCheck()
+    })
+
     ipcMain.handle('app:checkForUpdates', () => {
       manualCheckInProgress = true
       checkWithChannelResolution().catch((err) => {
@@ -464,9 +506,15 @@ app.whenReady().then(async () => {
       }, 10_000)
     })
 
-    checkWithChannelResolution().catch((err) => {
-      console.warn('Auto-update check failed:', err)
-    })
+    const checkFrequency = normalizeUpdateCheckFrequency(
+      preferencesStore.get('update.checkFrequency'),
+    )
+    if (checkFrequency !== 'never') {
+      checkWithChannelResolution().catch((err) => {
+        console.warn('Auto-update check failed:', err)
+      })
+      scheduleRecurringUpdateCheck()
+    }
   }
 
   // SECURITY: Validate and harden all <webview> tags before they attach.
@@ -748,6 +796,10 @@ app.on('before-quit', (event) => {
   // During update install, skip cleanup that could interfere with Squirrel.
   // Window configs already saved; windows already destroyed.
   if (updateInstalling) {
+    if (updateCheckIntervalTimer) {
+      clearInterval(updateCheckIntervalTimer)
+      updateCheckIntervalTimer = null
+    }
     notchOverlay?.dispose()
     agentSessionManager?.dispose()
     database.close()
@@ -834,6 +886,10 @@ app.on('before-quit', (event) => {
   // explicitly killed the tmux server.
   windowManager.isQuitting = true
 
+  if (updateCheckIntervalTimer) {
+    clearInterval(updateCheckIntervalTimer)
+    updateCheckIntervalTimer = null
+  }
   notchOverlay?.dispose()
   agentSessionManager?.dispose()
   windowManager.disposeAll()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -215,6 +215,7 @@ interface CanopyAPI {
   installUpdate: () => Promise<void>
   setUpdateChannel: (channel: string) => Promise<void>
   setAutoUpdate: (enabled: boolean) => Promise<void>
+  setUpdateCheckFrequency: (frequency: string) => Promise<void>
   onUpdateAvailable: (callback: (data: UpdateInfo) => void) => () => void
   onUpdateProgress: (callback: (data: UpdateProgress) => void) => () => void
   onUpdateDownloaded: (callback: (data: UpdateInfo) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -105,6 +105,8 @@ const api = {
   installUpdate: () => ipcRenderer.invoke('app:installUpdate'),
   setUpdateChannel: (channel: string) => ipcRenderer.invoke('app:setUpdateChannel', channel),
   setAutoUpdate: (enabled: boolean) => ipcRenderer.invoke('app:setAutoUpdate', enabled),
+  setUpdateCheckFrequency: (frequency: string) =>
+    ipcRenderer.invoke('app:setUpdateCheckFrequency', frequency),
 
   onUpdateAvailable: (callback: (data: { version: string; releaseNotes?: string }) => void) => {
     const handler = (

--- a/src/renderer/src/components/preferences/UpdatePrefs.svelte
+++ b/src/renderer/src/components/preferences/UpdatePrefs.svelte
@@ -6,6 +6,7 @@
 
   let autoUpdate = $derived(prefs['update.autoUpdate'] !== 'false')
   let channel = $derived(prefs['update.channel'] || 'stable')
+  let checkFrequency = $derived(prefs['update.checkFrequency'] || 'daily')
 
   let checkState: 'idle' | 'checking' | 'up-to-date' | 'error' = $state('idle')
   let checkCleanup: (() => void) | null = $state(null)
@@ -19,6 +20,11 @@
   function setChannel(value: string): void {
     setPref('update.channel', value)
     window.api.setUpdateChannel(value)
+  }
+
+  function setCheckFrequency(value: string): void {
+    setPref('update.checkFrequency', value)
+    window.api.setUpdateCheckFrequency(value)
   }
 
   function checkNow(): void {
@@ -75,6 +81,21 @@
         { value: 'next', label: 'Pre-release' },
       ]}
       onchange={setChannel}
+      maxWidth="180px"
+    />
+  </div>
+
+  <div class="select-row">
+    <span class="select-label">Check frequency</span>
+    <CustomSelect
+      value={checkFrequency}
+      options={[
+        { value: 'hourly', label: 'Every hour' },
+        { value: 'daily', label: 'Every day' },
+        { value: 'weekly', label: 'Every week' },
+        { value: 'never', label: 'Never (manual only)' },
+      ]}
+      onchange={setCheckFrequency}
       maxWidth="180px"
     />
   </div>


### PR DESCRIPTION
## What
Adds a "Check frequency" dropdown in Preferences → Updates letting users
pick how often the app checks for updates: hourly, daily (default),
weekly, or never (manual only).

## Why
Until now the app checked for updates exactly once per launch, with no
way to opt into more frequent checks for long-running sessions or to opt
out entirely. Users on the `next` channel in particular wanted a way to
pick up pre-releases without restarting, and some users want no
automatic checks at all.

## How
- New `update.checkFrequency` preference key (`'never' | 'hourly' | 'daily' | 'weekly'`, default `'daily'`).
- Main process manages a single `setInterval` timer via `scheduleRecurringUpdateCheck()`, rescheduled through a new `app:setUpdateCheckFrequency` IPC handler whenever the pref changes.
- Picking `never` disables both the startup check *and* the recurring check — only the manual "Check for updates" button works.
- Timer is cleared on `before-quit` (both the normal path and the Squirrel update-install path) to avoid leaks.
- Frequency normalization uses `ts-pattern` with `.exhaustive()` for compile-time safety.

## How to test
1. Open Preferences → Updates → confirm new "Check frequency" dropdown with Every hour / Every day / Every week / Never options; default is "Every day".
2. Change the value — it persists across restarts (check via SQLite `preferences` table: `update.checkFrequency`).
3. Set to "Never" in a packaged build → restart → no startup update check fires; manual "Check for updates" button still works.
4. Set to "Every hour" → verify a `checkForUpdates` call after the interval elapses (can tail main-process logs or temporarily lower `HOUR_MS` to a few seconds for quicker verification).
5. `npm run typecheck` and `npm run svelte-check` both pass with 0 errors.

## Screenshots / recordings
_Preferences → Updates now shows a third row "Check frequency" with a dropdown between the existing "Update channel" select and the "Check for updates" button._

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run svelte-check` passes
- [x] `npm run lint` passes
- [ ] Manual QA on macOS packaged build
- [x] No breaking changes to existing preferences schema