### PR TITLE
feat(worktree): create worktree from existing branch

### DIFF
--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -376,21 +376,19 @@ export class GitRepository {
         }
         const localName = branch.slice(slash + 1)
 
+        // Use `git branch --list` instead of `show-ref --verify` so that a
+        // missing branch is signalled by empty output (no error), letting real
+        // failures (corrupt repo, permissions) surface as GitCommandFailed.
         return validateRef(localName).asyncAndThen(() =>
           gitCall(
-            'show-ref',
-            git.raw(['show-ref', '--verify', '--quiet', `refs/heads/${localName}`]),
-          )
-            .map(() => 'local-exists' as const)
-            .orElse(() => okAsync('remote-only' as const))
-            .andThen((kind) =>
-              kind === 'local-exists'
-                ? gitCall('worktree add', git.raw(['worktree', 'add', path, localName]))
-                : gitCall(
-                    'worktree add',
-                    git.raw(['worktree', 'add', '-b', localName, path, branch]),
-                  ),
-            ),
+            'branch list',
+            git.raw(['branch', '--list', '--format=%(refname:short)', localName]),
+          ).andThen((output) => {
+            const exists = output.split('\n').some((line) => line.trim() === localName)
+            return exists
+              ? gitCall('worktree add', git.raw(['worktree', 'add', path, localName]))
+              : gitCall('worktree add', git.raw(['worktree', 'add', '-b', localName, path, branch]))
+          }),
         )
       })
       .map(() => undefined)

--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -356,6 +356,46 @@ export class GitRepository {
       .map(() => undefined)
   }
 
