### PR TITLE
feat: add toggleable cpu/ram hud in status bar

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -653,9 +653,11 @@ app.whenReady().then(async () => {
 
   // Status-bar perf HUD (always available, gated by user preference in renderer)
   ipcMain.handle('perf:hud:start', (event) => {
+    if (!windowManager.getWindowById(BrowserWindow.fromWebContents(event.sender)?.id ?? -1)) return
     perfHudService.subscribe(event.sender)
   })
   ipcMain.handle('perf:hud:stop', (event) => {
+    if (!windowManager.getWindowById(BrowserWindow.fromWebContents(event.sender)?.id ?? -1)) return
     perfHudService.unsubscribe(event.sender)
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,7 @@ import { fetchChangelogRange, resolveUpdateChannel } from './changelog/fetchChan
 import { validateBounds, cascadeBounds } from './windowBounds'
 import { TelemetryManager } from './telemetry/TelemetryManager'
 import { RemoteSessionService } from './remote/RemoteSessionService'
+import { PerfHudService } from './perf/PerfHudService'
 import type { WindowConfig } from './windowBounds'
 import { performance } from 'perf_hooks'
 
@@ -104,6 +105,7 @@ const browserManager = new BrowserManager()
 const credentialStore = new CredentialStore(database)
 const tmuxManager = new TmuxManager(app.getPath('userData'))
 const remoteSessionService = new RemoteSessionService(preferencesStore)
+const perfHudService = new PerfHudService()
 windowManager.setTmuxManager(tmuxManager)
 windowManager.setOnWindowDispose((paths) => {
   for (const path of paths) {
@@ -649,6 +651,14 @@ app.whenReady().then(async () => {
     })
   }
 
+  // Status-bar perf HUD (always available, gated by user preference in renderer)
+  ipcMain.handle('perf:hud:start', (event) => {
+    perfHudService.subscribe(event.sender)
+  })
+  ipcMain.handle('perf:hud:stop', (event) => {
+    perfHudService.unsubscribe(event.sender)
+  })
+
   ipcMain.handle('app:openExternal', (_event, { url }: { url: string }) => {
     if (!isSafeExternalUrl(url)) return
     return shell.openExternal(url)
@@ -812,6 +822,7 @@ app.on('before-quit', (event) => {
     notchOverlay?.dispose()
     agentSessionManager?.dispose()
     remoteSessionService.dispose()
+    perfHudService.shutdown()
     database.close()
     return
   }
@@ -903,6 +914,7 @@ app.on('before-quit', (event) => {
   notchOverlay?.dispose()
   agentSessionManager?.dispose()
   remoteSessionService.dispose()
+  perfHudService.shutdown()
   windowManager.disposeAll()
   database.close()
 })

--- a/src/main/perf/PerfHudService.ts
+++ b/src/main/perf/PerfHudService.ts
@@ -1,7 +1,12 @@
 import { app, type WebContents } from 'electron'
+import os from 'os'
 
 const SAMPLE_INTERVAL_MS = 1000
 const CHANNEL = 'perf:hud:metrics'
+// Electron's percentCPUUsage is per-single-core (Chromium convention), so on an
+// 8-core machine a fully-busy app reads ~800%. Normalize to 0-100% of the whole
+// machine so the status bar shows a value users intuitively understand.
+const CPU_CORES = Math.max(1, os.cpus().length)
 
 export interface PerfHudMetrics {
   cpu: number
@@ -27,7 +32,13 @@ export class PerfHudService {
 
   subscribe(wc: WebContents): void {
     const id = wc.id
-    if (this.subscribers.has(id)) return
+    if (this.subscribers.has(id)) {
+      // Reload path: the WebContents survives a renderer reload (same id, no
+      // 'destroyed' event fired), so the old subscription is still here. Re-send
+      // the last sample so the new renderer isn't blank for up to a full tick.
+      if (this.lastPayload && !wc.isDestroyed()) wc.send(CHANNEL, this.lastPayload)
+      return
+    }
 
     this.subscribers.set(id, wc)
 
@@ -97,8 +108,11 @@ export class PerfHudService {
       memKbTotal += m.memory.workingSetSize
     }
 
+    // Normalize from per-core to whole-machine percentage and clamp to 100 so
+    // brief over-shoots from sub-sample deltas don't display 101/102.
+    const cpuPercent = Math.min(100, Math.round(cpuTotal / CPU_CORES))
     const payload: PerfHudMetrics = {
-      cpu: Math.round(cpuTotal),
+      cpu: cpuPercent,
       memMb: Math.round(memKbTotal / 1024),
     }
 

--- a/src/main/perf/PerfHudService.ts
+++ b/src/main/perf/PerfHudService.ts
@@ -1,0 +1,120 @@
+import { app, type WebContents } from 'electron'
+
+const SAMPLE_INTERVAL_MS = 1000
+const CHANNEL = 'perf:hud:metrics'
+
+export interface PerfHudMetrics {
+  cpu: number
+  memMb: number
+}
+
+/**
+ * Sampling loop for the status-bar perf HUD.
+ *
+ * Designed to add zero overhead when nobody is watching: the interval only runs
+ * while at least one renderer is subscribed. When the last subscriber disconnects
+ * (toggle off, window closed, reload) the interval is cleared.
+ *
+ * Sampling cost: one synchronous app.getAppMetrics() call per tick (~sub-ms even
+ * with many child processes), small object allocation, optional structured clone
+ * for IPC. Memoized last payload skips IPC + DOM updates when nothing changed.
+ */
+export class PerfHudService {
+  private subscribers = new Map<number, WebContents>()
+  private destroyHandlers = new Map<number, () => void>()
+  private intervalHandle: ReturnType<typeof setInterval> | null = null
+  private lastPayload: PerfHudMetrics | null = null
+
+  subscribe(wc: WebContents): void {
+    const id = wc.id
+    if (this.subscribers.has(id)) return
+
+    this.subscribers.set(id, wc)
+
+    const onDestroyed = (): void => this.unsubscribeById(id)
+    wc.once('destroyed', onDestroyed)
+    this.destroyHandlers.set(id, onDestroyed)
+
+    // Send last known sample immediately so the HUD doesn't show empty state
+    // for up to a full second after toggling on.
+    if (this.lastPayload) {
+      wc.send(CHANNEL, this.lastPayload)
+    }
+
+    this.startIfNeeded()
+  }
+
+  unsubscribe(wc: WebContents): void {
+    this.unsubscribeById(wc.id)
+  }
+
+  shutdown(): void {
+    this.stopInterval()
+    for (const [id, handler] of this.destroyHandlers) {
+      const wc = this.subscribers.get(id)
+      if (wc && !wc.isDestroyed()) wc.removeListener('destroyed', handler)
+    }
+    this.subscribers.clear()
+    this.destroyHandlers.clear()
+    this.lastPayload = null
+  }
+
+  private unsubscribeById(id: number): void {
+    const wc = this.subscribers.get(id)
+    if (!wc) return
+    const handler = this.destroyHandlers.get(id)
+    if (handler && !wc.isDestroyed()) wc.removeListener('destroyed', handler)
+    this.subscribers.delete(id)
+    this.destroyHandlers.delete(id)
+    if (this.subscribers.size === 0) this.stopInterval()
+  }
+
+  private startIfNeeded(): void {
+    if (this.intervalHandle) return
+    if (this.subscribers.size === 0) return
+    // Tick once immediately to populate state, then on interval.
+    this.tick()
+    this.intervalHandle = setInterval(() => this.tick(), SAMPLE_INTERVAL_MS)
+  }
+
+  private stopInterval(): void {
+    if (!this.intervalHandle) return
+    clearInterval(this.intervalHandle)
+    this.intervalHandle = null
+  }
+
+  private tick(): void {
+    if (this.subscribers.size === 0) {
+      this.stopInterval()
+      return
+    }
+
+    const metrics = app.getAppMetrics()
+    let cpuTotal = 0
+    let memKbTotal = 0
+    for (const m of metrics) {
+      cpuTotal += m.cpu.percentCPUUsage
+      memKbTotal += m.memory.workingSetSize
+    }
+
+    const payload: PerfHudMetrics = {
+      cpu: Math.round(cpuTotal),
+      memMb: Math.round(memKbTotal / 1024),
+    }
+
+    // Skip IPC entirely if rounded values are unchanged: avoids DOM work and
+    // keeps the channel quiet when the app is idle.
+    if (
+      this.lastPayload &&
+      this.lastPayload.cpu === payload.cpu &&
+      this.lastPayload.memMb === payload.memMb
+    ) {
+      return
+    }
+    this.lastPayload = payload
+
+    for (const wc of this.subscribers.values()) {
+      if (!wc.isDestroyed()) wc.send(CHANNEL, payload)
+    }
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -672,6 +672,13 @@ interface CanopyAPI {
     dir: string
   }> | null>
 
+  // Status-bar perf HUD (always present)
+  perfHud: {
+    start: () => Promise<void>
+    stop: () => Promise<void>
+    onMetrics: (callback: (metrics: { cpu: number; memMb: number }) => void) => () => void
+  }
+
   // Remote control (WebRTC pairing via QR)
   remote: RemoteAPI
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -831,6 +831,20 @@ const api = {
       }
     : {}),
 
+  // Status-bar perf HUD (always available, opt-in via preference)
+  perfHud: {
+    start: () => ipcRenderer.invoke('perf:hud:start') as Promise<void>,
+    stop: () => ipcRenderer.invoke('perf:hud:stop') as Promise<void>,
+    onMetrics: (callback: (metrics: { cpu: number; memMb: number }) => void) => {
+      const handler = (_event: IpcRendererEvent, metrics: { cpu: number; memMb: number }): void =>
+        callback(metrics)
+      ipcRenderer.on('perf:hud:metrics', handler)
+      return (): void => {
+        ipcRenderer.removeListener('perf:hud:metrics', handler)
+      }
+    },
+  },
+
   // File utilities
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
 

--- a/src/renderer/src/components/layout/StatusBar.svelte
+++ b/src/renderer/src/components/layout/StatusBar.svelte
@@ -5,6 +5,9 @@
   import { getAllTabs, activeTabId, focusSessionByPtyId } from '../../lib/stores/tabs.svelte'
   import { findLeaf } from '../../lib/stores/splitTree'
   import { updateState, installUpdate } from '../../lib/stores/updateState.svelte'
+  import { prefs } from '../../lib/stores/preferences.svelte'
+  import { perfHudState, enablePerfHud, disablePerfHud } from '../../lib/stores/perfHud.svelte'
+  import { showPreferences } from '../../lib/stores/dialogs.svelte'
 
   const AI_TOOL_IDS = new Set(['claude', 'codex', 'opencode', 'gemini'])
 
@@ -158,6 +161,25 @@
     const done = activeAgent.tasks.filter((t) => t.status === 'completed').length
     return { done, total }
   })
+
+  // --- Perf HUD (status-bar CPU/RAM indicator) ---
+  // Subscription is gated on the user preference. When toggled off the main
+  // process stops sampling entirely, so the HUD adds zero overhead in that state.
+  let perfHudEnabled = $derived(prefs['perf.hud.enabled'] === 'true')
+
+  $effect(() => {
+    if (perfHudEnabled) {
+      enablePerfHud()
+      return () => {
+        disablePerfHud()
+      }
+    }
+    return undefined
+  })
+
+  function openPerfHudSettings(): void {
+    showPreferences('general')
+  }
 </script>
 
 {#if projects.length > 0}
@@ -264,6 +286,17 @@
 
     <!-- RIGHT: global indicators -->
     <div class="section right">
+      {#if perfHudEnabled && perfHudState.metrics}
+        <button
+          class="status-item dim perf-hud"
+          aria-label="App CPU {perfHudState.metrics.cpu}%, RAM {perfHudState.metrics.memMb} MB"
+          title="App CPU / RAM — click to open settings"
+          onclick={openPerfHudSettings}
+        >
+          {perfHudState.metrics.cpu}% · {perfHudState.metrics.memMb} MB
+        </button>
+      {/if}
+
       {#if agentCount > 0}
         <button
           class="status-item agents"
@@ -418,6 +451,10 @@
 
   .dim {
     color: var(--c-text-muted);
+  }
+
+  .perf-hud {
+    font-variant-numeric: tabular-nums;
   }
 
   /* Agent status in center */

--- a/src/renderer/src/components/preferences/GeneralPrefs.svelte
+++ b/src/renderer/src/components/preferences/GeneralPrefs.svelte
@@ -13,6 +13,7 @@
   let notchEnabled = $derived(prefs['notch.enabled'] === 'true')
   let wpmEnabled = $derived(prefs['wpm.enabled'] === 'true')
   let keystrokeVisualizerEnabled = $derived(prefs['keystrokeVisualizer.enabled'] === 'true')
+  let perfHudEnabled = $derived(prefs['perf.hud.enabled'] === 'true')
   let startupToolOptions = $derived(
     getTools()
       .filter((t) => t.category !== 'browser' && getToolAvailability()[t.id] !== false)
@@ -48,6 +49,10 @@
 
   function toggleKeystrokeVisualizer(): void {
     setPref('keystrokeVisualizer.enabled', keystrokeVisualizerEnabled ? 'false' : 'true')
+  }
+
+  function togglePerfHud(): void {
+    setPref('perf.hud.enabled', perfHudEnabled ? 'false' : 'true')
   }
 
   async function rerunSetupWizard(): Promise<void> {
@@ -90,6 +95,17 @@
     <div class="hint-row">
       Displays pressed keys and keyboard shortcuts as a floating overlay in the bottom-left corner
       of the terminal. Keys fade out after 2 seconds.
+    </div>
+  {/if}
+
+  <label class="checkbox-row">
+    <CustomCheckbox checked={perfHudEnabled} onchange={togglePerfHud} />
+    <span>Show CPU and RAM usage in status bar</span>
+  </label>
+  {#if perfHudEnabled}
+    <div class="hint-row">
+      Aggregates total CPU and resident memory across all Canopy processes (main, renderer, GPU,
+      utility). Sampled once per second; the sampler stops entirely when this toggle is off.
     </div>
   {/if}
 

--- a/src/renderer/src/lib/onboarding/steps.ts
+++ b/src/renderer/src/lib/onboarding/steps.ts
@@ -106,6 +106,14 @@ export const onboardingSteps: OnboardingStep[] = [
     introducedIn: '0.10.0',
     category: 'feature',
   },
+  {
+    id: 'perf-hud',
+    title: 'CPU and RAM in the status bar',
+    description:
+      'Enable "Show CPU and RAM usage in status bar" in Settings → General to see total CPU and memory across all Canopy processes, sampled once per second. Off by default — the sampler only runs while the indicator is visible, so there is no overhead when it is disabled.',
+    introducedIn: '0.11.0',
+    category: 'feature',
+  },
 ]
 
 export function getFirstLaunchSteps(): OnboardingStep[] {

--- a/src/renderer/src/lib/stores/perfHud.svelte.ts
+++ b/src/renderer/src/lib/stores/perfHud.svelte.ts
@@ -1,0 +1,30 @@
+// Reactive state + lifecycle for the status-bar perf HUD.
+// The main process only samples while at least one renderer has subscribed,
+// so disable() must always be called when the HUD toggle goes off.
+
+export const perfHudState: { metrics: { cpu: number; memMb: number } | null } = $state({
+  metrics: null,
+})
+
+let unsubMetrics: (() => void) | null = null
+let active = false
+
+export async function enablePerfHud(): Promise<void> {
+  if (active) return
+  active = true
+  unsubMetrics = window.api.perfHud.onMetrics((m) => {
+    perfHudState.metrics = m
+  })
+  await window.api.perfHud.start()
+}
+
+export async function disablePerfHud(): Promise<void> {
+  if (!active) return
+  active = false
+  if (unsubMetrics) {
+    unsubMetrics()
+    unsubMetrics = null
+  }
+  perfHudState.metrics = null
+  await window.api.perfHud.stop()
+}


### PR DESCRIPTION
## What

Adds an opt-in indicator in the bottom-right status bar that shows total app CPU and resident memory (aggregated across main, renderer, GPU, and utility processes). Toggled via Preferences → General; clicking the HUD opens the same settings page.

## Why

We already had dev-only perf diagnostics behind `CANOPY_PERF=1`, but no always-available way for users to see how much Canopy is consuming. The main constraint was that the HUD itself must not become a resource hog.

## How to test

1. `npm run dev`
2. Confirm the status bar looks unchanged (HUD off by default).
3. Open Preferences → General → enable "Show CPU and RAM usage in status bar".
4. Verify the HUD appears in the bottom-right as `X% · Y MB` and updates roughly once per second. Numbers should track Activity Monitor.
5. Click the HUD — Preferences → General opens.
6. Disable the toggle — HUD disappears immediately. Confirm via Activity Monitor that the main process returns to idle baseline (sampler stops).
7. Reload the renderer (Cmd-R) with the HUD on — subscription re-registers cleanly, no leftover intervals.
8. Restart the app — pref persists.

## Perf safeguards

- Sampling interval only runs while at least one renderer is subscribed; toggle off → `clearInterval` → zero overhead.
- 1 Hz sampling via `app.getAppMetrics()` (single synchronous call).
- Last payload is memoized — if rounded `cpu`/`memMb` values are unchanged the IPC send and downstream DOM update are skipped entirely.
- Per-window cleanup via `webContents.once('destroyed')` so reloads and window closes don't leak subscriptions.
- `font-variant-numeric: tabular-nums` on the HUD so digit width changes don't trigger layout thrash.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [x] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly