### PR TITLE
feat(agents): add Codex agent integration

### DIFF
--- a/.github/codex-version.json
+++ b/.github/codex-version.json
@@ -1,0 +1,4 @@
+{
+  "lastCheckedVersion": "rust-v0.118.0",
+  "lastCheckedAt": "2026-04-10T00:00:00Z"
+}

--- a/.github/prompts/codex-compat.md
+++ b/.github/prompts/codex-compat.md
@@ -1,0 +1,135 @@
+# Codex CLI Compatibility Analysis
+
+You are analyzing new Codex CLI releases to determine whether the **Canopy** desktop application (Electron + Svelte 5) needs code changes to stay compatible or to adopt new features.
+
+## Context
+
+The workflow has provided these values at the top of the prompt:
+
+- **FROM_VERSION** — the last version we checked (exclusive lower bound, e.g. `rust-v0.118.0`)
+- **TO_VERSION** — the latest available stable release (inclusive upper bound)
+- **EXISTING_PR** — PR number if a compatibility PR is already open (empty if none)
+- **REPO** — this repository (owner/repo format)
+
+The **release repo** is `openai/codex`. Tags use the format `rust-v{version}`.
+
+The **target branch** for PRs is `chore/codex-compat`.
+
+Release notes for each new version are appended below under `## Release Notes`.
+
+## Your task
+
+### 1. Understand the releases
+
+Read the release notes provided below. For each version, identify:
+
+- New or changed **hook events** (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop) and their input/output JSON schemas
+- New or changed **CLI flags** (`--model`, `--ask-for-approval`, `--sandbox`, `--full-auto`, `--enable`, `--profile`, etc.)
+- Changed **config format** (`hooks.json` structure, `config.toml` features section)
+- New **sandbox modes** or **approval modes**
+- New **tool types** beyond Bash in PreToolUse/PostToolUse events
+- Changes to **`codex resume`** subcommand behavior
+- New or changed **environment variables**
+- Changes to how hooks receive input on stdin or return output on stdout
+
+### 2. Fetch detailed diffs
+
+For deeper analysis, compare tags in the release repo:
+
+```bash
+# Compare two tags to see all changed files
+gh api repos/openai/codex/compare/{FROM_VERSION}...{TO_VERSION} --jq '.files[] | "\(.filename) (\(.status))"' | head -100
+
+# Read hooks schema or config modules at a given tag
+gh api "repos/openai/codex/contents/codex-rs/hooks?ref={TO_VERSION}" --jq '.[] | .name'
+```
+
+Focus on changes in `codex-rs/hooks/`, `codex-rs/config/`, `codex-rs/cli/`, and any files mentioning `hook`, `approval`, `sandbox`, or `config`.
+
+### 3. Scan the Canopy codebase
+
+**Known integration points** (start here):
+
+- `src/main/agents/adapters/codex.ts` — adapter: hook events, event normalization, CLI args, env vars, hooks.json setup, resume args
+- `src/renderer/src/components/preferences/CodexPrefs.svelte` — preference options (model, approval mode, sandbox, full-auto, profile, API key, base URL)
+- `src/renderer/src/components/agents/CodexExtras.svelte` — inspector extras (cwd, turns, transcript, last response)
+- `src/renderer/src/lib/agents/agentState.svelte.ts` — agent state handling, extra data merging
+- `src/main/agents/types.ts` — AgentType union, NormalizedEventName, AgentAdapter interface
+
+**Then discover more** — search broadly for additional references:
+
+```bash
+grep -r "codex" --include="*.ts" --include="*.svelte" --include="*.yml" --include="*.json" -l .
+grep -r "openai" --include="*.ts" --include="*.json" -l .
+```
+
+### 4. Apply changes
+
+Be **proactive** — not just compatibility fixes but also:
+
+- Add new hook events if Codex introduces them (update `CODEX_HOOK_EVENTS`, `EVENT_MAP`, and `busyEvents`/`idleEvents` in `codex.ts`)
+- Add new CLI flags to `buildCliArgs` and corresponding preference fields in `CodexPrefs.svelte`
+- Update `normalizeEvent` if new input fields appear in hook stdin JSON
+- Add new approval/sandbox mode options to preference dropdowns
+- Extract new data from hooks into `extra` field for the inspector
+- Update `toNotchStatus` if new status transitions become available
+
+For each change, make a **targeted, minimal edit**. Do not reformat or restructure code beyond what the change requires.
+
+### 5. Create or update the PR
+
+Use the FROM_VERSION, TO_VERSION, and EXISTING_PR values from the prompt header.
+
+**If no existing PR** (EXISTING_PR is empty):
+
+1. Create the branch: `git checkout -b chore/codex-compat`
+2. Commit changes with descriptive messages (one commit per logical change group, use `chore:` or `fix:` prefix)
+3. Push: `git push origin chore/codex-compat`
+4. Create PR targeting `next` with this structure:
+
+```
+Title: chore(deps): codex compatibility update ({FROM_VERSION} → {TO_VERSION})
+
+Body:
+## Codex CLI Compatibility Update
+
+### Versions analyzed
+[List each version analyzed]
+
+### Relevant changes
+[For each version: key changes that affected our codebase]
+
+### Modifications made
+[For each file changed: what was modified and why]
+
+### Risk assessment
+[Low/Medium/High — explain any risks or breaking changes]
+```
+
+**If existing PR** (EXISTING_PR is a PR number):
+
+1. Checkout the existing branch: `git fetch origin chore/codex-compat && git checkout chore/codex-compat`
+2. Commit incremental changes
+3. Push: `git push origin chore/codex-compat`
+4. Update the PR title and description to cover the expanded version range using `gh pr edit`
+
+### 6. If no changes needed
+
+If after analysis you determine no code changes are required:
+
+1. Do NOT create a branch or PR
+2. Write a summary to `$GITHUB_STEP_SUMMARY`:
+
+```bash
+cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+## Codex CLI Compatibility Check
+
+Analyzed versions: {FROM_VERSION} → {TO_VERSION}
+
+**No code changes needed.** The release changes do not affect Canopy's integration.
+EOF
+```
+
+## Tone
+
+Be precise and factual. State what you found, what you changed, and why. No filler or commentary beyond what is needed to explain each decision.

--- a/.github/workflows/codex-compat.yml
+++ b/.github/workflows/codex-compat.yml
@@ -1,0 +1,228 @@
+name: Codex CLI Compatibility Check
+
+on:
+  schedule:
+    # Twice daily at 06:43 and 18:43 UTC (offset from claude-code-compat)
+    - cron: '43 6,18 * * *'
+  workflow_dispatch:
+    inputs:
+      from_version:
+        description: 'Force check from this version (e.g., rust-v0.117.0). Overrides tracked version.'
+        required: false
+        type: string
+
+concurrency:
+  group: codex-compat
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: next
+          fetch-depth: 1
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - uses: volta-cli/action@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ── Version check (early exit if nothing new) ─────────────
+      - name: Read tracked version
+        id: tracked
+        run: |
+          if [ -f .github/codex-version.json ]; then
+            VERSION=$(jq -r '.lastCheckedVersion' .github/codex-version.json)
+          else
+            VERSION="rust-v0.0.0"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch latest stable release from openai/codex
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Filter out alpha/beta/rc prereleases, take first (most recent) stable
+          LATEST=$(gh api repos/openai/codex/releases --paginate \
+            --jq '[.[] | select(.tag_name | test("alpha|beta|rc") | not)] | .[0].tag_name')
+          if [ -z "$LATEST" ]; then
+            echo "No stable releases found" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Determine version range
+        id: range
+        env:
+          INPUT_FROM_VERSION: ${{ inputs.from_version }}
+          TRACKED_VERSION: ${{ steps.tracked.outputs.version }}
+          LATEST_VERSION: ${{ steps.latest.outputs.version }}
+        run: |
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "new_releases=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$INPUT_FROM_VERSION" ]; then
+            FROM="$INPUT_FROM_VERSION"
+          else
+            FROM="$TRACKED_VERSION"
+          fi
+          TO="$LATEST_VERSION"
+
+          if [ "$FROM" = "$TO" ]; then
+            echo "new_releases=false" >> "$GITHUB_OUTPUT"
+            echo "No new releases (tracked: $FROM, latest: $TO)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "new_releases=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "from=$FROM" >> "$GITHUB_OUTPUT"
+          echo "to=$TO" >> "$GITHUB_OUTPUT"
+
+      # ── Enumerate and fetch release notes ─────────────────────
+      - name: Fetch release notes for new versions
+        if: steps.range.outputs.new_releases == 'true'
+        id: releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FROM_VERSION: ${{ steps.range.outputs.from }}
+          TO_VERSION: ${{ steps.range.outputs.to }}
+        run: |
+          # Fetch all stable release tags from openai/codex
+          RELEASES=$(gh api repos/openai/codex/releases --paginate \
+            --jq '[.[] | select(.tag_name | test("alpha|beta|rc") | not)] | .[].tag_name')
+
+          # Strip rust-v prefix for semver comparison, then filter
+          FILTERED=$(echo "$RELEASES" | while read -r tag; do
+            FROM_STRIPPED="${FROM_VERSION#rust-v}"
+            TO_STRIPPED="${TO_VERSION#rust-v}"
+            TAG_STRIPPED="${tag#rust-v}"
+            if [ "$(printf '%s\n%s' "$FROM_STRIPPED" "$TAG_STRIPPED" | sort -V | head -1)" = "$FROM_STRIPPED" ] && \
+               [ "$tag" != "$FROM_VERSION" ] && \
+               [ "$(printf '%s\n%s' "$TAG_STRIPPED" "$TO_STRIPPED" | sort -V | head -1)" = "$TAG_STRIPPED" ]; then
+              echo "$tag"
+            fi
+          done | sort -t'v' -k2 -V)
+
+          echo "Versions to analyze:"
+          echo "$FILTERED"
+
+          # Fetch release body for each version and write to file
+          > /tmp/release-notes.md
+          for tag in $FILTERED; do
+            echo "Fetching release notes for $tag..."
+            BODY=$(gh api "repos/openai/codex/releases/tags/$tag" --jq '.body // "No release notes."')
+            {
+              echo "### ${tag}"
+              echo ""
+              echo "$BODY"
+              echo ""
+              echo "---"
+              echo ""
+            } >> /tmp/release-notes.md
+          done
+
+          echo "$FILTERED" > /tmp/version-list.txt
+          COUNT=$(echo "$FILTERED" | grep -c . || true)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      # ── Check for existing PR ─────────────────────────────────
+      - name: Check for existing compatibility PR
+        if: steps.range.outputs.new_releases == 'true'
+        id: existing_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list --head chore/codex-compat --state open --json number --jq '.[0].number // empty')
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      # ── Read prompt ───────────────────────────────────────────
+      - name: Read analysis prompt
+        if: steps.range.outputs.new_releases == 'true'
+        id: prompt
+        run: |
+          # Randomized delimiter prevents injection via untrusted release notes
+          DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
+          echo "content<<${DELIM}" >> "$GITHUB_OUTPUT"
+          cat .github/prompts/codex-compat.md >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "## Release Notes" >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          cat /tmp/release-notes.md >> "$GITHUB_OUTPUT"
+          echo "${DELIM}" >> "$GITHUB_OUTPUT"
+
+      # ── Run Claude Code analysis ──────────────────────────────
+      - name: Run compatibility analysis
+        if: steps.range.outputs.new_releases == 'true'
+        id: analysis
+        uses: anthropics/claude-code-action@v1
+        with:
+          allowed_bots: 'claude,dependabot'
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            FROM_VERSION: ${{ steps.range.outputs.from }}
+            TO_VERSION: ${{ steps.range.outputs.to }}
+            EXISTING_PR: ${{ steps.existing_pr.outputs.number }}
+
+            ${{ steps.prompt.outputs.content }}
+          claude_args: |
+            --model opus[1m]
+            --effort max
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git checkout chore/codex-compat),Bash(git checkout -b chore/codex-compat),Bash(git add:*),Bash(git commit:*),Bash(git push origin chore/codex-compat),Bash(git diff:*),Bash(git status:*),Bash(git fetch origin:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh api repos/openai/codex/:*)"
+          settings: |
+            {
+              "env": {
+                "ANTHROPIC_AUTH_TOKEN": "${{ secrets.ANTHROPIC_AUTH_TOKEN }}",
+                "ANTHROPIC_BASE_URL": "${{ secrets.ANTHROPIC_BASE_URL }}"
+              }
+            }
+
+      # ── Update version tracker ────────────────────────────────
+      - name: Update version tracker
+        if: steps.range.outputs.new_releases == 'true'
+        env:
+          TO_VERSION: ${{ steps.range.outputs.to }}
+        run: |
+          # Claude may have left unstaged changes or switched branches —
+          # discard everything and sync hard to the latest remote next.
+          git fetch origin next
+          git checkout next
+          git reset --hard origin/next
+          git clean -fdx -- ':!node_modules'
+
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          jq -n --arg v "$TO_VERSION" --arg t "$TIMESTAMP" \
+            '{lastCheckedVersion: $v, lastCheckedAt: $t}' \
+            > .github/codex-version.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/codex-version.json
+          if ! git diff --cached --quiet; then
+            git commit -m "ci: update codex version tracker [skip ci]"
+            git push origin next
+          fi
+
+      # ── Rebase compat branch onto updated next ───────────────
+      - name: Rebase compatibility branch
+        if: steps.range.outputs.new_releases == 'true'
+        run: |
+          # Only rebase if the compat branch exists on the remote
+          if git ls-remote --exit-code origin chore/codex-compat >/dev/null 2>&1; then
+            git fetch origin chore/codex-compat
+            git checkout chore/codex-compat
+            git rebase next || { git rebase --abort; echo "Rebase conflict — skipping"; exit 0; }
+            git push origin chore/codex-compat --force-with-lease
+          fi

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -818,7 +818,7 @@ software or this license, under any kind of legal claim.***
 
 The following npm package may be included in this product:
 
- - @anthropic-ai/claude-agent-sdk@0.2.81
+ - @anthropic-ai/claude-agent-sdk@0.2.98
 
 This package contains the following license:
 

--- a/src/main/agents/AgentSessionManager.ts
+++ b/src/main/agents/AgentSessionManager.ts
@@ -10,6 +10,7 @@ import type { NotchSessionStatus } from '../notch/types'
 import { getAdapter, registerAdapter, isAgentTool as isRegistered } from './registry'
 import { claudeAdapter } from './adapters/claude'
 import { geminiAdapter } from './adapters/gemini'
+import { codexAdapter } from './adapters/codex'
 
 interface AgentSession {
   agentType: AgentType
@@ -46,6 +47,7 @@ export class AgentSessionManager extends EventEmitter {
     // Register built-in adapters
     registerAdapter(claudeAdapter)
     registerAdapter(geminiAdapter)
+    registerAdapter(codexAdapter)
   }
 
   get sessionCount(): number {

--- a/src/main/agents/adapters/codex.ts
+++ b/src/main/agents/adapters/codex.ts
@@ -1,0 +1,255 @@
+import { match, P } from 'ts-pattern'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, rmdirSync } from 'fs'
+import { join } from 'path'
+import type {
+  AgentAdapter,
+  AgentType,
+  NormalizedEventName,
+  NormalizedHookEvent,
+  NormalizedStatusData,
+  PreferencesReader,
+  SettingsSetup,
+} from '../types'
+import type { SessionStatusType } from '../../notch/types'
+import { BLOCKED_ENV_VARS } from '../../security/envBlocklist'
+import { summarizeToolInput } from '../utils'
+
+const CODEX_HOOK_EVENTS = ['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse', 'Stop']
+
+const EVENT_MAP: Record<string, NormalizedEventName> = {
+  SessionStart: 'SessionStart',
+  UserPromptSubmit: 'PromptSubmit',
+  PreToolUse: 'BeforeToolUse',
+  PostToolUse: 'AfterToolUse',
+  Stop: 'Idle',
+}
+
+const INTERNAL_BLOCKED = new Set(['CANOPY_HOOK_PORT', 'CANOPY_HOOK_TOKEN', 'ELECTRON_RUN_AS_NODE'])
+
+/** Refcount for concurrent Codex sessions sharing the same worktree hooks.json */
+interface WorktreeRef {
+  count: number
+  original: string | null
+  createdDir: boolean
+}
+const worktreeRefs = new Map<string, WorktreeRef>()
+
+function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const out = { ...target }
+  for (const [key, val] of Object.entries(source)) {
+    if (
+      val !== null &&
+      typeof val === 'object' &&
+      !Array.isArray(val) &&
+      typeof out[key] === 'object' &&
+      out[key] !== null &&
+      !Array.isArray(out[key])
+    ) {
+      out[key] = deepMerge(out[key] as Record<string, unknown>, val as Record<string, unknown>)
+    } else {
+      out[key] = val
+    }
+  }
+  return out
+}
+
+export const codexAdapter: AgentAdapter = {
+  agentType: 'codex' as AgentType,
+  toolId: 'codex',
+
+  busyEvents: new Set(['UserPromptSubmit', 'PreToolUse']),
+  idleEvents: new Set(['Stop']),
+
+  setupSettings(
+    _settingsPath: string,
+    worktreePath: string,
+    hookScriptPath: string,
+    _statusLineScriptPath: string | null,
+    overrides?: Record<string, unknown>,
+  ): SettingsSetup {
+    const codexDir = join(worktreePath, '.codex')
+    const hooksPath = join(codexDir, 'hooks.json')
+
+    let ref = worktreeRefs.get(worktreePath)
+    if (!ref) {
+      const createdDir = !existsSync(codexDir)
+      if (createdDir) mkdirSync(codexDir, { recursive: true })
+
+      let original: string | null = null
+      if (existsSync(hooksPath)) {
+        try {
+          original = readFileSync(hooksPath, 'utf-8')
+        } catch {
+          /* inaccessible */
+        }
+      }
+
+      ref = { count: 0, original, createdDir }
+      worktreeRefs.set(worktreePath, ref)
+    }
+    ref.count++
+
+    // Build Canopy hook entries
+    const canopyHooks: Record<
+      string,
+      Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>
+    > = {}
+    for (const event of CODEX_HOOK_EVENTS) {
+      canopyHooks[event] = [{ matcher: '', hooks: [{ type: 'command', command: hookScriptPath }] }]
+    }
+
+    // Merge with existing project-level hooks
+    let existing: Record<string, unknown> = {}
+    if (ref.original) {
+      try {
+        existing = JSON.parse(ref.original)
+      } catch {
+        /* corrupt file */
+      }
+    }
+
+    const merged = deepMerge(existing, { ...(overrides ?? {}), hooks: canopyHooks })
+    writeFileSync(hooksPath, JSON.stringify(merged, null, 2), 'utf-8')
+
+    return {
+      args: ['--enable', 'codex_hooks'],
+      cleanup: () => {
+        const r = worktreeRefs.get(worktreePath)
+        if (!r) return
+        r.count--
+        if (r.count <= 0) {
+          try {
+            if (r.original !== null) {
+              writeFileSync(hooksPath, r.original, 'utf-8')
+            } else {
+              unlinkSync(hooksPath)
+              if (r.createdDir) {
+                rmdirSync(codexDir)
+              }
+            }
+          } catch {
+            /* best-effort */
+          }
+          worktreeRefs.delete(worktreePath)
+        }
+      },
+    }
+  },
+
+  normalizeEvent(raw: Record<string, unknown>): NormalizedHookEvent {
+    const rawName = (raw.hook_event_name as string) ?? ''
+
+    // Collect Codex-specific extra fields for the inspector
+    const extra: Record<string, unknown> = {}
+    if (raw.cwd) extra.cwd = raw.cwd
+    if (raw.transcript_path) extra.transcriptPath = raw.transcript_path
+    if (raw.turn_id) extra.turnId = raw.turn_id
+    if (raw.last_assistant_message) extra.lastAssistantMessage = raw.last_assistant_message
+    if (raw.source) extra.source = raw.source
+
+    return {
+      agentType: 'codex',
+      sessionId: (raw.session_id as string) ?? '',
+      event: EVENT_MAP[rawName] ?? 'Unknown',
+      rawEventName: rawName,
+      toolName: raw.tool_name as string | undefined,
+      toolInput: raw.tool_input as Record<string, unknown> | undefined,
+      toolResponse: raw.tool_response as string | undefined,
+      error: raw.error as string | undefined,
+      errorDetails: raw.error_details as string | undefined,
+      message: raw.message as string | undefined,
+      title: raw.title as string | undefined,
+      model: raw.model as string | undefined,
+      permissionMode: raw.permission_mode as string | undefined,
+      prompt: raw.prompt as string | undefined,
+      extra: Object.keys(extra).length > 0 ? extra : undefined,
+    }
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  normalizeStatus(_raw: Record<string, unknown>): NormalizedStatusData {
+    // Codex does not expose a status line
+    return {}
+  },
+
+  buildCliArgs(prefs: PreferencesReader): string[] {
+    const args: string[] = []
+    const model = prefs.get('codex.model')
+    const approvalMode = prefs.get('codex.approvalMode')
+    const sandbox = prefs.get('codex.sandbox')
+    const fullAuto = prefs.get('codex.fullAuto')
+    const profile = prefs.get('codex.profile')
+
+    if (model) args.push('--model', model)
+    if (approvalMode) args.push('--ask-for-approval', approvalMode)
+    if (sandbox) args.push('--sandbox', sandbox)
+    if (fullAuto === 'true') args.push('--full-auto')
+    if (profile) args.push('--profile', profile)
+
+    return args
+  },
+
+  buildEnvVars(prefs: PreferencesReader): Record<string, string> {
+    const env: Record<string, string> = {}
+
+    const apiKey = prefs.get('codex.apiKey')
+    const baseUrl = prefs.get('codex.baseUrl')
+    const customEnv = prefs.get('codex.customEnv')
+
+    if (apiKey) env.OPENAI_API_KEY = apiKey
+    if (baseUrl) env.OPENAI_BASE_URL = baseUrl
+
+    if (customEnv) {
+      try {
+        const parsed = JSON.parse(customEnv)
+        for (const [k, v] of Object.entries(parsed)) {
+          if (
+            typeof v === 'string' &&
+            !BLOCKED_ENV_VARS.has(k.toUpperCase()) &&
+            !INTERNAL_BLOCKED.has(k)
+          ) {
+            env[k] = v
+          }
+        }
+      } catch {
+        // Invalid JSON
+      }
+    }
+
+    return env
+  },
+
+  buildResumeArgs(resumeSessionId: string): string[] {
+    return ['resume', resumeSessionId]
+  },
+
+  buildSessionContext(worktreePath: string, workspaceName: string, branch: string | null): string {
+    let ctx = `Working in canopy workspace '${workspaceName}'`
+    if (branch) {
+      ctx += `, worktree '${branch}' (branch: ${branch})`
+    }
+    ctx += `.\nProject root: ${worktreePath}.`
+    return ctx
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  formatNotification(_event: NormalizedHookEvent): { title: string; body: string } | null {
+    // Codex has no interactive permission request events
+    return null
+  },
+
+  toNotchStatus(event: NormalizedHookEvent): { status: SessionStatusType; detail?: string } | null {
+    const toolDetail = event.toolName
+      ? `${event.toolName}: ${summarizeToolInput(event.toolInput)}`
+      : undefined
+
+    return match(event.event)
+      .with(P.union('SessionStart', 'Idle'), () => ({ status: 'idle' as const }))
+      .with(P.union('PromptSubmit', 'AfterToolUse'), () => ({ status: 'thinking' as const }))
+      .with('BeforeToolUse', () => ({ status: 'toolCalling' as const, detail: toolDetail }))
+      .otherwise(() => null)
+  },
+}

--- a/src/main/agents/adapters/codex.ts
+++ b/src/main/agents/adapters/codex.ts
@@ -12,7 +12,7 @@ import type {
 } from '../types'
 import type { SessionStatusType } from '../../notch/types'
 import { BLOCKED_ENV_VARS } from '../../security/envBlocklist'
-import { summarizeToolInput } from '../utils'
+import { deepMerge, summarizeToolInput } from '../utils'
 
 const CODEX_HOOK_EVENTS = ['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse', 'Stop']
 
@@ -26,35 +26,16 @@ const EVENT_MAP: Record<string, NormalizedEventName> = {
 
 const INTERNAL_BLOCKED = new Set(['CANOPY_HOOK_PORT', 'CANOPY_HOOK_TOKEN', 'ELECTRON_RUN_AS_NODE'])
 
+const CODEX_GITIGNORE_ENTRY = '.codex/'
+
 /** Refcount for concurrent Codex sessions sharing the same worktree hooks.json */
 interface WorktreeRef {
   count: number
   original: string | null
   createdDir: boolean
+  addedGitignore: boolean
 }
 const worktreeRefs = new Map<string, WorktreeRef>()
-
-function deepMerge(
-  target: Record<string, unknown>,
-  source: Record<string, unknown>,
-): Record<string, unknown> {
-  const out = { ...target }
-  for (const [key, val] of Object.entries(source)) {
-    if (
-      val !== null &&
-      typeof val === 'object' &&
-      !Array.isArray(val) &&
-      typeof out[key] === 'object' &&
-      out[key] !== null &&
-      !Array.isArray(out[key])
-    ) {
-      out[key] = deepMerge(out[key] as Record<string, unknown>, val as Record<string, unknown>)
-    } else {
-      out[key] = val
-    }
-  }
-  return out
-}
 
 export const codexAdapter: AgentAdapter = {
   agentType: 'codex' as AgentType,
@@ -87,7 +68,22 @@ export const codexAdapter: AgentAdapter = {
         }
       }
 
-      ref = { count: 0, original, createdDir }
+      // Ensure .codex/ is gitignored so hooks.json (containing local paths) isn't committed
+      let addedGitignore = false
+      const gitignorePath = join(worktreePath, '.gitignore')
+      try {
+        const content = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : ''
+        const lines = content.split('\n')
+        if (!lines.some((l) => l.trim() === CODEX_GITIGNORE_ENTRY || l.trim() === '.codex')) {
+          const suffix = content.length > 0 && !content.endsWith('\n') ? '\n' : ''
+          writeFileSync(gitignorePath, content + suffix + CODEX_GITIGNORE_ENTRY + '\n', 'utf-8')
+          addedGitignore = true
+        }
+      } catch {
+        /* gitignore may be unwritable */
+      }
+
+      ref = { count: 0, original, createdDir, addedGitignore }
       worktreeRefs.set(worktreePath, ref)
     }
     ref.count++
@@ -132,6 +128,20 @@ export const codexAdapter: AgentAdapter = {
             }
           } catch {
             /* best-effort */
+          }
+          // Remove gitignore entry we added
+          if (r.addedGitignore) {
+            try {
+              const gitignorePath = join(worktreePath, '.gitignore')
+              const content = readFileSync(gitignorePath, 'utf-8')
+              const cleaned = content
+                .split('\n')
+                .filter((l) => l.trim() !== CODEX_GITIGNORE_ENTRY)
+                .join('\n')
+              writeFileSync(gitignorePath, cleaned, 'utf-8')
+            } catch {
+              /* best-effort */
+            }
           }
           worktreeRefs.delete(worktreePath)
         }
