### PR TITLE
feat(ui): add pane drag-and-drop for reorder, move, and detach

### DIFF
--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -1,7 +1,20 @@
 <script lang="ts">
   import type { PaneSession } from '../../lib/stores/splitTree'
-  import { restartPane, updatePaneTitle, isAiToolId } from '../../lib/stores/tabs.svelte'
-  import { dragState, setDropTarget, type DropZone } from '../../lib/stores/dragState.svelte'
+  import {
+    restartPane,
+    updatePaneTitle,
+    isAiToolId,
+    movePaneToTarget,
+    detachPaneToTab,
+  } from '../../lib/stores/tabs.svelte'
+  import {
+    dragState,
+    setDropTarget,
+    startPaneDrag,
+    activateDrag,
+    clearDrag,
+    type DropZone,
+  } from '../../lib/stores/dragState.svelte'
   import TerminalInstance from '../../lib/terminal/TerminalInstance.svelte'
   import BrowserPane from '../browser/BrowserPane.svelte'
   import EditorPane from '../editor/EditorPane.svelte'
@@ -19,6 +32,7 @@
     worktreePath,
     focused,
     active,
+    isMultiPane = false,
     onFocus,
   }: {
     pane: PaneSession
@@ -26,6 +40,7 @@
     worktreePath: string
     focused: boolean
     active: boolean
+    isMultiPane?: boolean
     onFocus: () => void
   } = $props()
 
@@ -35,11 +50,18 @@
   let wpmEnabled = $derived(prefs['wpm.enabled'] === 'true')
   let keystrokeVisualizerEnabled = $derived(prefs['keystrokeVisualizer.enabled'] === 'true')
 
-  // Whether this pane is a valid drop target
+  // Whether this pane is a valid drop target (for both tab and pane drags)
   let isValidTarget = $derived(
     dragState.isDragging &&
-      dragState.sourceTabId !== tabId &&
-      dragState.sourceWorktree === worktreePath,
+      dragState.sourceWorktree === worktreePath &&
+      (dragState.dragType === 'tab'
+        ? dragState.sourceTabId !== tabId
+        : dragState.sourcePaneId !== pane.id),
+  )
+
+  // Whether this pane is the drag source (for visual dimming)
+  let isDragSource = $derived(
+    dragState.dragType === 'pane' && dragState.sourcePaneId === pane.id && dragState.isDragging,
   )
 
   function computeZone(e: PointerEvent): DropZone | null {
@@ -76,6 +98,7 @@
     }
   }
 
+  // Drop target listener (active when a drag is in progress and this pane is a valid target)
   $effect(() => {
     if (!isValidTarget) {
       hoveredZone = null
@@ -87,11 +110,76 @@
       hoveredZone = null
     }
   })
