### PR TITLE
feat(agents): add OpenCode integration via plugin bridge

### DIFF
--- a/.github/opencode-version.json
+++ b/.github/opencode-version.json
@@ -1,0 +1,4 @@
+{
+  "lastCheckedVersion": "v1.4.3",
+  "lastCheckedAt": "2026-04-10T00:00:00Z"
+}

--- a/.github/prompts/opencode-compat.md
+++ b/.github/prompts/opencode-compat.md
@@ -1,0 +1,148 @@
+# OpenCode Compatibility Analysis
+
+You are analyzing new OpenCode releases to determine whether the **Canopy** desktop application (Electron + Svelte 5) needs code changes to stay compatible or to adopt new features.
+
+## Context
+
+The workflow has provided these values at the top of the prompt:
+
+- **FROM_VERSION** — the last version we checked (exclusive lower bound)
+- **TO_VERSION** — the latest available release (inclusive upper bound)
+- **EXISTING_PR** — PR number if a compatibility PR is already open (empty if none)
+- **REPO** — this repository (owner/repo format)
+
+The **release repo** is `anomalyco/opencode` — the official OpenCode repository.
+
+The **target branch** for PRs is `chore/opencode-compat`.
+
+Release notes for each new version are appended below under `## Release Notes`.
+
+## Your task
+
+### 1. Understand the releases
+
+Read the release notes provided below. For each version, identify:
+
+- New or changed **CLI flags** and **subcommands**
+- Changed or removed **environment variables** and **config keys** (`OPENCODE_CONFIG_DIR`, `OPENCODE_CONFIG_CONTENT`, etc.)
+- New **plugin hooks**, changed hook signatures, or removed hooks
+- Changes to the **plugin loading** mechanism or `@opencode-ai/plugin` SDK
+- New **tool capabilities** or changed tool argument shapes
+- Changes to **permission** handling or approval flows
+- Changes to **session management** (`--continue`, `--session`, `--model` flags)
+
+### 2. Fetch detailed diffs (self-serve)
+
+For deeper analysis, fetch diffs from the OpenCode repo using the FROM_VERSION and TO_VERSION values from the prompt header:
+
+```bash
+# Compare two tags to see all file changes
+gh api repos/anomalyco/opencode/compare/{FROM_VERSION}...{TO_VERSION} --jq '.files[] | "\(.filename) (\(.status))"'
+
+# Read a specific file at a given tag
+gh api repos/anomalyco/opencode/contents/pkg/plugin/plugin.go?ref={TO_VERSION} --jq '.content' | base64 -d
+```
+
+Focus on files under `pkg/plugin/` (plugin system), `pkg/tui/` (TUI changes), and `pkg/client/` (SDK/API surface).
+
+### 3. Check SDK updates
+
+Check if a new `@opencode-ai/plugin` version is available:
+
+```bash
+npm view @opencode-ai/plugin versions --json
+```
+
+Cross-reference with what the release notes mention. If a relevant update exists, bump the version in the user's `~/.config/opencode/package.json` guidance or update our bridge plugin accordingly.
+
+### 4. Scan the Canopy codebase
+
+**Known integration points** (start here):
+
+- `resources/opencode-canopy-bridge.ts` — bridge plugin that runs inside OpenCode, forwarding events to Canopy's hook server
+- `src/main/agents/adapters/opencode.ts` — Canopy-side adapter (event normalization, CLI args, env vars, notch status)
+- `src/renderer/src/components/preferences/OpenCodePrefs.svelte` — preferences UI
+- `src/renderer/src/components/agents/OpenCodeExtras.svelte` — inspector extras
+- `src/renderer/src/lib/agents/agentState.svelte.ts` — agent state handling (todo sync, question detection)
+- `src/main/agents/types.ts` — shared agent types
+
+**Then discover more** — search broadly for additional references:
+
+```bash
+grep -r "opencode" --include="*.ts" --include="*.yml" --include="*.md" --include="*.json" --include="*.svelte" -l .
+grep -r "OPENCODE" --include="*.ts" --include="*.yml" --include="*.json" -l .
+```
+
+### 5. Apply changes
+
+Be **proactive** — not just compatibility fixes but also:
+
+- Adopt new OpenCode plugin hooks that provide richer data for the inspector
+- Update event mappings if hook signatures or event types change
+- Update CLI args if new flags are available and useful (new models, permission modes)
+- Update the bridge plugin if the `Hooks` interface changes
+- Update `OpenCodePrefs.svelte` if new configurable options become available
+- Bump `@opencode-ai/plugin` types if the SDK changes
+
+For each change, make a **targeted, minimal edit**. Do not reformat or restructure code beyond what the change requires.
+
+### 6. Create or update the PR
+
+Use the FROM_VERSION, TO_VERSION, and EXISTING_PR values from the prompt header.
+
+**If no existing PR** (EXISTING_PR is empty):
+
+1. Create the branch: `git checkout -b chore/opencode-compat`
+2. Commit changes with descriptive messages (one commit per logical change group, use `chore:` or `fix:` prefix)
+3. Push: `git push origin chore/opencode-compat`
+4. Create PR targeting `next` with this structure:
+
+```
+Title: chore(deps): opencode compatibility update ({FROM_VERSION} → {TO_VERSION})
+
+Body:
+## OpenCode Compatibility Update
+
+### Versions analyzed
+[List each version analyzed]
+
+### Relevant changes
+[For each version: key changes that affected our codebase]
+
+### Modifications made
+[For each file changed: what was modified and why]
+
+### SDK changes
+[SDK version bump details, or "No SDK changes needed"]
+
+### Risk assessment
+[Low/Medium/High — explain any risks or breaking changes]
+```
+
+**If existing PR** (EXISTING_PR is a PR number):
+
+1. Checkout the existing branch: `git fetch origin chore/opencode-compat && git checkout chore/opencode-compat`
+2. Commit incremental changes
+3. Push: `git push origin chore/opencode-compat`
+4. Update the PR title and description to cover the expanded version range using `gh pr edit`
+
+### 7. If no changes needed
+
+If after analysis you determine no code changes are required:
+
+1. Do NOT create a branch or PR
+2. Write a summary to `$GITHUB_STEP_SUMMARY`:
+
+```bash
+cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+## OpenCode Compatibility Check
+
+Analyzed versions: {FROM_VERSION} → {TO_VERSION}
+
+**No code changes needed.** The release changes do not affect Canopy's integration.
+EOF
+```
+
+## Tone
+
+Be precise and factual. State what you found, what you changed, and why. No filler or commentary beyond what is needed to explain each decision.

--- a/.github/workflows/opencode-compat.yml
+++ b/.github/workflows/opencode-compat.yml
@@ -1,0 +1,201 @@
+name: OpenCode Compatibility Check
+
+on:
+  schedule:
+    # Twice daily at 07:43 and 19:43 UTC (offset from :00/:30)
+    - cron: '43 7,19 * * *'
+  workflow_dispatch:
+    inputs:
+      from_version:
+        description: 'Force check from this version (e.g., v1.4.2). Overrides tracked version.'
+        required: false
+        type: string
+
+concurrency:
+  group: opencode-compat
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: next
+          fetch-depth: 1
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - uses: volta-cli/action@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ── Version check (early exit if nothing new) ─────────────
+      - name: Read tracked version
+        id: tracked
+        run: |
+          if [ -f .github/opencode-version.json ]; then
+            VERSION=$(jq -r '.lastCheckedVersion' .github/opencode-version.json)
+          else
+            VERSION="v0.0.0"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch latest release from OpenCode repo
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST=$(gh api repos/anomalyco/opencode/releases/latest --jq '.tag_name')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Determine version range
+        id: range
+        env:
+          INPUT_FROM_VERSION: ${{ inputs.from_version }}
+          TRACKED_VERSION: ${{ steps.tracked.outputs.version }}
+          LATEST_VERSION: ${{ steps.latest.outputs.version }}
+        run: |
+          if [ -n "$INPUT_FROM_VERSION" ]; then
+            FROM="$INPUT_FROM_VERSION"
+          else
+            FROM="$TRACKED_VERSION"
+          fi
+          TO="$LATEST_VERSION"
+
+          if [ "$FROM" = "$TO" ]; then
+            echo "new_releases=false" >> "$GITHUB_OUTPUT"
+            echo "No new releases (tracked: $FROM, latest: $TO)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "new_releases=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "from=$FROM" >> "$GITHUB_OUTPUT"
+          echo "to=$TO" >> "$GITHUB_OUTPUT"
+
+      # ── Enumerate and fetch release notes ─────────────────────
+      - name: Fetch release notes for new versions
+        if: steps.range.outputs.new_releases == 'true'
+        id: releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FROM_VERSION: ${{ steps.range.outputs.from }}
+          TO_VERSION: ${{ steps.range.outputs.to }}
+        run: |
+          # Fetch all release tags, filter to those between FROM and TO
+          RELEASES=$(gh api repos/anomalyco/opencode/releases --paginate --jq '.[].tag_name')
+
+          # Filter versions: keep only those > FROM and <= TO
+          FILTERED=$(echo "$RELEASES" | while read -r tag; do
+            if [ "$(printf '%s\n%s' "$FROM_VERSION" "$tag" | sort -V | head -1)" = "$FROM_VERSION" ] && \
+               [ "$tag" != "$FROM_VERSION" ] && \
+               [ "$(printf '%s\n%s' "$tag" "$TO_VERSION" | sort -V | head -1)" = "$tag" ]; then
+              echo "$tag"
+            fi
+          done | sort -V)
+
+          echo "Versions to analyze:"
+          echo "$FILTERED"
+
+          # Fetch release body for each version and write to file
+          > /tmp/release-notes.md
+          for tag in $FILTERED; do
+            echo "Fetching release notes for $tag..."
+            BODY=$(gh api "repos/anomalyco/opencode/releases/tags/$tag" --jq '.body // "No release notes."')
+            {
+              echo "### ${tag}"
+              echo ""
+              echo "$BODY"
+              echo ""
+              echo "---"
+              echo ""
+            } >> /tmp/release-notes.md
+          done
+
+          echo "$FILTERED" > /tmp/version-list.txt
+          COUNT=$(echo "$FILTERED" | grep -c . || true)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      # ── Check for existing PR ─────────────────────────────────
+      - name: Check for existing compatibility PR
+        if: steps.range.outputs.new_releases == 'true'
+        id: existing_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list --head chore/opencode-compat --state open --json number --jq '.[0].number // empty')
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      # ── Read prompt ───────────────────────────────────────────
+      - name: Read analysis prompt
+        if: steps.range.outputs.new_releases == 'true'
+        id: prompt
+        run: |
+          # Randomized delimiter prevents injection via untrusted release notes
+          DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
+          echo "content<<${DELIM}" >> "$GITHUB_OUTPUT"
+          cat .github/prompts/opencode-compat.md >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "## Release Notes" >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          cat /tmp/release-notes.md >> "$GITHUB_OUTPUT"
+          echo "${DELIM}" >> "$GITHUB_OUTPUT"
+
+      # ── Run Claude Code analysis ──────────────────────────────
+      - name: Run compatibility analysis
+        if: steps.range.outputs.new_releases == 'true'
+        id: analysis
+        uses: anthropics/claude-code-action@v1
+        with:
+          allowed_bots: 'claude,dependabot'
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            FROM_VERSION: ${{ steps.range.outputs.from }}
+            TO_VERSION: ${{ steps.range.outputs.to }}
+            EXISTING_PR: ${{ steps.existing_pr.outputs.number }}
+
+            ${{ steps.prompt.outputs.content }}
+          claude_args: |
+            --model opus[1m]
+            --effort max
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git checkout chore/opencode-compat),Bash(git checkout -b chore/opencode-compat),Bash(git add:*),Bash(git commit:*),Bash(git push origin chore/opencode-compat),Bash(git diff:*),Bash(git status:*),Bash(git fetch origin:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh api repos/anomalyco/opencode/:*),Bash(npm view:*)"
+          settings: |
+            {
+              "env": {
+                "ANTHROPIC_AUTH_TOKEN": "${{ secrets.ANTHROPIC_AUTH_TOKEN }}",
+                "ANTHROPIC_BASE_URL": "${{ secrets.ANTHROPIC_BASE_URL }}"
+              }
+            }
+
+      # ── Update version tracker ────────────────────────────────
+      - name: Update version tracker
+        if: steps.range.outputs.new_releases == 'true'
+        env:
+          TO_VERSION: ${{ steps.range.outputs.to }}
+        run: |
+          # Claude may have left unstaged changes or switched branches —
+          # discard everything and sync hard to the latest remote next.
+          git fetch origin next
+          git checkout next
+          git reset --hard origin/next
+          git clean -fdx -- ':!node_modules'
+
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          jq -n --arg v "$TO_VERSION" --arg t "$TIMESTAMP" \
+            '{lastCheckedVersion: $v, lastCheckedAt: $t}' \
+            > .github/opencode-version.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/opencode-version.json
+          if ! git diff --cached --quiet; then
+            git commit -m "ci: update opencode version tracker [skip ci]"
+            git push origin next
+          fi