@@ -209,7 +219,7 @@ export const codexAdapter: AgentAdapter = {
           if (
             typeof v === 'string' &&
             !BLOCKED_ENV_VARS.has(k.toUpperCase()) &&
-            !INTERNAL_BLOCKED.has(k)
+            !INTERNAL_BLOCKED.has(k.toUpperCase())
           ) {
             env[k] = v
           }

--- a/src/main/agents/adapters/gemini.ts
+++ b/src/main/agents/adapters/gemini.ts
@@ -23,7 +23,7 @@ import type {
 } from '../types'
 import type { SessionStatusType } from '../../notch/types'
 import { BLOCKED_ENV_VARS } from '../../security/envBlocklist'
-import { summarizeToolInput } from '../utils'
+import { deepMerge, summarizeToolInput } from '../utils'
 
 /** Model ID -> context window size in tokens (lazy-loaded) */
 let geminiModelLimits: Record<string, number> | null = null
@@ -81,28 +81,6 @@ const EVENT_MAP: Record<string, NormalizedEventName> = {
 }
 
 const INTERNAL_BLOCKED = new Set(['CANOPY_HOOK_PORT', 'CANOPY_HOOK_TOKEN', 'ELECTRON_RUN_AS_NODE'])
-
-function deepMerge(
-  target: Record<string, unknown>,
-  source: Record<string, unknown>,
-): Record<string, unknown> {
-  const out = { ...target }
-  for (const [key, val] of Object.entries(source)) {
-    if (
-      val !== null &&
-      typeof val === 'object' &&
-      !Array.isArray(val) &&
-      typeof out[key] === 'object' &&
-      out[key] !== null &&
-      !Array.isArray(out[key])
-    ) {
-      out[key] = deepMerge(out[key] as Record<string, unknown>, val as Record<string, unknown>)
-    } else {
-      out[key] = val
-    }
-  }
-  return out
-}
 
 export const geminiAdapter: AgentAdapter = {
   agentType: 'gemini' as AgentType,
@@ -277,7 +255,7 @@ export const geminiAdapter: AgentAdapter = {
           if (
             typeof v === 'string' &&
             !BLOCKED_ENV_VARS.has(k.toUpperCase()) &&
-            !INTERNAL_BLOCKED.has(k)
+            !INTERNAL_BLOCKED.has(k.toUpperCase())
           ) {
             env[k] = v
           }

--- a/src/main/agents/types.ts
+++ b/src/main/agents/types.ts
@@ -1,6 +1,6 @@
 import type { SessionStatusType } from '../notch/types'
 
-export type AgentType = 'claude' | 'gemini'
+export type AgentType = 'claude' | 'gemini' | 'codex'
 
 export type NormalizedEventName =
   | 'SessionStart'

--- a/src/main/agents/utils.ts
+++ b/src/main/agents/utils.ts
@@ -1,3 +1,25 @@
+export function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const out = { ...target }
+  for (const [key, val] of Object.entries(source)) {
+    if (
+      val !== null &&
+      typeof val === 'object' &&
+      !Array.isArray(val) &&
+      typeof out[key] === 'object' &&
+      out[key] !== null &&
+      !Array.isArray(out[key])
+    ) {
+      out[key] = deepMerge(out[key] as Record<string, unknown>, val as Record<string, unknown>)
+    } else {
+      out[key] = val
+    }
+  }
+  return out
+}
+
 export function truncate(text: string, max: number): string {
   return text.length > max ? text.slice(0, max - 3) + '...' : text
 }

--- a/src/renderer/src/components/agents/AgentInspector.svelte
+++ b/src/renderer/src/components/agents/AgentInspector.svelte
@@ -2,6 +2,7 @@
   import { match, P } from 'ts-pattern'
   import type { AgentSessionState } from '../../lib/agents/agentState.svelte'
   import ClaudeExtras from './ClaudeExtras.svelte'
+  import CodexExtras from './CodexExtras.svelte'
 
   let {
     state,
@@ -157,6 +158,8 @@
   <!-- Agent-specific extras -->
   {#if state.agentType === 'claude'}
     <ClaudeExtras extra={state.extra} />
+  {:else if state.agentType === 'codex'}
+    <CodexExtras extra={state.extra} />
   {/if}
 
   <!-- Tasks -->

--- a/src/renderer/src/components/agents/CodexExtras.svelte
+++ b/src/renderer/src/components/agents/CodexExtras.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  let { extra }: { extra: Record<string, unknown> } = $props()
+
+  let cwd = $derived((extra.cwd as string | undefined) ?? null)
+  let turnCount = $derived((extra.turnCount as number | undefined) ?? null)
+  let transcriptPath = $derived((extra.transcriptPath as string | undefined) ?? null)
+  let lastMessage = $derived((extra.lastAssistantMessage as string | undefined) ?? null)
+
+  function shortPath(p: string): string {
+    const home = p.match(/^\/Users\/[^/]+/)
+    if (home) return '~' + p.slice(home[0].length)
+    return p
+  }
+
+  function truncate(text: string, max: number): string {
+    return text.length > max ? text.slice(0, max - 1) + '\u2026' : text
+  }
+</script>
+
+{#if cwd || turnCount || transcriptPath || lastMessage}
+  <div class="section">
+    <h4 class="section-label">Codex</h4>
+    <div class="info-grid">
+      {#if turnCount}
+        <span class="info-key">Turns</span>
+        <span class="info-val">{turnCount}</span>
+      {/if}
+      {#if cwd}
+        <span class="info-key">CWD</span>
+        <span class="info-val mono" title={cwd}>{shortPath(cwd)}</span>
+      {/if}
+      {#if transcriptPath}
+        <span class="info-key">Transcript</span>
+        <span class="info-val mono" title={transcriptPath}
+          >{shortPath(transcriptPath).split('/').pop()}</span
+        >
+      {/if}
+    </div>
+  </div>
+{/if}
+
+{#if lastMessage}
+  <div class="section">
+    <h4 class="section-label">Last response</h4>
+    <p class="last-msg">{truncate(lastMessage, 200)}</p>
+  </div>
+{/if}
+
+<style>
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .section-label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--c-text-faint);
+    margin: 0;
+  }
+
+  .info-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 3px 12px;
+    font-size: 12px;
+  }
+
+  .info-key {
+    color: var(--c-text-muted);
+  }
+
+  .info-val {
+    color: var(--c-text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mono {
+    font-family: monospace;
+    font-size: 11px;
+  }
+
+  .last-msg {
+    font-size: 11px;
+    color: var(--c-text-secondary);
+    margin: 0;
+    line-height: 1.4;
+    word-break: break-word;
+  }
+</style>

--- a/src/renderer/src/components/agents/CodexExtras.svelte
+++ b/src/renderer/src/components/agents/CodexExtras.svelte
@@ -7,7 +7,7 @@
   let lastMessage = $derived((extra.lastAssistantMessage as string | undefined) ?? null)
 
   function shortPath(p: string): string {
-    const home = p.match(/^\/Users\/[^/]+/)
+    const home = p.match(/^(?:\/Users\/[^/]+|\/home\/[^/]+|[A-Z]:\\Users\\[^\\]+)/)
     if (home) return '~' + p.slice(home[0].length)
     return p
   }

--- a/src/renderer/src/components/agents/CodexExtras.svelte
+++ b/src/renderer/src/components/agents/CodexExtras.svelte
@@ -32,7 +32,7 @@
       {#if transcriptPath}
         <span class="info-key">Transcript</span>
         <span class="info-val mono" title={transcriptPath}
-          >{shortPath(transcriptPath).split('/').pop()}</span
+          >{shortPath(transcriptPath).split(/[/\\]/).pop()}</span
         >
       {/if}
     </div>

--- a/src/renderer/src/components/preferences/CodexPrefs.svelte
+++ b/src/renderer/src/components/preferences/CodexPrefs.svelte
@@ -1,0 +1,445 @@
+<script lang="ts">
+  import { prefs, setPref } from '../../lib/stores/preferences.svelte'
+  import CustomSelect from '../shared/CustomSelect.svelte'
+
+  // Model & behavior
+  let model = $derived(prefs['codex.model'] || '')
+  let approvalMode = $derived(prefs['codex.approvalMode'] || '')
+  let sandbox = $derived(prefs['codex.sandbox'] || '')
+  let fullAuto = $derived(prefs['codex.fullAuto'] === 'true')
+  let profile = $derived(prefs['codex.profile'] || '')
+
+  // API
+  let apiKey = $derived(prefs['codex.apiKey'] || '')
+  let baseUrl = $derived(prefs['codex.baseUrl'] || '')
+
+  // Custom env vars
+  let envEntries = $derived.by(() => {
+    const raw = prefs['codex.customEnv']
+    if (!raw) return [] as Array<{ key: string; value: string }>
+    try {
+      const parsed = JSON.parse(raw) as Record<string, string>
+      return Object.entries(parsed).map(([key, value]) => ({ key, value }))
+    } catch {
+      return [] as Array<{ key: string; value: string }>
+    }
+  })
+  let showEnvForm = $state(false)
+  let newEnvKey = $state('')
+  let newEnvValue = $state('')
+
+  // Settings JSON
+  let settingsJson = $derived(prefs['codex.settingsJson'] || '')
+
+  function persistEnvEntries(entries: Array<{ key: string; value: string }>): void {
+    const obj: Record<string, string> = {}
+    for (const entry of entries) {
+      if (entry.key.trim()) obj[entry.key.trim()] = entry.value
+    }
+    if (Object.keys(obj).length > 0) {
+      setPref('codex.customEnv', JSON.stringify(obj))
+    } else {
+      setPref('codex.customEnv', '')
+    }
+  }
+
+  function addEnvVar(): void {
+    if (!newEnvKey.trim()) return
+    persistEnvEntries([...envEntries, { key: newEnvKey.trim(), value: newEnvValue }])
+    newEnvKey = ''
+    newEnvValue = ''
+    showEnvForm = false
+  }
+
+  function removeEnvVar(index: number): void {
+    persistEnvEntries(envEntries.filter((_, i) => i !== index))
+  }
+
+  function updatePref(key: string): (e: Event) => void {
+    return (e: Event) => {
+      const target = e.target as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+      setPref(key, target.value)
+    }
+  }
+</script>
+
+<div class="section">
+  <h3 class="section-title">Codex</h3>
+
+  <div class="subsection">
+    <h4 class="subsection-title">Model & behavior</h4>
+
+    <div class="field">
+      <label class="field-label" for="codex-model">Model</label>
+      <input
+        id="codex-model"
+        class="text-input"
+        type="text"
+        value={model}
+        onchange={updatePref('codex.model')}
+        placeholder="Default"
+        spellcheck="false"
+      />
+      <span class="field-hint">Leave empty for Codex default</span>
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="codex-approval">Approval mode</label>
+      <span class="field-hint">Controls when Codex pauses for human approval</span>
+      <CustomSelect
+        id="codex-approval"
+        value={approvalMode}
+        options={[
+          { value: '', label: 'Default' },
+          { value: 'untrusted', label: 'Untrusted' },
+          { value: 'on-request', label: 'On Request' },
+          { value: 'never', label: 'Never' },
+        ]}
+        onchange={(v) => setPref('codex.approvalMode', v)}
+      />
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="codex-sandbox">Sandbox</label>
+      <span class="field-hint">Command execution policy</span>
+      <CustomSelect
+        id="codex-sandbox"
+        value={sandbox}
+        options={[
+          { value: '', label: 'Default' },
+          { value: 'read-only', label: 'Read Only' },
+          { value: 'workspace-write', label: 'Workspace Write' },
+          { value: 'danger-full-access', label: 'Full Access' },
+        ]}
+        onchange={(v) => setPref('codex.sandbox', v)}
+      />
+    </div>
+
+    <div class="field">
+      <label class="field-label checkbox-label">
+        <input
+          type="checkbox"
+          checked={fullAuto}
+          onchange={() => setPref('codex.fullAuto', fullAuto ? '' : 'true')}
+        />
+        Full auto
+      </label>
+      <span class="field-hint">Workspace-write sandbox + on-request approvals</span>
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="codex-profile">Profile</label>
+      <input
+        id="codex-profile"
+        class="text-input"
+        type="text"
+        value={profile}
+        onchange={updatePref('codex.profile')}
+        placeholder="Default"
+        spellcheck="false"
+      />
+      <span class="field-hint">Configuration profile from config.toml</span>
+    </div>
+  </div>
+
+  <div class="subsection">
+    <h4 class="subsection-title">API</h4>
+
+    <div class="field">
+      <label class="field-label" for="codex-apikey">API key</label>
+      <span class="field-hint">OpenAI API key. Falls back to OPENAI_API_KEY env variable</span>
+      <input
+        id="codex-apikey"
+        class="text-input"
+        type="password"
+        value={apiKey}
+        onchange={updatePref('codex.apiKey')}
+        placeholder="Uses OPENAI_API_KEY from environment"
+        spellcheck="false"
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="codex-baseurl">Base URL</label>
+      <input
+        id="codex-baseurl"
+        class="text-input"
+        type="text"
+        value={baseUrl}
+        onchange={updatePref('codex.baseUrl')}
+        placeholder="https://api.openai.com"
+        spellcheck="false"
+      />
+      <span class="field-hint">Custom API endpoint</span>
+    </div>
+  </div>
+
+  <div class="subsection">
+    <h4 class="subsection-title">Environment variables</h4>
+
+    <p class="field-hint" style="margin: 0 0 4px;">Extra env vars passed to Codex sessions</p>
+
+    {#if envEntries.length > 0}
+      <div class="env-list">
+        {#each envEntries as entry, i (entry.key)}
+          <div class="env-row">
+            <span class="env-key">{entry.key}</span>
+            <span class="env-sep">=</span>
+            <span class="env-value">{entry.value}</span>
+            <button class="remove-btn" onclick={() => removeEnvVar(i)}>Remove</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if showEnvForm}
+      <div class="env-form">
+        <input
+          class="form-input"
+          bind:value={newEnvKey}
+          placeholder="VARIABLE_NAME"
+          spellcheck="false"
+          onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
+        />
+        <input
+          class="form-input"
+          bind:value={newEnvValue}
+          placeholder="value"
+          spellcheck="false"
+          onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
+        />
+        <div class="form-actions">
+          <button class="btn btn-cancel" onclick={() => (showEnvForm = false)}>Cancel</button>
+          <button class="btn btn-add" onclick={addEnvVar}>Add</button>
+        </div>
+      </div>
+    {:else}
+      <button class="btn btn-add-item" onclick={() => (showEnvForm = true)}>+ Add variable</button>
+    {/if}
+  </div>
+
+  <div class="subsection">
+    <h4 class="subsection-title">Advanced</h4>
+
+    <div class="field">
+      <label class="field-label" for="codex-settings">Settings JSON override</label>
+      <textarea
+        id="codex-settings"
+        class="text-input textarea mono"
+        rows="4"
+        value={settingsJson}
+        onchange={updatePref('codex.settingsJson')}
+        placeholder={'{"key": "value"}'}
+        spellcheck="false"
+      ></textarea>
+      <span class="field-hint"
+        >Merged into project-level .codex/hooks.json (hooks always preserved)</span
+      >
+    </div>
+  </div>
+</div>
+
+<style>
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .section-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--c-text);
+    margin: 0;
+  }
+
+  .subsection {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .subsection-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--c-text-muted);
+    margin: 0;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .field-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--c-text-secondary);
+  }
+
+  .field-hint {
+    font-size: 11px;
+    color: var(--c-text-faint);
+  }
+
+  .text-input {
+    padding: 6px 10px;
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+    background: var(--c-hover);
+    color: var(--c-text);
+    font-size: 13px;
+    font-family: inherit;
+    outline: none;
+  }
+
+  .text-input:focus {
+    border-color: var(--c-focus-ring);
+  }
+
+  .textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+
+  .mono {
+    font-family: monospace;
+    font-size: 12px;
+  }
+
+  .checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+  }
+
+  /* Env var list */
+  .env-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .env-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    background: var(--c-border-subtle);
+    font-size: 13px;
+  }
+
+  .env-key {
+    color: var(--c-accent-text);
+    font-family: monospace;
+    font-size: 12px;
+  }
+
+  .env-sep {
+    color: var(--c-text-faint);
+  }
+
+  .env-value {
+    color: var(--c-text-secondary);
+    font-family: monospace;
+    font-size: 12px;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .remove-btn {
+    padding: 2px 8px;
+    border: none;
+    border-radius: 4px;
+    background: var(--c-danger-bg);
+    color: var(--c-danger-text);
+    font-size: 11px;
+    font-family: inherit;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .remove-btn:hover {
+    filter: brightness(1.15);
+  }
+
+  /* Env form */
+  .env-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    border: 1px solid var(--c-border);
+    border-radius: 8px;
+    background: var(--c-border-subtle);
+  }
+
+  .form-input {
+    padding: 6px 10px;
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+    background: var(--c-hover);
+    color: var(--c-text);
+    font-size: 13px;
+    font-family: monospace;
+    outline: none;
+  }
+
+  .form-input:focus {
+    border-color: var(--c-focus-ring);
+  }
+
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .btn {
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+    border: none;
+  }
+
+  .btn-cancel {
+    background: var(--c-active);
+    color: var(--c-text);
+  }
+
+  .btn-add {
+    background: var(--c-accent-bg);
+    color: var(--c-accent-text);
+  }
+
+  .btn-add:hover {
+    background: var(--c-accent-bg-hover);
+  }
+
+  .btn-add-item {
+    align-self: flex-start;
+    padding: 6px 14px;
+    border: 1px dashed var(--c-text-faint);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--c-text-secondary);
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .btn-add-item:hover {
+    background: var(--c-hover);
+    color: var(--c-text);
+  }
+</style>

--- a/src/renderer/src/components/preferences/PreferencesModal.svelte
+++ b/src/renderer/src/components/preferences/PreferencesModal.svelte
@@ -8,6 +8,7 @@
   import ShortcutsPrefs from './ShortcutsPrefs.svelte'
   import ClaudePrefs from './ClaudePrefs.svelte'
   import GeminiPrefs from './GeminiPrefs.svelte'
+  import CodexPrefs from './CodexPrefs.svelte'
   import UpdatePrefs from './UpdatePrefs.svelte'
   import ViewportsPrefs from './ViewportsPrefs.svelte'
   import SidebarPrefs from './SidebarPrefs.svelte'
@@ -27,7 +28,7 @@
     { label: 'General', sections: ['General', 'Updates', 'Privacy', 'Shortcuts'] },
     { label: 'Features', sections: ['Notch', 'Misc'] },
     { label: 'Appearance', sections: ['Appearance', 'Sidebar'] },
-    { label: 'AI Agents', sections: ['Claude', 'Gemini'] },
+    { label: 'AI Agents', sections: ['Claude', 'Gemini', 'Codex'] },
     { label: 'Dev Tools', sections: ['Terminal', 'Tools', 'Git', 'Tasks', 'File Watcher'] },
     { label: 'Web Browser', sections: ['Web Browser'] },
     { label: 'Security', sections: ['Remote Control'] },
@@ -106,6 +107,8 @@
         <ClaudePrefs />
       {:else if activeSection === 'Gemini'}
         <GeminiPrefs />
+      {:else if activeSection === 'Codex'}
+        <CodexPrefs />
       {:else if activeSection === 'Git'}
         <GitPrefs />
       {:else if activeSection === 'Web Browser'}

--- a/src/renderer/src/lib/agents/agentState.svelte.ts
+++ b/src/renderer/src/lib/agents/agentState.svelte.ts
@@ -1,7 +1,7 @@
 import { match } from 'ts-pattern'
 import { SvelteDate } from 'svelte/reactivity'
 
-export type AgentType = 'claude' | 'gemini'
+export type AgentType = 'claude' | 'gemini' | 'codex'
 
 export interface SubagentRecord {
   agentId: string
@@ -140,6 +140,12 @@ export function handleHookEvent(ptySessionId: string, event: NormalizedHookEvent
   if (extra) {
     if (typeof extra.contextPercent === 'number') session.contextPercent = extra.contextPercent
     if (typeof extra.contextSize === 'number') session.contextSize = extra.contextSize
+    // Merge agent-specific extras (Codex: cwd, transcriptPath, turnId, etc.)
+    for (const [k, v] of Object.entries(extra)) {
+      if (k !== 'contextPercent' && k !== 'contextSize') {
+        session.extra[k] = v
+      }
+    }
   }
 
   match(event.event)
@@ -162,6 +168,11 @@ export function handleHookEvent(ptySessionId: string, event: NormalizedHookEvent
     })
     .with('PromptSubmit', () => {
       session.status = { type: 'thinking' }
+      // Track turn count (Codex provides turn_id per turn)
+      if (extra?.turnId) {
+        const count = (session.extra.turnCount as number | undefined) ?? 0
+        session.extra.turnCount = count + 1
+      }
     })
     .with('BeforeToolUse', () => {
       session.status = {


### PR DESCRIPTION
## What

Full hook-based integration for OpenAI Codex CLI, matching the existing Claude Code and Gemini adapters. Codex sessions now get real-time status tracking, inspector data, preferences UI, and session resume.

## Why

Codex was registered as a tool but ran as a plain CLI without hook integration — no status tracking, no inspector, no session context injection, no resume on app restart.

## How it works

- **Hooks setup**: Writes to project-level `.codex/hooks.json` (Codex has no `--settings` flag or config home env var). Merges with existing hooks, refcounts concurrent sessions per worktree, restores original on cleanup. Enables hooks via `--enable codex_hooks` CLI flag.
- **5 hook events**: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop — normalized to the shared event schema.
- **Session resume**: `buildResumeArgs` returns `['resume', sessionId]` (Codex uses a subcommand, not a flag).
- **Inspector**: CodexExtras component shows turn count, working directory, transcript path, and last assistant response.
- **Preferences**: Model, approval mode, sandbox, full-auto, profile, API key, base URL, custom env vars, settings JSON override.

## How to test

1. `npm run dev`, spawn Codex from the tool picker
2. Verify dev console shows `[agent-hook] SessionStart`, `UserPromptSubmit`, `PreToolUse`, etc.
3. Check inspector panel shows model, permission mode, tool calls, turns, CWD
4. Send a prompt, verify notch status transitions: idle → thinking → toolCalling → idle
5. Open Settings → Codex, set a model or approval mode, respawn — verify CLI args include the preference
6. Close and reopen the app — verify the Codex session resumes
7. After session exit, verify `.codex/hooks.json` is cleaned up (or restored if it existed before)

## Checklist

- [x] Follows existing adapter pattern (Claude, Gemini)
- [x] `npm run typecheck` passes (0 errors, 0 warnings)
- [x] No Node.js imports in renderer code
- [x] API key field uses `type="password"` with `autocomplete="off"`
- [x] Env vars filtered through `BLOCKED_ENV_VARS` blocklist
- [x] Uses `ts-pattern` for status mapping
- [ ] Onboarding step for new Codex feature (follow-up)