+
+  // --- Alt+drag pane initiation (capture phase to intercept before terminal) ---
+
+  let paneDragStartX = 0
+  let paneDragStartY = 0
+  let paneDragActive = false
+
+  function handlePaneDragPointerDown(e: PointerEvent): void {
+    if (!e.altKey || e.button !== 0 || !isMultiPane) return
+    e.preventDefault()
+    e.stopPropagation()
+
+    paneDragStartX = e.clientX
+    paneDragStartY = e.clientY
+    paneDragActive = false
+    startPaneDrag(tabId, pane.id, worktreePath)
+
+    window.addEventListener('pointermove', handlePaneDragMove)
+    window.addEventListener('pointerup', handlePaneDragEnd)
+  }
+
+  function handlePaneDragMove(e: PointerEvent): void {
+    const dx = e.clientX - paneDragStartX
+    const dy = e.clientY - paneDragStartY
+    if (!paneDragActive && Math.sqrt(dx * dx + dy * dy) > 5) {
+      paneDragActive = true
+      activateDrag()
+    }
+  }
+
+  function handlePaneDragEnd(): void {
+    window.removeEventListener('pointermove', handlePaneDragMove)
+    window.removeEventListener('pointerup', handlePaneDragEnd)
+
+    if (paneDragActive) {
+      const dt = dragState.dropTarget
+      if (dragState.detachToTabBar) {
+        detachPaneToTab(worktreePath, tabId, pane.id)
+      } else if (dt) {
+        movePaneToTarget(worktreePath, tabId, pane.id, dt.tabId, dt.paneId, dt.zone)
+      }
+    }
+
+    paneDragActive = false
+    clearDrag()
+  }
+
+  // Attach capture-phase listener to intercept Alt+click before terminal content
+  $effect(() => {
+    if (!wrapperEl) return
+    wrapperEl.addEventListener('pointerdown', handlePaneDragPointerDown, { capture: true })
+    return () => {
+      wrapperEl!.removeEventListener('pointerdown', handlePaneDragPointerDown, { capture: true })
+      // Safety: clean up window listeners if component unmounts mid-drag
+      window.removeEventListener('pointermove', handlePaneDragMove)
+      window.removeEventListener('pointerup', handlePaneDragEnd)
+    }
+  })
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="pane-wrapper" class:focused onclick={onFocus} bind:this={wrapperEl}>
+<div
+  class="pane-wrapper"
+  class:focused
+  class:drag-source={isDragSource}
+  title={isMultiPane ? 'Alt+drag to move pane' : undefined}
+  onclick={onFocus}
+  bind:this={wrapperEl}
+>
   {#if pane.paneType === 'browser'}
     <BrowserPane
       browserId={pane.sessionId}
@@ -154,6 +242,10 @@
   .pane-wrapper.focused {
     outline: 1px solid var(--c-border);
     outline-offset: -1px;
+  }
+
+  .pane-wrapper.drag-source {
+    opacity: 0.4;
   }
 
   .pane-content {

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -176,7 +176,6 @@
   class="pane-wrapper"
   class:focused
   class:drag-source={isDragSource}
-  title={isMultiPane ? 'Alt+drag to move pane' : undefined}
   onclick={onFocus}
   bind:this={wrapperEl}
 >

--- a/src/renderer/src/components/terminal/SplitPaneContainer.svelte
+++ b/src/renderer/src/components/terminal/SplitPaneContainer.svelte
@@ -39,6 +39,7 @@
   })
 
   let layout = $derived(buildFlatLayout(node, containerWidth, containerHeight))