+  static worktreeAddCheckout(
+    repoRoot: string,
+    path: string,
+    branch: string,
+    createLocalTracking: boolean,
+  ): ResultAsync<void, GitError> {
+    return validateRef(branch)
+      .asyncAndThen(() => {
+        const git = simpleGit(repoRoot)
+
+        if (!createLocalTracking) {
+          return gitCall('worktree add', git.raw(['worktree', 'add', path, branch]))
+        }
+
+        const slash = branch.indexOf('/')
+        if (slash < 0) {
+          return gitCall('worktree add', git.raw(['worktree', 'add', path, branch]))
+        }
+        const localName = branch.slice(slash + 1)
+
+        return validateRef(localName).asyncAndThen(() =>
+          gitCall(
+            'show-ref',
+            git.raw(['show-ref', '--verify', '--quiet', `refs/heads/${localName}`]),
+          )
+            .map(() => 'local-exists' as const)
+            .orElse(() => okAsync('remote-only' as const))
+            .andThen((kind) =>
+              kind === 'local-exists'
+                ? gitCall('worktree add', git.raw(['worktree', 'add', path, localName]))
+                : gitCall(
+                    'worktree add',
+                    git.raw(['worktree', 'add', '-b', localName, path, branch]),
+                  ),
+            ),
+        )
+      })
+      .map(() => undefined)
+  }
+
   static worktreeRemove(
     repoRoot: string,
     path: string,

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -805,6 +805,30 @@ export function registerIpcHandlers(
   )
 
   ipcMain.handle(
+    'git:worktreeCheckout',
+    async (
+      _event,
+      payload: {
+        repoRoot: string
+        path: string
+        branch: string
+        createLocalTracking: boolean
+      },
+    ) => {
+      const resolvedPath = payload.path.startsWith('~/')
+        ? os.homedir() + payload.path.slice(1)
+        : payload.path
+      const result = await GitRepository.worktreeAddCheckout(
+        payload.repoRoot,
+        resolvedPath,
+        payload.branch,
+        payload.createLocalTracking,
+      )
+      return unwrapOrThrow(result, gitErrorMessage)
+    },
+  )
+
+  ipcMain.handle(
     'git:worktreeRemove',
     async (_event, payload: { repoRoot: string; path: string; force: boolean }) => {
       const result = await GitRepository.worktreeRemove(

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -354,6 +354,12 @@ interface CanopyAPI {
     branch: string,
     baseBranch: string,
   ) => Promise<void>
+  gitWorktreeCheckout: (
+    repoRoot: string,
+    path: string,
+    branch: string,
+    createLocalTracking: boolean,
+  ) => Promise<void>
   gitWorktreeRemove: (repoRoot: string, path: string, force: boolean) => Promise<void>
   gitUnmergedCommits: (repoRoot: string, branch: string) => Promise<string[]>
   gitStatusPorcelain: (repoRoot: string, worktreePath?: string) => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -270,6 +270,18 @@ const api = {
     ipcRenderer.invoke('git:branchMerged', { repoRoot, branch }),
   gitWorktreeAdd: (repoRoot: string, path: string, branch: string, baseBranch: string) =>
     ipcRenderer.invoke('git:worktreeAdd', { repoRoot, path, branch, baseBranch }),
+  gitWorktreeCheckout: (
+    repoRoot: string,
+    path: string,
+    branch: string,
+    createLocalTracking: boolean,
+  ) =>
+    ipcRenderer.invoke('git:worktreeCheckout', {
+      repoRoot,
+      path,
+      branch,
+      createLocalTracking,
+    }),
   gitWorktreeRemove: (repoRoot: string, path: string, force: boolean) =>
     ipcRenderer.invoke('git:worktreeRemove', { repoRoot, path, force }),
   gitUnmergedCommits: (repoRoot: string, branch: string) =>

--- a/src/renderer/src/components/worktree/BranchPicker.svelte
+++ b/src/renderer/src/components/worktree/BranchPicker.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { isRemoteOnly } from './utils'
+
   let {
     branches,
     label,
@@ -43,12 +45,6 @@
       selectedIdx = Math.max(0, filteredBranches.length - 1)
     }
   })
-
-  function isRemoteOnly(b: string): boolean {
-    if (!branches.remote.includes(b)) return false
-    const localName = b.slice(b.indexOf('/') + 1)
-    return !branches.local.includes(localName)
-  }
 
   function pick(branch: string): void {
     selectedBranch = branch
@@ -127,7 +123,7 @@
           onpointerenter={() => (selectedIdx = i)}
         >
           <span class="branch-name">{branch}</span>
-          {#if showRemoteOnlyTag && isRemoteOnly(branch)}
+          {#if showRemoteOnlyTag && isRemoteOnly(branch, branches)}
             <span class="remote-only-tag">(remote only)</span>
           {/if}
         </div>

--- a/src/renderer/src/components/worktree/BranchPicker.svelte
+++ b/src/renderer/src/components/worktree/BranchPicker.svelte
@@ -1,0 +1,278 @@
+<script lang="ts">
+  let {
+    branches,
+    label,
+    query = $bindable(''),
+    selectedBranch = $bindable(''),
+    refreshing,
+    onRefresh,
+    onCommit,
+    showRemoteOnlyTag = false,
+    highlightPicked = false,
+  }: {
+    branches: { local: string[]; remote: string[] }
+    label: string
+    query?: string
+    selectedBranch?: string
+    refreshing: boolean
+    onRefresh: () => void | Promise<void>
+    onCommit?: () => void
+    showRemoteOnlyTag?: boolean
+    highlightPicked?: boolean
+  } = $props()
+
+  let selectedIdx = $state(0)
+
+  function fuzzyMatch(text: string, q: string): boolean {
+    if (!q) return true
+    const lower = text.toLowerCase()
+    let qi = 0
+    for (let i = 0; i < lower.length && qi < q.length; i++) {
+      if (lower[i] === q[qi]) qi++
+    }
+    return qi === q.length
+  }
+
+  let allBranches = $derived([...branches.local, ...branches.remote])
+  let filteredBranches = $derived(
+    query ? allBranches.filter((b) => fuzzyMatch(b, query.toLowerCase())) : allBranches,
+  )
+
+  $effect(() => {
+    if (selectedIdx >= filteredBranches.length) {
+      selectedIdx = Math.max(0, filteredBranches.length - 1)
+    }
+  })
+
+  function isRemoteOnly(b: string): boolean {
+    if (!branches.remote.includes(b)) return false
+    const localName = b.slice(b.indexOf('/') + 1)
+    return !branches.local.includes(localName)
+  }
+
+  function pick(branch: string): void {
+    selectedBranch = branch
+  }
+
+  function scrollIntoView(): void {
+    requestAnimationFrame(() => {
+      const el = document.querySelector('.branch-item.selected')
+      el?.scrollIntoView({ block: 'nearest' })
+    })
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      selectedIdx = (selectedIdx + 1) % Math.max(1, filteredBranches.length)
+      scrollIntoView()
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      selectedIdx =
+        (selectedIdx - 1 + filteredBranches.length) % Math.max(1, filteredBranches.length)
+      scrollIntoView()
+    } else if (e.key === 'Enter' && filteredBranches.length > 0) {
+      e.preventDefault()
+      const branch = filteredBranches[selectedIdx]
+      pick(branch)
+      onCommit?.()
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="branch-picker" onkeydown={handleKeydown}>
+  <div class="field-header">
+    <!-- svelte-ignore a11y_label_has_associated_control -->
+    <label class="field-label">{label}</label>
+    <button
+      class="btn-refresh"
+      onclick={onRefresh}
+      disabled={refreshing}
+      title="Fetch from remote"
+      type="button"
+    >
+      <svg
+        class="refresh-icon"
+        class:spinning={refreshing}
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+      >
+        <path d="M13.65 2.35A8 8 0 1 0 16 8h-2a6 6 0 1 1-1.76-4.24L10 6h6V0l-2.35 2.35z" />
+      </svg>
+    </button>
+  </div>
+  <input
+    class="field-input"
+    type="text"
+    bind:value={query}
+    placeholder="Search branches..."
+    spellcheck="false"
+    autocomplete="off"
+  />
+  <div class="branch-list">
+    {#if filteredBranches.length === 0}
+      <div class="branch-empty">No branches found</div>
+    {:else}
+      {#each filteredBranches as branch, i (branch)}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <div
+          class="branch-item"
+          class:selected={i === selectedIdx}
+          class:picked={highlightPicked && selectedBranch === branch}
+          onclick={() => pick(branch)}
+          onpointerenter={() => (selectedIdx = i)}
+        >
+          <span class="branch-name">{branch}</span>
+          {#if showRemoteOnlyTag && isRemoteOnly(branch)}
+            <span class="remote-only-tag">(remote only)</span>
+          {/if}
+        </div>
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .branch-picker {
+    display: contents;
+  }
+
+  .field-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+  }
+
+  .field-label {
+    display: block;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    color: var(--c-text-muted);
+    text-transform: uppercase;
+  }
+
+  .btn-refresh {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--c-text-muted);
+    cursor: pointer;
+    transition:
+      background 0.1s,
+      color 0.1s;
+  }
+
+  .btn-refresh:hover:not(:disabled) {
+    background: var(--c-active);
+    color: var(--c-text-secondary);
+  }
+
+  .btn-refresh:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+
+  .refresh-icon {
+    transition: transform 0.2s;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .refresh-icon.spinning {
+    animation: spin 0.8s linear infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .refresh-icon.spinning {
+      animation: none;
+    }
+  }
+
+  .field-input {
+    width: 100%;
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+    background: var(--c-bg-input);
+    color: var(--c-text);
+    font-size: 13px;
+    font-family: inherit;
+    padding: 8px 10px;
+    outline: none;
+    transition: border-color 0.1s;
+    box-sizing: border-box;
+  }
+
+  .field-input:focus {
+    border-color: var(--c-focus-ring);
+  }
+
+  .field-input::placeholder {
+    color: var(--c-text-faint);
+  }
+
+  .branch-list {
+    margin-top: 8px;
+    max-height: 260px;
+    overflow-y: auto;
+    border: 1px solid var(--c-border-subtle);
+    border-radius: 6px;
+  }
+
+  .branch-item {
+    display: flex;
+    align-items: baseline;
+    padding: 6px 10px;
+    font-size: 13px;
+    color: var(--c-text);
+    cursor: pointer;
+    transition: background 0.05s;
+  }
+
+  .branch-item:hover,
+  .branch-item.selected {
+    background: var(--c-active);
+  }
+
+  .branch-item.picked {
+    background: var(--c-accent-bg);
+    color: var(--c-accent-text);
+  }
+
+  .branch-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .remote-only-tag {
+    margin-left: 8px;
+    font-size: 11px;
+    color: var(--c-text-faint);
+    flex-shrink: 0;
+  }
+
+  .branch-empty {
+    padding: 16px 10px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--c-text-faint);
+  }
+</style>

--- a/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
+++ b/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
@@ -10,6 +10,7 @@
   import { getTheme } from '../../lib/terminal/themes'
   import { safeDirName } from '../../lib/sanitize'
   import BranchPicker from './BranchPicker.svelte'
+  import { isRemoteOnly } from './utils'
 
   let {
     onClose,
@@ -54,16 +55,10 @@
   let projectName = $derived(repoRoot.split('/').pop() || 'project')
   let workspaceId = $derived(workspaceIdProp ?? workspaceState.workspace?.id)
 
-  function isRemoteOnly(b: string): boolean {
-    if (!branches.remote.includes(b)) return false
-    const localName = b.slice(b.indexOf('/') + 1)
-    return !branches.local.includes(localName)
-  }
-
   let effectiveBranchName = $derived(
     mode === 'new'
       ? newBranchName
-      : selectedBase && isRemoteOnly(selectedBase)
+      : selectedBase && isRemoteOnly(selectedBase, branches)
         ? selectedBase.slice(selectedBase.indexOf('/') + 1)
         : selectedBase,
   )
@@ -202,7 +197,7 @@
     if (!selectedBase) return
     step = 'creating'
     try {
-      const createLocalTracking = isRemoteOnly(selectedBase)
+      const createLocalTracking = isRemoteOnly(selectedBase, branches)
       await window.api.gitWorktreeCheckout(repoRoot, worktreeDir, selectedBase, createLocalTracking)
       createdPath = worktreeDirDisplay
 
@@ -346,13 +341,13 @@
       {:else}
         <!-- Branch picker (shared between new-mode base selection and existing-mode checkout) -->
         <div class="modal-body">
-          <div class="mode-toggle" role="tablist">
+          <div class="mode-toggle" role="radiogroup" aria-label="Branch mode">
             <button
               class="mode-btn"
               class:active={mode === 'new'}
               onclick={() => setMode('new')}
-              role="tab"
-              aria-selected={mode === 'new'}
+              role="radio"
+              aria-checked={mode === 'new'}
               type="button"
             >
               New branch
@@ -361,8 +356,8 @@
               class="mode-btn"
               class:active={mode === 'existing'}
               onclick={() => setMode('existing')}
-              role="tab"
-              aria-selected={mode === 'existing'}
+              role="radio"
+              aria-checked={mode === 'existing'}
               type="button"
             >
               From existing branch

--- a/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
+++ b/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
@@ -9,6 +9,7 @@
   import { openTool } from '../../lib/stores/tabs.svelte'
   import { getTheme } from '../../lib/terminal/themes'
   import { safeDirName } from '../../lib/sanitize'
+  import BranchPicker from './BranchPicker.svelte'
 
   let {
     onClose,
@@ -23,13 +24,14 @@
   } = $props()
 
   type Step = 'loading' | 'pickBase' | 'creating' | 'setup' | 'done' | 'error'
+  type Mode = 'new' | 'existing'
 
   let step = $state<Step>('loading')
+  let mode = $state<Mode>('new')
   let branches = $state<{ local: string[]; remote: string[] }>({ local: [], remote: [] })
   let branchQuery = $state('')
   let selectedBase = $state('')
   let newBranchName = $state('')
-  let selectedBranchIdx = $state(0)
   let errorMessage = $state('')
   let createdPath = $state('')
   let homedir = $state('')
@@ -52,11 +54,25 @@
   let projectName = $derived(repoRoot.split('/').pop() || 'project')
   let workspaceId = $derived(workspaceIdProp ?? workspaceState.workspace?.id)
 
+  function isRemoteOnly(b: string): boolean {
+    if (!branches.remote.includes(b)) return false
+    const localName = b.slice(b.indexOf('/') + 1)
+    return !branches.local.includes(localName)
+  }
+
+  let effectiveBranchName = $derived(
+    mode === 'new'
+      ? newBranchName
+      : selectedBase && isRemoteOnly(selectedBase)
+        ? selectedBase.slice(selectedBase.indexOf('/') + 1)
+        : selectedBase,
+  )
+
   // Worktree dir: <baseDir>/<projectName>/<safeBranchName>
   let worktreeDir = $derived.by(() => {
-    if (!newBranchName) return ''
+    if (!effectiveBranchName) return ''
     const baseDir = getPref('worktrees.baseDir', '~/canopy/worktrees')
-    const safeName = safeDirName(newBranchName)
+    const safeName = safeDirName(effectiveBranchName)
     return `${baseDir}/${projectName}/${safeName}`
   })
 
@@ -132,28 +148,6 @@
     }
   }
 
-  // Fuzzy match for branch search
-  function fuzzyMatch(text: string, q: string): boolean {
-    if (!q) return true
-    const lower = text.toLowerCase()
-    let qi = 0
-    for (let i = 0; i < lower.length && qi < q.length; i++) {
-      if (lower[i] === q[qi]) qi++
-    }
-    return qi === q.length
-  }
-
-  let allBranches = $derived([...branches.local, ...branches.remote])
-  let filteredBranches = $derived(
-    branchQuery ? allBranches.filter((b) => fuzzyMatch(b, branchQuery.toLowerCase())) : allBranches,
-  )
-
-  $effect(() => {
-    if (selectedBranchIdx >= filteredBranches.length) {
-      selectedBranchIdx = Math.max(0, filteredBranches.length - 1)
-    }
-  })
-
   // Validate branch name
   let branchNameError = $derived.by(() => {
     if (!newBranchName) return null
@@ -177,8 +171,12 @@
     }
   }
 
-  function selectBranch(branch: string): void {
-    selectedBase = branch
+  function setMode(next: Mode): void {
+    if (mode === next) return
+    mode = next
+    selectedBase = ''
+    newBranchName = ''
+    // branchQuery preserved — search stays useful across modes
   }
 
   async function createWorktree(): Promise<void> {
@@ -186,6 +184,26 @@
     step = 'creating'
     try {
       await window.api.gitWorktreeAdd(repoRoot, worktreeDir, newBranchName, selectedBase)
+      createdPath = worktreeDirDisplay
+
+      if (hasSetupConfig() && workspaceId) {
+        step = 'setup'
+        await runSetup()
+      } else {
+        finishCreation()
+      }
+    } catch (err) {
+      errorMessage = err instanceof Error ? err.message : String(err)
+      step = 'error'
+    }
+  }
+
+  async function createWorktreeFromExisting(): Promise<void> {
+    if (!selectedBase) return
+    step = 'creating'
+    try {
+      const createLocalTracking = isRemoteOnly(selectedBase)
+      await window.api.gitWorktreeCheckout(repoRoot, worktreeDir, selectedBase, createLocalTracking)
       createdPath = worktreeDirDisplay
 
       if (hasSetupConfig() && workspaceId) {
@@ -247,29 +265,6 @@
     finishCreation()
   }
 
-  function handleBranchListKeydown(e: KeyboardEvent): void {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault()
-      selectedBranchIdx = (selectedBranchIdx + 1) % Math.max(1, filteredBranches.length)
-      scrollIntoView()
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault()
-      selectedBranchIdx =
-        (selectedBranchIdx - 1 + filteredBranches.length) % Math.max(1, filteredBranches.length)
-      scrollIntoView()
-    } else if (e.key === 'Enter' && filteredBranches.length > 0) {
-      e.preventDefault()
-      selectBranch(filteredBranches[selectedBranchIdx])
-    }
-  }
-
-  function scrollIntoView(): void {
-    requestAnimationFrame(() => {
-      const el = document.querySelector('.branch-item.selected')
-      el?.scrollIntoView({ block: 'nearest' })
-    })
-  }
-
   function setupTerminalAction(node: HTMLDivElement): { destroy: () => void } {
     initSetupTerminal(node)
     return { destroy: disposeSetupTerminal }
@@ -311,57 +306,7 @@
         <p class="status-text">Loading branches...</p>
       </div>
     {:else if step === 'pickBase'}
-      {#if !selectedBase}
-        <!-- Pick base branch -->
-        <div class="modal-body" onkeydown={handleBranchListKeydown}>
-          <div class="field-header">
-            <!-- svelte-ignore a11y_label_has_associated_control -->
-            <label class="field-label">Base branch</label>
-            <button
-              class="btn-refresh"
-              onclick={refreshBranches}
-              disabled={refreshing}
-              title="Fetch from remote"
-            >
-              <svg
-                class="refresh-icon"
-                class:spinning={refreshing}
-                width="14"
-                height="14"
-                viewBox="0 0 16 16"
-                fill="currentColor"
-              >
-                <path d="M13.65 2.35A8 8 0 1 0 16 8h-2a6 6 0 1 1-1.76-4.24L10 6h6V0l-2.35 2.35z" />
-              </svg>
-            </button>
-          </div>
-          <input
-            class="field-input"
-            type="text"
-            bind:value={branchQuery}
-            placeholder="Search branches..."
-            spellcheck="false"
-            autocomplete="off"
-          />
-          <div class="branch-list">
-            {#if filteredBranches.length === 0}
-              <div class="branch-empty">No branches found</div>
-            {:else}
-              {#each filteredBranches as branch, i (branch)}
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div
-                  class="branch-item"
-                  class:selected={i === selectedBranchIdx}
-                  onclick={() => selectBranch(branch)}
-                  onpointerenter={() => (selectedBranchIdx = i)}
-                >
-                  {branch}
-                </div>
-              {/each}
-            {/if}
-          </div>
-        </div>
-      {:else}
+      {#if mode === 'new' && selectedBase}
         <!-- Name new branch -->
         <div class="modal-body">
           <p class="field-info">Base: <strong>{selectedBase}</strong></p>
@@ -397,6 +342,58 @@
               Create
             </button>
           </div>
+        </div>
+      {:else}
+        <!-- Branch picker (shared between new-mode base selection and existing-mode checkout) -->
+        <div class="modal-body">
+          <div class="mode-toggle" role="tablist">
+            <button
+              class="mode-btn"
+              class:active={mode === 'new'}
+              onclick={() => setMode('new')}
+              role="tab"
+              aria-selected={mode === 'new'}
+              type="button"
+            >
+              New branch
+            </button>
+            <button
+              class="mode-btn"
+              class:active={mode === 'existing'}
+              onclick={() => setMode('existing')}
+              role="tab"
+              aria-selected={mode === 'existing'}
+              type="button"
+            >
+              From existing branch
+            </button>
+          </div>
+          <BranchPicker
+            {branches}
+            bind:query={branchQuery}
+            bind:selectedBranch={selectedBase}
+            {refreshing}
+            onRefresh={refreshBranches}
+            label={mode === 'new' ? 'Base branch' : 'Branch to check out'}
+            showRemoteOnlyTag={mode === 'existing'}
+            highlightPicked={mode === 'existing'}
+            onCommit={mode === 'existing' ? createWorktreeFromExisting : undefined}
+          />
+          {#if mode === 'existing'}
+            {#if selectedBase && worktreeDir}
+              <p class="field-detail">Path: {worktreeDirDisplay}</p>
+            {/if}
+            <div class="modal-actions">
+              <button class="btn btn-cancel" onclick={onClose}>Cancel</button>
+              <button
+                class="btn btn-primary"
+                onclick={createWorktreeFromExisting}
+                disabled={!selectedBase}
+              >
+                Create
+              </button>
+            </div>
+          {/if}
         </div>
       {/if}
     {:else if step === 'creating'}
@@ -595,13 +592,6 @@
     align-items: center;
   }
 
-  .field-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin-bottom: 6px;
-  }
-
   .field-label {
     display: block;
     font-size: 11px;
@@ -609,53 +599,6 @@
     letter-spacing: 0.5px;
     color: var(--c-text-muted);
     text-transform: uppercase;
-  }
-
-  .btn-refresh {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
-    padding: 0;
-    border: none;
-    border-radius: 4px;
-    background: transparent;
-    color: var(--c-text-muted);
-    cursor: pointer;
-    transition:
-      background 0.1s,
-      color 0.1s;
-  }
-
-  .btn-refresh:hover:not(:disabled) {
-    background: var(--c-active);
-    color: var(--c-text-secondary);
-  }
-
-  .btn-refresh:disabled {
-    cursor: default;
-    opacity: 0.5;
-  }
-
-  .refresh-icon {
-    transition: transform 0.2s;
-  }
-
-  @keyframes spin {
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
-  .refresh-icon.spinning {
-    animation: spin 0.8s linear infinite;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .refresh-icon.spinning {
-      animation: none;
-    }
   }
 
   .field-input {
@@ -704,32 +647,38 @@
     word-break: break-all;
   }
 
-  .branch-list {
-    margin-top: 8px;
-    max-height: 260px;
-    overflow-y: auto;
-    border: 1px solid var(--c-border-subtle);
+  .mode-toggle {
+    display: flex;
+    gap: 2px;
+    padding: 2px;
+    margin: 0 0 12px;
+    background: var(--c-active);
     border-radius: 6px;
   }
 
-  .branch-item {
-    padding: 6px 10px;
-    font-size: 13px;
-    color: var(--c-text);
+  .mode-btn {
+    flex: 1;
+    padding: 5px 8px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--c-text-muted);
+    font-size: 12px;
+    font-family: inherit;
     cursor: pointer;
-    transition: background 0.05s;
+    transition:
+      background 0.1s,
+      color 0.1s;
   }
 
-  .branch-item:hover,
-  .branch-item.selected {
-    background: var(--c-active);
+  .mode-btn:hover:not(.active) {
+    color: var(--c-text-secondary);
   }
 
-  .branch-empty {
-    padding: 16px 10px;
-    text-align: center;
-    font-size: 13px;
-    color: var(--c-text-faint);
+  .mode-btn.active {
+    background: var(--c-bg-overlay);
+    color: var(--c-text);
+    box-shadow: 0 1px 2px var(--c-shadow, rgba(0, 0, 0, 0.15));
   }
 
   .modal-actions {

--- a/src/renderer/src/components/worktree/utils.ts
+++ b/src/renderer/src/components/worktree/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns true when `branch` is a remote-tracking ref (e.g. "origin/feature-x")
+ * and no local branch with the same short name exists. Used to surface
+ * "remote only" branches in the picker and to decide whether
+ * `git worktree add` needs `-b <localName>` to create a tracking branch.
+ */
+export function isRemoteOnly(
+  branch: string,
+  branches: { local: string[]; remote: string[] },
+): boolean {
+  if (!branches.remote.includes(branch)) return false
+  const localName = branch.slice(branch.indexOf('/') + 1)
+  return !branches.local.includes(localName)
+}

--- a/src/renderer/src/lib/onboarding/steps.ts
+++ b/src/renderer/src/lib/onboarding/steps.ts
@@ -82,6 +82,14 @@ export const onboardingSteps: OnboardingStep[] = [
     introducedIn: '0.10.0',
     category: 'feature',
   },
+  {
+    id: 'worktree-existing-branch',
+    title: 'Create worktrees from existing branches',
+    description:
+      'The Create Worktree dialog now has a "From existing branch" mode — pick any local or remote branch and check it out into a new worktree in one step. Remote-only branches are created as local tracking branches automatically.',
+    introducedIn: '0.10.0',
+    category: 'feature',
+  },
 ]
 
 export function getFirstLaunchSteps(): OnboardingStep[] {


### PR DESCRIPTION
## What

Add a "From existing branch" mode to the Create Worktree dialog that
checks out any local or remote-only branch into a new worktree in one
step. Remote-only picks (e.g. `origin/feature-x`) are created as local
tracking branches automatically.

## Why

Previously the Create Worktree flow only supported creating a new branch
off a base. Users wanting to check out an existing branch (e.g. a
teammate's PR branch from `origin`) had to drop to the terminal. This
closes that gap without adding clicks for the default new-branch flow.

## How to test

Preconditions: a repo with local `feature/foo`, a remote-only
`origin/feature-remote`, and `origin/main` shadowing local `main`.

1. Open the Create Worktree dialog from the sidebar — confirm the
   segmented `[New branch] [From existing branch]` toggle is visible
   with "New branch" active by default.
2. **Regression:** in "New branch" mode, pick a base, type a name,
   Enter → worktree created, click count matches today.
3. Switch to "From existing branch" → label becomes "Branch to check
   out", no naming step.
4. Select `feature/foo` → Create → `git -C <worktree> branch
   --show-current` = `feature/foo`, no new branch created.
5. Select `origin/feature-remote` (shows "(remote only)" tag) → Create
   → new worktree has local `feature-remote` tracking
   `origin/feature-remote`.
6. Select `origin/main` (no "(remote only)" tag, because local `main`
   exists) → Create → reuses local `main`, no "branch already exists".
7. Attempt to check out `main` while it's already checked out in the
   main worktree → expect a clear error message in the dialog.
8. In existing mode, type a search query, ArrowDown, Enter → immediate
   creation (no intermediate step).
9. **Regression:** task-tracker "New branch" flow via
   `BranchCreateForm` still works (still routes through
   `gitWorktreeAdd`).

## Screenshots / recordings

_UI change — screenshots of both modes to be attached before merge._

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default) — _N/A, additive UX in an existing dialog_
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (segmented toggle focusable, branch list keydown, Enter commits)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle` (`git:worktreeCheckout`)
- [x] Renderer code does not import Node.js modules directly