--- a/resources/opencode-canopy-bridge.ts
+++ b/resources/opencode-canopy-bridge.ts
@@ -20,8 +20,10 @@ const basePath = process.env.CANOPY_HOOK_PATH || ''
 
 async function postHook(payload: Record<string, unknown>): Promise<void> {
   if (!port || !token) return
+  if (!/^\d+$/.test(port)) return
   try {
-    await fetch(`http://127.0.0.1:${port}${basePath}/hook`, {
+    const url = new URL(`http://127.0.0.1:${port}${basePath}/hook`)
+    await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/resources/opencode-canopy-bridge.ts
+++ b/resources/opencode-canopy-bridge.ts
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/**
+ * Canopy bridge plugin for OpenCode.
+ *
+ * Runs inside the OpenCode process, subscribes to lifecycle events,
+ * and forwards them as JSON POSTs to Canopy's agent hook HTTP server.
+ *
+ * Environment variables (set by Canopy before spawning OpenCode):
+ *   CANOPY_HOOK_PORT  — localhost port of the hook server
+ *   CANOPY_HOOK_TOKEN — per-session auth token
+ *   CANOPY_HOOK_PATH  — URL path prefix (e.g. /session/<id>)
+ *
+ * When env vars are absent (OpenCode launched outside Canopy), the plugin
+ * returns an empty hooks object and does nothing.
+ */
+
+const port = process.env.CANOPY_HOOK_PORT
+const token = process.env.CANOPY_HOOK_TOKEN
+const basePath = process.env.CANOPY_HOOK_PATH || ''
+
+async function postHook(payload: Record<string, unknown>): Promise<void> {
+  if (!port || !token) return
+  try {
+    await fetch(`http://127.0.0.1:${port}${basePath}/hook`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Canopy-Auth': token,
+      },
+      body: JSON.stringify(payload),
+    })
+  } catch {
+    // Fire-and-forget — Canopy may have shut down
+  }
+}
+
+// Plugin matches the Plugin type: (input: PluginInput, options?: PluginOptions) => Promise<Hooks>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const CanopyBridge = async (_input: unknown, _options?: unknown) => {
+  if (!port || !token) return {}
+
+  return {
+    // Generic event handler — receives all OpenCode events as a discriminated union
+    event: async (input: { event: { type: string; properties?: Record<string, unknown> } }) => {
+      const { type, properties } = input.event
+      const sessionID = (properties?.sessionID as string) ?? ''
+
+      switch (type) {
+        case 'session.created': {
+          const info = properties?.info as Record<string, unknown> | undefined
+          await postHook({
+            hook_event_name: 'SessionCreated',
+            session_id: info?.id ?? sessionID,
+          })
+          break
+        }
+
+        case 'session.idle':
+          await postHook({
+            hook_event_name: 'SessionIdle',
+            session_id: sessionID,
+          })
+          break
+
+        case 'session.error':
+          await postHook({
+            hook_event_name: 'SessionError',
+            session_id: sessionID,
+            error:
+              typeof properties?.error === 'string'
+                ? properties.error
+                : JSON.stringify(properties?.error ?? 'unknown error'),
+          })
+          break
+
+        case 'session.deleted':
+          await postHook({
+            hook_event_name: 'SessionDeleted',
+            session_id: sessionID,
+            reason: 'deleted',
+          })
+          break
+
+        case 'session.compacted':
+          await postHook({
+            hook_event_name: 'SessionCompacted',
+            session_id: sessionID,
+          })
+          break
+
+        case 'session.status': {
+          const status = properties?.status as Record<string, unknown> | undefined
+          const statusType = status?.type as string | undefined
+          // Split into distinct event names so Canopy can track busy/idle state
+          await postHook({
+            hook_event_name: statusType === 'busy' ? 'SessionBusy' : 'SessionStatusIdle',
+            session_id: sessionID,
+            status: statusType,
+          })
+          break
+        }
+
+        case 'todo.updated': {
+          const todos = properties?.todos as Array<Record<string, unknown>> | undefined
+          await postHook({
+            hook_event_name: 'TodoUpdated',
+            session_id: sessionID,
+            notification_type: 'Todo',
+            title: 'Task updated',
+            todos,
+          })
+          break
+        }
+
+        case 'permission.updated': {
+          // Permission events come through as events too
+          await postHook({
+            hook_event_name: 'PermissionAsked',
+            session_id: sessionID,
+            tool_name: (properties as Record<string, unknown>)?.title ?? '',
+            tool_input: (properties as Record<string, unknown>)?.metadata,
+          })
+          break
+        }
+      }
+    },
+
+    // Tool execution hooks — specific interceptors with typed signatures
+    'tool.execute.before': async (
+      input: { tool: string; sessionID: string; callID: string },
+      output: { args: unknown },
+    ) => {
+      await postHook({
+        hook_event_name: 'ToolExecuteBefore',
+        session_id: input.sessionID,
+        tool_name: input.tool,
+        tool_input: typeof output.args === 'object' ? output.args : { raw: output.args },
+      })
+    },
+
+    'tool.execute.after': async (
+      input: { tool: string; sessionID: string; callID: string; args: unknown },
+      output: { title: string; output: string; metadata: unknown },
+    ) => {
+      await postHook({
+        hook_event_name: 'ToolExecuteAfter',
+        session_id: input.sessionID,
+        tool_name: input.tool,
+        tool_input: typeof input.args === 'object' ? input.args : { raw: input.args },
+        tool_response: output.output,
+      })
+    },
+
+    // Permission ask hook
+    'permission.ask': async (
+      input: { id: string; type: string; sessionID: string; title: string; metadata: unknown },
+      _output: { status: string },
+    ) => {
+      await postHook({
+        hook_event_name: 'PermissionAsked',
+        session_id: input.sessionID,
+        tool_name: input.title,
+        tool_input: typeof input.metadata === 'object' ? input.metadata : undefined,
+      })
+    },
+
+    // Compaction start hook
+    'experimental.session.compacting': async (input: { sessionID: string }, _output: unknown) => {
+      await postHook({
+        hook_event_name: 'SessionCompacting',
+        session_id: input.sessionID,
+      })
+    },
+  }
+}

--- a/src/main/agents/AgentSessionManager.ts
+++ b/src/main/agents/AgentSessionManager.ts
@@ -10,6 +10,7 @@ import type { NotchSessionStatus } from '../notch/types'
 import { getAdapter, registerAdapter, isAgentTool as isRegistered } from './registry'
 import { claudeAdapter } from './adapters/claude'
 import { geminiAdapter } from './adapters/gemini'
+import { opencodeAdapter } from './adapters/opencode'
 
 interface AgentSession {
   agentType: AgentType
@@ -46,6 +47,7 @@ export class AgentSessionManager extends EventEmitter {
     // Register built-in adapters
     registerAdapter(claudeAdapter)
     registerAdapter(geminiAdapter)
+    registerAdapter(opencodeAdapter)
   }
 
   get sessionCount(): number {

--- a/src/main/agents/AgentSessionManager.ts
+++ b/src/main/agents/AgentSessionManager.ts
@@ -262,6 +262,8 @@ export class AgentSessionManager extends EventEmitter {
           unlinkSync(fullPath)
         } else if (entry.startsWith('gemini-home-') && statSync(fullPath).isDirectory()) {
           rmSync(fullPath, { recursive: true, force: true })
+        } else if (entry.startsWith('opencode-config-') && statSync(fullPath).isDirectory()) {
+          rmSync(fullPath, { recursive: true, force: true })
         }
       } catch {
         // Ignore

--- a/src/main/agents/adapters/opencode.ts
+++ b/src/main/agents/adapters/opencode.ts
@@ -1,0 +1,228 @@
+import { match, P } from 'ts-pattern'
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import os from 'os'
+import { is } from '@electron-toolkit/utils'
+import type {
+  AgentAdapter,
+  AgentType,
+  NormalizedEventName,
+  NormalizedHookEvent,
+  NormalizedStatusData,
+  PreferencesReader,
+} from '../types'
+import type { SessionStatusType } from '../../notch/types'
+import { BLOCKED_ENV_VARS } from '../../security/envBlocklist'
+import { summarizeToolInput } from '../utils'
+
+const PLUGIN_FILENAME = 'canopy-bridge.ts'
+
+const EVENT_MAP: Record<string, NormalizedEventName> = {
+  SessionCreated: 'SessionStart',
+  SessionBusy: 'PromptSubmit',
+  SessionStatusIdle: 'Idle',
+  SessionIdle: 'Idle',
+  SessionError: 'IdleFailure',
+  SessionDeleted: 'SessionEnd',
+  SessionCompacting: 'BeforeCompact',
+  SessionCompacted: 'AfterCompact',
+  ToolExecuteBefore: 'BeforeToolUse',
+  ToolExecuteAfter: 'AfterToolUse',
+  PermissionAsked: 'PermissionRequest',
+  TodoUpdated: 'Notification',
+}
+
+const INTERNAL_BLOCKED = new Set(['CANOPY_HOOK_PORT', 'CANOPY_HOOK_TOKEN', 'ELECTRON_RUN_AS_NODE'])
+
+/**
+ * Ensure the canopy bridge plugin is installed in ~/.config/opencode/plugins/.
+ * The plugin is idempotent — it no-ops when CANOPY_HOOK_PORT is absent,
+ * so it's safe to leave installed permanently.
+ * Only overwrites if the source file is newer or content differs.
+ */
+function ensureBridgePlugin(): void {
+  const pluginsDir = join(os.homedir(), '.config', 'opencode', 'plugins')
+  const destPath = join(pluginsDir, PLUGIN_FILENAME)
+
+  const sourcePath = is.dev
+    ? join(process.cwd(), 'resources', 'opencode-canopy-bridge.ts')
+    : join(process.resourcesPath, 'app.asar.unpacked', 'resources', 'opencode-canopy-bridge.ts')
+
+  if (!existsSync(sourcePath)) return
+
+  mkdirSync(pluginsDir, { recursive: true })
+
+  // Skip copy if content is identical
+  if (existsSync(destPath)) {
+    try {
+      const src = readFileSync(sourcePath)
+      const dst = readFileSync(destPath)
+      if (src.equals(dst)) return
+    } catch {
+      /* overwrite on read error */
+    }
+  }
+
+  copyFileSync(sourcePath, destPath)
+}
+
+export const opencodeAdapter: AgentAdapter = {
+  agentType: 'opencode' as AgentType,
+  toolId: 'opencode',
+
+  busyEvents: new Set(['SessionBusy', 'ToolExecuteBefore', 'PermissionAsked', 'SessionCompacting']),
+  idleEvents: new Set(['SessionStatusIdle', 'SessionIdle', 'SessionError', 'SessionDeleted']),
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setupSettings(_settingsPath, _worktreePath, _hookScriptPath, _statusLineScriptPath, _overrides) {
+    // Install bridge plugin into ~/.config/opencode/plugins/ (idempotent).
+    // The plugin reads CANOPY_HOOK_PORT/TOKEN/PATH from env at runtime,
+    // so it works per-session without per-session file management.
+    ensureBridgePlugin()
+
+    return {
+      args: [],
+      env: {},
+      cleanup: () => {
+        // No cleanup needed — the plugin is harmless without env vars
+      },
+    }
+  },
+
+  normalizeEvent(raw: Record<string, unknown>): NormalizedHookEvent {
+    const rawName = (raw.hook_event_name as string) ?? ''
+    let event = EVENT_MAP[rawName] ?? 'Unknown'
+    const toolName = raw.tool_name as string | undefined
+
+    // OpenCode's "question" tool = user input needed → treat like permission request
+    if (rawName === 'ToolExecuteBefore' && toolName === 'question') {
+      event = 'PermissionRequest'
+    }
+
+    // Attach OpenCode todos as extra data for task list rendering
+    let extra: Record<string, unknown> | undefined
+    if (rawName === 'TodoUpdated' && Array.isArray(raw.todos)) {
+      extra = { opencodeTodos: raw.todos }
+    }
+
+    return {
+      agentType: 'opencode',
+      sessionId: (raw.session_id as string) ?? '',
+      event,
+      rawEventName: rawName,
+      toolName,
+      toolInput: raw.tool_input as Record<string, unknown> | undefined,
+      toolResponse: raw.tool_response as string | undefined,
+      error: raw.error as string | undefined,
+      errorDetails: raw.error_details as string | undefined,
+      message: raw.message as string | undefined,
+      title: raw.title as string | undefined,
+      notificationType: raw.notification_type as string | undefined,
+      agentId: raw.agent_id as string | undefined,
+      agentSubtype: raw.agent_type as string | undefined,
+      reason: raw.reason as string | undefined,
+      model: raw.model as string | undefined,
+      permissionMode: raw.permission_mode as string | undefined,
+      compactSummary: raw.compact_summary as string | undefined,
+      prompt: raw.prompt as string | undefined,
+      taskId: raw.task_id as string | undefined,
+      taskSubject: raw.task_subject as string | undefined,
+      taskDescription: raw.task_description as string | undefined,
+      teammateName: raw.teammate_name as string | undefined,
+      extra,
+      teamName: raw.team_name as string | undefined,
+    }
+  },
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  normalizeStatus(_raw: Record<string, unknown>): NormalizedStatusData {
+    // OpenCode does not expose a status line mechanism
+    return {}
+  },
+
+  buildCliArgs(prefs: PreferencesReader): string[] {
+    const args: string[] = []
+    const model = prefs.get('opencode.model')
+
+    // OpenCode uses --model provider/model format
+    if (model) args.push('--model', model)
+
+    return args
+  },
+
+  buildEnvVars(prefs: PreferencesReader): Record<string, string> {
+    const env: Record<string, string> = {}
+
+    const apiKey = prefs.get('opencode.apiKey')
+    const customEnv = prefs.get('opencode.customEnv')
+    const settingsJson = prefs.get('opencode.settingsJson')
+
+    // OpenCode is provider-agnostic; the API key env var depends on the model chosen.
+    // Users can set the right env var via customEnv. If apiKey is set, default to ANTHROPIC_API_KEY.
+    if (apiKey) env.ANTHROPIC_API_KEY = apiKey
+
+    // Pass config overrides via OPENCODE_CONFIG_CONTENT
+    if (settingsJson) env.OPENCODE_CONFIG_CONTENT = settingsJson
+
+    if (customEnv) {
+      try {
+        const parsed = JSON.parse(customEnv)
+        for (const [k, v] of Object.entries(parsed)) {
+          if (
+            typeof v === 'string' &&
+            !BLOCKED_ENV_VARS.has(k.toUpperCase()) &&
+            !INTERNAL_BLOCKED.has(k)
+          ) {
+            env[k] = v
+          }
+        }
+      } catch {
+        // Invalid JSON
+      }
+    }
+
+    return env
+  },
+
+  buildResumeArgs(resumeSessionId: string): string[] {
+    return ['--continue', '--session', resumeSessionId]
+  },
+
+  buildSessionContext(worktreePath: string, workspaceName: string, branch: string | null): string {
+    let ctx = `Working in canopy workspace '${workspaceName}'`
+    if (branch) {
+      ctx += `, worktree '${branch}' (branch: ${branch})`
+    }
+    ctx += `.\nProject root: ${worktreePath}.`
+    return ctx
+  },
+
+  formatNotification(event: NormalizedHookEvent): { title: string; body: string } | null {
+    if (event.event !== 'PermissionRequest') return null
+    const body = event.toolName
+      ? `${event.toolName}: ${summarizeToolInput(event.toolInput)}`
+      : 'A tool requires your approval'
+    return { title: 'OpenCode — Permission Required', body }
+  },
+
+  toNotchStatus(event: NormalizedHookEvent): { status: SessionStatusType; detail?: string } | null {
+    const toolDetail = event.toolName
+      ? `${event.toolName}: ${summarizeToolInput(event.toolInput)}`
+      : undefined
+
+    return match(event.event)
+      .with(P.union('SessionStart', 'Idle'), () => ({ status: 'idle' as const }))
+      .with(P.union('PromptSubmit', 'AfterToolUse', 'AfterCompact'), () => ({
+        status: 'thinking' as const,
+      }))
+      .with('BeforeToolUse', () => ({ status: 'toolCalling' as const, detail: toolDetail }))
+      .with('PermissionRequest', () => ({
+        status: 'waitingPermission' as const,
+        detail: toolDetail,
+      }))
+      .with('BeforeCompact', () => ({ status: 'compacting' as const }))
+      .with('IdleFailure', () => ({ status: 'error' as const, detail: event.error }))
+      .with('SessionEnd', () => ({ status: 'ended' as const, detail: event.reason }))
+      .otherwise(() => null)
+  },
+}

--- a/src/main/agents/adapters/opencode.ts
+++ b/src/main/agents/adapters/opencode.ts
@@ -30,7 +30,12 @@ const EVENT_MAP: Record<string, NormalizedEventName> = {
   TodoUpdated: 'Notification',
 }
 
-const INTERNAL_BLOCKED = new Set(['CANOPY_HOOK_PORT', 'CANOPY_HOOK_TOKEN', 'ELECTRON_RUN_AS_NODE'])
+const INTERNAL_BLOCKED = new Set([
+  'CANOPY_HOOK_PORT',
+  'CANOPY_HOOK_TOKEN',
+  'ELECTRON_RUN_AS_NODE',
+  'OPENCODE_CONFIG_DIR',
+])
 
 export const opencodeAdapter: AgentAdapter = {
   agentType: 'opencode' as AgentType,
@@ -149,7 +154,7 @@ export const opencodeAdapter: AgentAdapter = {
           if (
             typeof v === 'string' &&
             !BLOCKED_ENV_VARS.has(k.toUpperCase()) &&
-            !INTERNAL_BLOCKED.has(k)
+            !INTERNAL_BLOCKED.has(k.toUpperCase())
           ) {
             env[k] = v
           }

--- a/src/main/agents/adapters/opencode.ts
+++ b/src/main/agents/adapters/opencode.ts
@@ -1,7 +1,7 @@
 import { match, P } from 'ts-pattern'
-import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'fs'
+import { copyFileSync, mkdirSync, rmSync } from 'fs'
 import { join } from 'path'
-import os from 'os'
+import { randomUUID } from 'crypto'
 import { is } from '@electron-toolkit/utils'
 import type {
   AgentAdapter,
@@ -14,8 +14,6 @@ import type {
 import type { SessionStatusType } from '../../notch/types'
 import { BLOCKED_ENV_VARS } from '../../security/envBlocklist'
 import { summarizeToolInput } from '../utils'
-
-const PLUGIN_FILENAME = 'canopy-bridge.ts'
 
 const EVENT_MAP: Record<string, NormalizedEventName> = {
   SessionCreated: 'SessionStart',
@@ -34,38 +32,6 @@ const EVENT_MAP: Record<string, NormalizedEventName> = {
 
 const INTERNAL_BLOCKED = new Set(['CANOPY_HOOK_PORT', 'CANOPY_HOOK_TOKEN', 'ELECTRON_RUN_AS_NODE'])
 
-/**
- * Ensure the canopy bridge plugin is installed in ~/.config/opencode/plugins/.
- * The plugin is idempotent — it no-ops when CANOPY_HOOK_PORT is absent,
- * so it's safe to leave installed permanently.
- * Only overwrites if the source file is newer or content differs.
- */
-function ensureBridgePlugin(): void {
-  const pluginsDir = join(os.homedir(), '.config', 'opencode', 'plugins')
-  const destPath = join(pluginsDir, PLUGIN_FILENAME)
-
-  const sourcePath = is.dev
-    ? join(process.cwd(), 'resources', 'opencode-canopy-bridge.ts')
-    : join(process.resourcesPath, 'app.asar.unpacked', 'resources', 'opencode-canopy-bridge.ts')
-
-  if (!existsSync(sourcePath)) return
-
-  mkdirSync(pluginsDir, { recursive: true })
-
-  // Skip copy if content is identical
-  if (existsSync(destPath)) {
-    try {
-      const src = readFileSync(sourcePath)
-      const dst = readFileSync(destPath)
-      if (src.equals(dst)) return
-    } catch {
-      /* overwrite on read error */
-    }
-  }
-
-  copyFileSync(sourcePath, destPath)
-}
-
 export const opencodeAdapter: AgentAdapter = {
   agentType: 'opencode' as AgentType,
   toolId: 'opencode',
@@ -74,17 +40,29 @@ export const opencodeAdapter: AgentAdapter = {
   idleEvents: new Set(['SessionStatusIdle', 'SessionIdle', 'SessionError', 'SessionDeleted']),
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  setupSettings(_settingsPath, _worktreePath, _hookScriptPath, _statusLineScriptPath, _overrides) {
-    // Install bridge plugin into ~/.config/opencode/plugins/ (idempotent).
-    // The plugin reads CANOPY_HOOK_PORT/TOKEN/PATH from env at runtime,
-    // so it works per-session without per-session file management.
-    ensureBridgePlugin()
+  setupSettings(settingsPath, _worktreePath, _hookScriptPath, _statusLineScriptPath, _overrides) {
+    // Create a per-session config dir inside Canopy's userData with the bridge plugin.
+    // OPENCODE_CONFIG_DIR is an additive search path — OpenCode discovers plugins/
+    // inside it alongside the user's own ~/.config/opencode/ config.
+    // This avoids writing to the user's external OpenCode config directory.
+    const configDir = join(settingsPath, '..', `opencode-config-${randomUUID()}`)
+    const pluginsDir = join(configDir, 'plugins')
+    mkdirSync(pluginsDir, { recursive: true })
+
+    const bridgeSource = is.dev
+      ? join(process.cwd(), 'resources', 'opencode-canopy-bridge.ts')
+      : join(process.resourcesPath, 'app.asar.unpacked', 'resources', 'opencode-canopy-bridge.ts')
+    copyFileSync(bridgeSource, join(pluginsDir, 'canopy-bridge.ts'))
 
     return {
       args: [],
-      env: {},
+      env: { OPENCODE_CONFIG_DIR: configDir },
       cleanup: () => {
-        // No cleanup needed — the plugin is harmless without env vars
+        try {
+          rmSync(configDir, { recursive: true, force: true })
+        } catch {
+          /* best-effort */
+        }
       },
     }
   },

--- a/src/main/agents/types.ts
+++ b/src/main/agents/types.ts
@@ -1,6 +1,6 @@
 import type { SessionStatusType } from '../notch/types'
 
-export type AgentType = 'claude' | 'gemini'
+export type AgentType = 'claude' | 'gemini' | 'opencode'
 
 export type NormalizedEventName =
   | 'SessionStart'

--- a/src/main/db/PreferencesStore.ts
+++ b/src/main/db/PreferencesStore.ts
@@ -2,7 +2,7 @@ import { safeStorage } from 'electron'
 import type { Database as BetterSqlite3Database } from 'better-sqlite3'
 import type { Database } from './Database'
 
-const ENCRYPTED_KEYS = new Set(['claude.apiKey', 'gemini.apiKey'])
+const ENCRYPTED_KEYS = new Set(['claude.apiKey', 'gemini.apiKey', 'opencode.apiKey'])
 const ENCRYPTED_KEY_PREFIXES = ['taskTracker.token.']
 
 function isEncryptedKey(key: string): boolean {

--- a/src/renderer/src/components/agents/AgentInspector.svelte
+++ b/src/renderer/src/components/agents/AgentInspector.svelte
@@ -2,6 +2,7 @@
   import { match, P } from 'ts-pattern'
   import type { AgentSessionState } from '../../lib/agents/agentState.svelte'
   import ClaudeExtras from './ClaudeExtras.svelte'
+  import OpenCodeExtras from './OpenCodeExtras.svelte'
 
   let {
     state,
@@ -157,6 +158,8 @@
   <!-- Agent-specific extras -->
   {#if state.agentType === 'claude'}
     <ClaudeExtras extra={state.extra} />
+  {:else if state.agentType === 'opencode'}
+    <OpenCodeExtras extra={state.extra} />
   {/if}
 
   <!-- Tasks -->

--- a/src/renderer/src/components/agents/OpenCodeExtras.svelte
+++ b/src/renderer/src/components/agents/OpenCodeExtras.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  let { extra }: { extra: Record<string, unknown> } = $props()
+
+  let pendingQuestion = $derived((extra.pendingQuestion as string | null) ?? null)
+</script>
+
+{#if pendingQuestion}
+  <div class="section">
+    <h4 class="section-label">Waiting for input</h4>
+    <div class="question-box">
+      <span class="question-text">{pendingQuestion}</span>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .section-label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--c-text-faint);
+    margin: 0;
+  }
+
+  .question-box {
+    padding: 6px 10px;
+    border-radius: 6px;
+    border-left: 3px solid var(--c-warning-text);
+    background: var(--c-border-subtle);
+  }
+
+  .question-text {
+    font-size: 12px;
+    color: var(--c-text-secondary);
+    line-height: 1.4;
+  }
+</style>

--- a/src/renderer/src/components/preferences/OpenCodePrefs.svelte
+++ b/src/renderer/src/components/preferences/OpenCodePrefs.svelte
@@ -1,0 +1,360 @@
+<script lang="ts">
+  import { prefs, setPref } from '../../lib/stores/preferences.svelte'
+
+  // Model & behavior
+  let model = $derived(prefs['opencode.model'] || '')
+
+  // API
+  let apiKey = $derived(prefs['opencode.apiKey'] || '')
+
+  // Custom env vars
+  let envEntries = $derived.by(() => {
+    const raw = prefs['opencode.customEnv']
+    if (!raw) return [] as Array<{ key: string; value: string }>
+    try {
+      const parsed = JSON.parse(raw) as Record<string, string>
+      return Object.entries(parsed).map(([key, value]) => ({ key, value }))
+    } catch {
+      return [] as Array<{ key: string; value: string }>
+    }
+  })
+  let showEnvForm = $state(false)
+  let newEnvKey = $state('')
+  let newEnvValue = $state('')
+
+  // Settings JSON
+  let settingsJson = $derived(prefs['opencode.settingsJson'] || '')
+
+  function persistEnvEntries(entries: Array<{ key: string; value: string }>): void {
+    const obj: Record<string, string> = {}
+    for (const entry of entries) {
+      if (entry.key.trim()) obj[entry.key.trim()] = entry.value
+    }
+    if (Object.keys(obj).length > 0) {
+      setPref('opencode.customEnv', JSON.stringify(obj))
+    } else {
+      setPref('opencode.customEnv', '')
+    }
+  }
+
+  function addEnvVar(): void {
+    if (!newEnvKey.trim()) return
+    persistEnvEntries([...envEntries, { key: newEnvKey.trim(), value: newEnvValue }])
+    newEnvKey = ''
+    newEnvValue = ''
+    showEnvForm = false
+  }
+
+  function removeEnvVar(index: number): void {
+    persistEnvEntries(envEntries.filter((_, i) => i !== index))
+  }
+
+  function updatePref(key: string): (e: Event) => void {
+    return (e: Event) => {
+      const target = e.target as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+      setPref(key, target.value)
+    }
+  }
+</script>
+
+<div class="section">
+  <h3 class="section-title">OpenCode</h3>
+
+  <div class="subsection">
+    <h4 class="subsection-title">Model & behavior</h4>
+
+    <div class="field">
+      <label class="field-label" for="opencode-model">Model</label>
+      <input
+        id="opencode-model"
+        class="text-input"
+        type="text"
+        value={model}
+        onchange={updatePref('opencode.model')}
+        placeholder="provider/model"
+        spellcheck="false"
+      />
+      <span class="field-hint"
+        >Format: provider/model (e.g. anthropic/claude-sonnet-4-20250514)</span
+      >
+    </div>
+  </div>
+
+  <div class="subsection">
+    <h4 class="subsection-title">API</h4>
+
+    <div class="field">
+      <label class="field-label" for="opencode-apikey">API key</label>
+      <span class="field-hint"
+        >Set as ANTHROPIC_API_KEY. For other providers, use environment variables below</span
+      >
+      <input
+        id="opencode-apikey"
+        class="text-input"
+        type="password"
+        value={apiKey}
+        onchange={updatePref('opencode.apiKey')}
+        placeholder="Uses existing env variable"
+        spellcheck="false"
+        autocomplete="off"
+      />
+    </div>
+  </div>
+
+  <div class="subsection">
+    <h4 class="subsection-title">Environment variables</h4>
+
+    <p class="field-hint" style="margin: 0 0 4px;">Extra env vars passed to OpenCode sessions</p>
+
+    {#if envEntries.length > 0}
+      <div class="env-list">
+        {#each envEntries as entry, i (entry.key)}
+          <div class="env-row">
+            <span class="env-key">{entry.key}</span>
+            <span class="env-sep">=</span>
+            <span class="env-value">{entry.value}</span>
+            <button class="remove-btn" onclick={() => removeEnvVar(i)}>Remove</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if showEnvForm}
+      <div class="env-form">
+        <input
+          class="form-input"
+          bind:value={newEnvKey}
+          placeholder="VARIABLE_NAME"
+          spellcheck="false"
+          onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
+        />
+        <input
+          class="form-input"
+          bind:value={newEnvValue}
+          placeholder="value"
+          spellcheck="false"
+          onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
+        />
+        <div class="form-actions">
+          <button class="btn btn-cancel" onclick={() => (showEnvForm = false)}>Cancel</button>
+          <button class="btn btn-add" onclick={addEnvVar}>Add</button>
+        </div>
+      </div>
+    {:else}
+      <button class="btn btn-add-item" onclick={() => (showEnvForm = true)}>+ Add variable</button>
+    {/if}
+  </div>
+
+  <div class="subsection">
+    <h4 class="subsection-title">Advanced</h4>
+
+    <div class="field">
+      <label class="field-label" for="opencode-settings">Config JSON override</label>
+      <textarea
+        id="opencode-settings"
+        class="text-input textarea mono"
+        rows="4"
+        value={settingsJson}
+        onchange={updatePref('opencode.settingsJson')}
+        placeholder={'{"key": "value"}'}
+        spellcheck="false"
+      ></textarea>
+      <span class="field-hint">Passed via OPENCODE_CONFIG_CONTENT at session start</span>
+    </div>
+  </div>
+</div>
+
+<style>
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .section-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--c-text);
+    margin: 0;
+  }
+
+  .subsection {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .subsection-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--c-text-muted);
+    margin: 0;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .field-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--c-text-secondary);
+  }
+
+  .field-hint {
+    font-size: 11px;
+    color: var(--c-text-faint);
+  }
+
+  .text-input {
+    padding: 6px 10px;
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+    background: var(--c-hover);
+    color: var(--c-text);
+    font-size: 13px;
+    font-family: inherit;
+    outline: none;
+  }
+
+  .text-input:focus {
+    border-color: var(--c-focus-ring);
+  }
+
+  .textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+
+  .mono {
+    font-family: monospace;
+    font-size: 12px;
+  }
+
+  .env-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .env-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    background: var(--c-border-subtle);
+    font-size: 13px;
+  }
+
+  .env-key {
+    color: var(--c-accent-text);
+    font-family: monospace;
+    font-size: 12px;
+  }
+
+  .env-sep {
+    color: var(--c-text-faint);
+  }
+
+  .env-value {
+    color: var(--c-text-secondary);
+    font-family: monospace;
+    font-size: 12px;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .remove-btn {
+    padding: 2px 8px;
+    border: none;
+    border-radius: 4px;
+    background: var(--c-danger-bg);
+    color: var(--c-danger-text);
+    font-size: 11px;
+    font-family: inherit;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .remove-btn:hover {
+    filter: brightness(1.15);
+  }
+
+  .env-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    border: 1px solid var(--c-border);
+    border-radius: 8px;
+    background: var(--c-border-subtle);
+  }
+
+  .form-input {
+    padding: 6px 10px;
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+    background: var(--c-hover);
+    color: var(--c-text);
+    font-size: 13px;
+    font-family: monospace;
+    outline: none;
+  }
+
+  .form-input:focus {
+    border-color: var(--c-focus-ring);
+  }
+
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .btn {
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+    border: none;
+  }
+
+  .btn-cancel {
+    background: var(--c-active);
+    color: var(--c-text);
+  }
+
+  .btn-add {
+    background: var(--c-accent-bg);
+    color: var(--c-accent-text);
+  }
+
+  .btn-add:hover {
+    background: var(--c-accent-bg-hover);
+  }
+
+  .btn-add-item {
+    align-self: flex-start;
+    padding: 6px 14px;
+    border: 1px dashed var(--c-text-faint);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--c-text-secondary);
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .btn-add-item:hover {
+    background: var(--c-hover);
+    color: var(--c-text);
+  }
+</style>

--- a/src/renderer/src/components/preferences/PreferencesModal.svelte
+++ b/src/renderer/src/components/preferences/PreferencesModal.svelte
@@ -8,6 +8,7 @@
   import ShortcutsPrefs from './ShortcutsPrefs.svelte'
   import ClaudePrefs from './ClaudePrefs.svelte'
   import GeminiPrefs from './GeminiPrefs.svelte'
+  import OpenCodePrefs from './OpenCodePrefs.svelte'
   import UpdatePrefs from './UpdatePrefs.svelte'
   import ViewportsPrefs from './ViewportsPrefs.svelte'
   import SidebarPrefs from './SidebarPrefs.svelte'
@@ -27,7 +28,7 @@
     { label: 'General', sections: ['General', 'Updates', 'Privacy', 'Shortcuts'] },
     { label: 'Features', sections: ['Notch', 'Misc'] },
     { label: 'Appearance', sections: ['Appearance', 'Sidebar'] },
-    { label: 'AI Agents', sections: ['Claude', 'Gemini'] },
+    { label: 'AI Agents', sections: ['Claude', 'Gemini', 'OpenCode'] },
     { label: 'Dev Tools', sections: ['Terminal', 'Tools', 'Git', 'Tasks', 'File Watcher'] },
     { label: 'Web Browser', sections: ['Web Browser'] },
     { label: 'Security', sections: ['Remote Control'] },
@@ -106,6 +107,8 @@
         <ClaudePrefs />
       {:else if activeSection === 'Gemini'}
         <GeminiPrefs />
+      {:else if activeSection === 'OpenCode'}
+        <OpenCodePrefs />
       {:else if activeSection === 'Git'}
         <GitPrefs />
       {:else if activeSection === 'Web Browser'}

--- a/src/renderer/src/components/shared/ToolIcon.svelte
+++ b/src/renderer/src/components/shared/ToolIcon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ClaudeAILogo, OpenAILogo, GeminiLogo, GitLogo } from '@selemondev/svgl-svelte'
-  import { Terminal, Globe, FileText } from 'lucide-svelte'
+  import { Terminal, Globe, FileText, Code } from 'lucide-svelte'
 
   let { icon, size = 14 }: { icon: string; size?: number } = $props()
 </script>
@@ -13,6 +13,8 @@
   <GeminiLogo width={size} height={size} />
 {:else if icon === 'Git'}
   <GitLogo width={size} height={size} />
+{:else if icon === 'code' || icon === 'OpenCode'}
+  <Code {size} />
 {:else if icon === 'terminal'}
   <Terminal {size} />
 {:else if icon === 'Globe'}

--- a/src/renderer/src/lib/agents/agentState.svelte.ts
+++ b/src/renderer/src/lib/agents/agentState.svelte.ts
@@ -1,7 +1,7 @@
 import { match } from 'ts-pattern'
 import { SvelteDate } from 'svelte/reactivity'
 
-export type AgentType = 'claude' | 'gemini'
+export type AgentType = 'claude' | 'gemini' | 'opencode'
 
 export interface SubagentRecord {
   agentId: string
@@ -162,6 +162,7 @@ export function handleHookEvent(ptySessionId: string, event: NormalizedHookEvent
     })
     .with('PromptSubmit', () => {
       session.status = { type: 'thinking' }
+      delete session.extra.pendingQuestion
     })
     .with('BeforeToolUse', () => {
       session.status = {
@@ -174,9 +175,19 @@ export function handleHookEvent(ptySessionId: string, event: NormalizedHookEvent
         type: 'waitingPermission',
         toolName: event.toolName ?? 'unknown',
       }
+      // OpenCode: store question details for inspector display
+      if (event.toolName === 'question' && event.toolInput) {
+        const questions = event.toolInput.questions as
+          | Array<{ question?: string; header?: string }>
+          | undefined
+        if (questions?.[0]) {
+          session.extra.pendingQuestion = questions[0].question ?? questions[0].header ?? ''
+        }
+      }
     })
     .with('AfterToolUse', () => {
       session.toolCallCount++
+      delete session.extra.pendingQuestion
       handleTaskToolUse(session, event)
     })
     .with('AfterToolUseFailure', () => {
@@ -184,6 +195,7 @@ export function handleHookEvent(ptySessionId: string, event: NormalizedHookEvent
     })
     .with('Idle', () => {
       session.status = { type: 'idle' }
+      delete session.extra.pendingQuestion
     })
     .with('IdleFailure', () => {
       session.status = {
@@ -230,6 +242,24 @@ export function handleHookEvent(ptySessionId: string, event: NormalizedHookEvent
           timestamp: Date.now(),
         },
       ]
+      // OpenCode: sync todo list → task list
+      const todos = extra?.opencodeTodos as
+        | Array<{ id: string; content: string; status: string }>
+        | undefined
+      if (todos) {
+        session.tasks = todos.slice(0, MAX_TASKS).map((t) => ({
+          id: t.id,
+          subject: t.content,
+          status:
+            t.status === 'completed'
+              ? ('completed' as const)
+              : t.status === 'in_progress'
+                ? ('in_progress' as const)
+                : ('pending' as const),
+          activeForm: null,
+          owner: null,
+        }))
+      }
     })
     .with('BeforeCompact', () => {
       session.status = { type: 'compacting' }

--- a/src/renderer/src/lib/onboarding/steps.ts
+++ b/src/renderer/src/lib/onboarding/steps.ts
@@ -111,7 +111,7 @@ export const onboardingSteps: OnboardingStep[] = [
     title: 'OpenCode integration',
     description:
       'OpenCode is now available as an AI agent in Canopy. Launch it from the tool launcher and configure it in Settings → OpenCode.',
-    introducedIn: '0.12.0',
+    introducedIn: '0.11.0',
     category: 'feature',
   },
   {

--- a/src/renderer/src/lib/onboarding/steps.ts
+++ b/src/renderer/src/lib/onboarding/steps.ts
@@ -107,6 +107,14 @@ export const onboardingSteps: OnboardingStep[] = [
     category: 'feature',
   },
   {
+    id: 'opencode',
+    title: 'OpenCode integration',
+    description:
+      'OpenCode is now available as an AI agent in Canopy. Launch it from the tool launcher and configure it in Settings → OpenCode.',
+    introducedIn: '0.12.0',
+    category: 'feature',
+  },
+  {
     id: 'perf-hud',
     title: 'CPU and RAM in the status bar',
     description:


### PR DESCRIPTION
## What
Adds OpenCode as a third agent adapter alongside Claude and Gemini. A TypeScript bridge plugin installed in `~/.config/opencode/plugins/` forwards OpenCode's session, tool, and permission events to Canopy's HTTP hook server.

## Why
OpenCode is a growing AI coding agent. Integrating it into Canopy gives users the same notch status, inspector, and preferences experience they have with Claude and Gemini.

## How to test
1. Install OpenCode (`brew install opencode`)
2. `npm run dev`, open Canopy
3. Launch OpenCode from the tool launcher
4. Verify the bridge plugin appears in `~/.config/opencode/plugins/canopy-bridge.ts`
5. Confirm notch status toggles between idle (green) and thinking (orange) as OpenCode processes prompts
6. Trigger a question tool (e.g. ask OpenCode something ambiguous) and verify the inspector shows "Waiting for input" with the question text, and notch shows permission state
7. Check Preferences > OpenCode section: model, API key, env vars, config JSON override
8. Kill the session and confirm no orphan files remain

## Checklist
- [x] Lint and typecheck pass
- [x] Follows existing adapter pattern (claude.ts, gemini.ts)
- [x] No secrets or .env files committed
- [ ] Tests added/updated
- [ ] Documentation updated