+  let isMultiPane = $derived(node.type !== 'leaf')
 
   function handleDividerDrag(
     splitId: string,
@@ -70,6 +71,7 @@
         {worktreePath}
         focused={rect.paneId === focusedPaneId}
         {active}
+        {isMultiPane}
         onFocus={() => onFocusPane(rect.paneId)}
       />
     </div>

--- a/src/renderer/src/components/terminal/TabBar.svelte
+++ b/src/renderer/src/components/terminal/TabBar.svelte
@@ -14,7 +14,13 @@
   import { allPanes, findLeaf } from '../../lib/stores/splitTree'
   import { agentBadges, agentSessions, type BadgeType } from '../../lib/agents/agentState.svelte'
   import { browserSessions } from '../../lib/browser/browserState.svelte'
-  import { dragState, startDrag, activateDrag, clearDrag } from '../../lib/stores/dragState.svelte'
+  import {
+    dragState,
+    startDrag,
+    activateDrag,
+    clearDrag,
+    setDetachTarget,
+  } from '../../lib/stores/dragState.svelte'
   import {
     connectionStatus,
     type ConnectionStatus,
@@ -148,14 +154,14 @@
     dropTargetId = found
   }
 
-  async function handleDragEnd(): Promise<void> {
+  function handleDragEnd(): void {
     window.removeEventListener('pointermove', handleDragMove)
     window.removeEventListener('pointerup', handleDragEnd)
 
     // Check for panel-split drop first (drag from tab bar to a panel)
     const dt = dragState.dropTarget
     if (dragActive && dragTabId && dt) {
-      await moveTabToSplit(worktreePath, dragTabId, dt.tabId, dt.paneId, dt.zone)
+      void moveTabToSplit(worktreePath, dragTabId, dt.tabId, dt.paneId, dt.zone)
     } else if (dragActive && dragTabId && dropTargetId) {
       // Existing tab-reorder logic
       const fromIdx = tabs.findIndex((t) => t.id === dragTabId)
@@ -179,6 +185,87 @@
     dropTargetId = null
     clearDrag()
   }
+
+  // --- Pane drag: tab bar as detach target + tab-switch-on-hover ---
+
+  let isPaneDragActive = $derived(
+    dragState.dragType === 'pane' &&
+      dragState.isDragging &&
+      dragState.sourceWorktree === worktreePath,
+  )
+
+  let paneDragHoverTabId: string | null = $state(null)
+  let paneDragHoverTimer: ReturnType<typeof setTimeout> | null = null
+
+  function handlePaneDragOverTabBar(e: PointerEvent): void {
+    if (!containerEl) return
+
+    const barRect = containerEl.getBoundingClientRect()
+    const inBar =
+      e.clientX >= barRect.left &&
+      e.clientX <= barRect.right &&
+      e.clientY >= barRect.top &&
+      e.clientY <= barRect.bottom
+
+    if (!inBar) {
+      setDetachTarget(false)
+      clearHoverTimer()
+      paneDragHoverTabId = null
+      return
+    }
+
+    // Check if pointer is over a specific tab
+    const tabEls = containerEl.querySelectorAll<HTMLElement>('[data-tab-id]')
+    let hoveredTab: string | null = null
+    for (const el of tabEls) {
+      const rect = el.getBoundingClientRect()
+      if (e.clientX >= rect.left && e.clientX <= rect.right) {
+        hoveredTab = el.dataset.tabId ?? null
+        break
+      }
+    }
+
+    if (hoveredTab) {
+      // Over a tab — not a detach target, but potentially a tab-switch target
+      setDetachTarget(false)
+
+      if (hoveredTab !== dragState.sourceTabId && hoveredTab !== paneDragHoverTabId) {
+        clearHoverTimer()
+        paneDragHoverTabId = hoveredTab
+        paneDragHoverTimer = setTimeout(() => {
+          if (paneDragHoverTabId) {
+            void switchTab(paneDragHoverTabId)
+          }
+        }, 300)
+      }
+    } else {
+      // Over the tab bar but not over any tab — detach target
+      setDetachTarget(true)
+      clearHoverTimer()
+      paneDragHoverTabId = null
+    }
+  }
+
+  function clearHoverTimer(): void {
+    if (paneDragHoverTimer) {
+      clearTimeout(paneDragHoverTimer)
+      paneDragHoverTimer = null
+    }
+  }
+
+  $effect(() => {
+    if (!isPaneDragActive) {
+      clearHoverTimer()
+      paneDragHoverTabId = null
+      return
+    }
+    window.addEventListener('pointermove', handlePaneDragOverTabBar)
+    return () => {
+      window.removeEventListener('pointermove', handlePaneDragOverTabBar)
+      clearHoverTimer()
+      paneDragHoverTabId = null
+    }
+  })
 </script>
 
 {#if tabs.length > 0}
@@ -234,6 +321,10 @@
         </div>
       {/each}
     </div>
+
+    {#if isPaneDragActive && dragState.detachToTabBar}
+      <div class="detach-indicator" aria-label="Drop to detach pane as new tab">+</div>
+    {/if}
 
     {#if overflowTabs.length > 0}
       <div class="overflow-wrapper">
@@ -421,6 +512,22 @@
   .tab-close:hover {
     background: var(--c-hover-strong);
     color: var(--c-text);
+  }
+
+  .detach-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    flex-shrink: 0;
+    background: var(--c-accent-bg);
+    border: 1px solid var(--c-focus-ring);
+    border-radius: 4px;
+    color: var(--c-accent-text);
+    font-size: 16px;
+    font-weight: 600;
+    pointer-events: none;
+    margin: 2px 4px;
   }
 
   .overflow-wrapper {

--- a/src/renderer/src/lib/onboarding/steps.ts
+++ b/src/renderer/src/lib/onboarding/steps.ts
@@ -114,6 +114,14 @@ export const onboardingSteps: OnboardingStep[] = [
     introducedIn: '0.11.0',
     category: 'feature',
   },
+  {
+    id: 'pane-drag',
+    title: 'Drag panes to rearrange splits',
+    description:
+      'Hold Alt (Option on Mac) and drag any pane to reorder it within a split, move it to another tab, or drop it on the tab bar to detach it into its own tab.',
+    introducedIn: '0.11.0',
+    category: 'feature',
+  },
 ]
 
 export function getFirstLaunchSteps(): OnboardingStep[] {

--- a/src/renderer/src/lib/stores/dragState.svelte.ts
+++ b/src/renderer/src/lib/stores/dragState.svelte.ts
@@ -7,24 +7,43 @@ export interface DropTarget {
 }
 
 interface DragState {
+  dragType: 'tab' | 'pane' | null
   sourceTabId: string | null
+  sourcePaneId: string | null
   sourceWorktree: string | null
   isDragging: boolean
   dropTarget: DropTarget | null
+  detachToTabBar: boolean
 }
 
 export const dragState: DragState = $state({
+  dragType: null,
   sourceTabId: null,
+  sourcePaneId: null,
   sourceWorktree: null,
   isDragging: false,
   dropTarget: null,
+  detachToTabBar: false,
 })
 
 export function startDrag(tabId: string, worktreePath: string): void {
+  dragState.dragType = 'tab'
   dragState.sourceTabId = tabId
+  dragState.sourcePaneId = null
   dragState.sourceWorktree = worktreePath
   dragState.isDragging = false
   dragState.dropTarget = null
+  dragState.detachToTabBar = false
+}
+
+export function startPaneDrag(tabId: string, paneId: string, worktreePath: string): void {
+  dragState.dragType = 'pane'
+  dragState.sourceTabId = tabId
+  dragState.sourcePaneId = paneId
+  dragState.sourceWorktree = worktreePath
+  dragState.isDragging = false
+  dragState.dropTarget = null
+  dragState.detachToTabBar = false
 }
 
 export function activateDrag(): void {
@@ -35,9 +54,16 @@ export function setDropTarget(target: DropTarget | null): void {
   dragState.dropTarget = target
 }
 
+export function setDetachTarget(value: boolean): void {
+  dragState.detachToTabBar = value
+}
+
 export function clearDrag(): void {
+  dragState.dragType = null
   dragState.sourceTabId = null
+  dragState.sourcePaneId = null
   dragState.sourceWorktree = null
   dragState.isDragging = false
   dragState.dropTarget = null
+  dragState.detachToTabBar = false
 }

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -1297,15 +1297,6 @@ export function movePaneToTarget(
     if (!removeResult.tree) return false // was the only pane — should not happen
     const newTree = graftSubtree(removeResult.tree, targetPaneId, direction, leaf, position)
     if (!newTree) {
-      // Depth exceeded — rollback: re-graft the pane back
-      const rollback = graftSubtree(
-        removeResult.tree,
-        firstLeaf(removeResult.tree).id,
-        direction,
-        leaf,
-        'second',
-      )
-      if (rollback) sourceTab.rootSplit = rollback
       return false
     }
     sourceTab.rootSplit = newTree
@@ -1315,17 +1306,6 @@ export function movePaneToTarget(
     // Cross-tab move: graft into target tab
     const newTargetTree = graftSubtree(targetTab.rootSplit, targetPaneId, direction, leaf, position)
     if (!newTargetTree) {
-      // Depth exceeded — rollback: put pane back in source
-      if (removeResult.tree) {
-        const rollback = graftSubtree(
-          removeResult.tree,
-          firstLeaf(removeResult.tree).id,
-          direction,
-          leaf,
-          'second',
-        )
-        if (rollback) sourceTab.rootSplit = rollback
-      }
       return false
     }
 

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -1268,6 +1268,132 @@ export async function moveTabToSplit(
   return true
 }
 
+// --- Move pane within or across tabs ---
+
+export function movePaneToTarget(
+  worktreePath: string,
+  sourceTabId: string,
+  sourcePaneId: string,
+  targetTabId: string,
+  targetPaneId: string,
+  zone: DropZone,
+): boolean {
+  const tabs = tabsByWorktree[worktreePath]
+  if (!tabs) return false
+
+  const sourceTab = tabs.find((t) => t.id === sourceTabId)
+  const targetTab = tabs.find((t) => t.id === targetTabId)
+  if (!sourceTab || !targetTab) return false
+
+  // Extract the source pane from its tree
+  const removeResult = treeRemovePane(sourceTab.rootSplit, sourcePaneId)
+  if (!removeResult) return false
+
+  const leaf = createLeaf(removeResult.removed)
+  const { direction, position } = mapZone(zone)
+
+  if (sourceTabId === targetTabId) {
+    // Same-tab reorder: removeResult.tree is the tree without the source pane
+    if (!removeResult.tree) return false // was the only pane — should not happen
+    const newTree = graftSubtree(removeResult.tree, targetPaneId, direction, leaf, position)
+    if (!newTree) {
+      // Depth exceeded — rollback: re-graft the pane back
+      const rollback = graftSubtree(
+        removeResult.tree,
+        firstLeaf(removeResult.tree).id,
+        direction,
+        leaf,
+        'second',
+      )
+      if (rollback) sourceTab.rootSplit = rollback
+      return false
+    }
+    sourceTab.rootSplit = newTree
+    sourceTab.focusedPaneId = sourcePaneId
+    reconcileTabIdentity(sourceTab)
+  } else {
+    // Cross-tab move: graft into target tab
+    const newTargetTree = graftSubtree(targetTab.rootSplit, targetPaneId, direction, leaf, position)
+    if (!newTargetTree) {
+      // Depth exceeded — rollback: put pane back in source
+      if (removeResult.tree) {
+        const rollback = graftSubtree(
+          removeResult.tree,
+          firstLeaf(removeResult.tree).id,
+          direction,
+          leaf,
+          'second',
+        )
+        if (rollback) sourceTab.rootSplit = rollback
+      }
+      return false
+    }
+
+    targetTab.rootSplit = newTargetTree
+    targetTab.focusedPaneId = sourcePaneId
+    reconcileTabIdentity(targetTab)
+
+    if (!removeResult.tree) {
+      // Source tab had only this pane — remove the tab
+      const sourceIdx = tabs.findIndex((t) => t.id === sourceTabId)
+      tabs.splice(sourceIdx, 1)
+      if (activeTabId[worktreePath] === sourceTabId) {
+        activeTabId[worktreePath] = targetTabId
+      }
+    } else {
+      sourceTab.rootSplit = removeResult.tree
+      sourceTab.focusedPaneId = firstLeaf(removeResult.tree).id
+      reconcileTabIdentity(sourceTab)
+    }
+
+    activeTabId[worktreePath] = targetTabId
+  }
+
+  scheduleSave(worktreePath)
+  return true
+}
+
+export function detachPaneToTab(
+  worktreePath: string,
+  sourceTabId: string,
+  sourcePaneId: string,
+): boolean {
+  const tabs = tabsByWorktree[worktreePath]
+  if (!tabs) return false
+
+  const sourceTab = tabs.find((t) => t.id === sourceTabId)
+  if (!sourceTab) return false
+
+  // Already a standalone tab — nothing to detach
+  if (sourceTab.rootSplit.type === 'leaf') return false
+
+  const removeResult = treeRemovePane(sourceTab.rootSplit, sourcePaneId)
+  if (!removeResult || !removeResult.tree) return false
+
+  // Update source tab
+  sourceTab.rootSplit = removeResult.tree
+  sourceTab.focusedPaneId = firstLeaf(removeResult.tree).id
+  reconcileTabIdentity(sourceTab)
+
+  // Create new tab for the detached pane
+  const removed = removeResult.removed
+  const newTab: TabInfo = {
+    id: nextTabId(),
+    toolId: removed.toolId,
+    toolName: removed.toolName,
+    name: computeDisplayName(removed.toolName, worktreePath, removed.toolId),
+    worktreePath,
+    rootSplit: createLeaf(removed),
+    focusedPaneId: removed.id,
+  }
+
+  tabs.push(newTab)
+  activeTabId[worktreePath] = newTab.id
+
+  scheduleSave(worktreePath)
+  return true
+}
+
 // --- Layout persistence ---
 
 const saveTimers: Record<string, ReturnType<typeof setTimeout>> = {}


### PR DESCRIPTION
## What

Add Alt+drag support for panes within splits — reorder within the same tab, move across tabs, or detach back to a standalone tab.

## Why

Once a tab was merged into a split, its panes were locked in place. Users had no way to rearrange, swap, or extract individual panes without closing and re-creating them.

## How to test

1. Open two shell tabs, drag one into the other to create a split (existing feature)
2. **Reorder**: Alt+drag a pane and drop on the other pane's left/right/top/bottom zone — it should move
3. **Detach**: Alt+drag a pane onto the empty area of the tab bar — a "+" indicator appears, releasing creates a new tab
4. **Cross-tab move**: Open a third tab, Alt+drag a pane, hover over the third tab in the tab bar for 300ms (it switches), then drop on a pane zone
5. **Guards**: Alt+drag does nothing on a single-pane tab; depth limit (4) is respected
6. **Session preservation**: terminals keep running after moves — no respawn
7. **Persistence**: restart the app, layout should be restored correctly

## Screenshots / recordings

UI changes:
- Drop zone overlays (existing) now appear for pane-to-pane drops
- Source pane dims to 40% opacity during drag
- "+" detach indicator appears on tab bar when dragging pane over empty space
- Tooltip "Alt+drag to move pane" on hover in multi-pane tabs

## Checklist

- [x] Typecheck passes (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] No Node.js imports in renderer code
- [x] CSS uses custom properties (no hardcoded colors)
- [x] Onboarding step added for the new feature
- [ ] Manual QA on macOS
- [ ] Manual QA on Linux