### PR TITLE
feat: crash detection with GitHub issue reporting

### DIFF
--- a/src/main/crash/CrashReporter.ts
+++ b/src/main/crash/CrashReporter.ts
@@ -1,0 +1,94 @@
+import { app } from 'electron'
+import os from 'os'
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+export interface CrashReport {
+  timestamp: string
+  type:
+    | 'uncaughtException'
+    | 'unhandledRejection'
+    | 'rendererCrash'
+    | 'childProcessGone'
+    | 'ungracefulShutdown'
+  errorMessage: string
+  stack?: string
+  appVersion: string
+  electronVersion: string
+  os: string
+}
+
+export class CrashReporter {
+  private readonly sentinelPath: string
+  private readonly reportPath: string
+
+  constructor() {
+    const dir = app.getPath('userData')
+    this.sentinelPath = join(dir, '.canopy-running')
+    this.reportPath = join(dir, 'crash-report.json')
+  }
+
+  init(): void {
+    try {
+      if (existsSync(this.sentinelPath) && !existsSync(this.reportPath)) {
+        this.writeCrashReport({
+          timestamp: new Date().toISOString(),
+          type: 'ungracefulShutdown',
+          errorMessage: 'The app did not shut down cleanly',
+          appVersion: app.getVersion(),
+          electronVersion: process.versions.electron,
+          os: `${os.platform()} ${os.release()} ${os.arch()}`,
+        })
+      }
+      writeFileSync(this.sentinelPath, String(process.pid))
+    } catch {
+      // Crash reporter must never throw
+    }
+  }
+
+  recordCrash(type: CrashReport['type'], error: Error): void {
+    try {
+      this.writeCrashReport({
+        timestamp: new Date().toISOString(),
+        type,
+        errorMessage: error.message,
+        stack: error.stack,
+        appVersion: app.getVersion(),
+        electronVersion: process.versions.electron,
+        os: `${os.platform()} ${os.release()} ${os.arch()}`,
+      })
+    } catch {
+      // Crash reporter must never throw
+    }
+  }
+
+  getCrashReport(): CrashReport | null {
+    try {
+      if (!existsSync(this.reportPath)) return null
+      const raw = readFileSync(this.reportPath, 'utf-8')
+      return JSON.parse(raw) as CrashReport
+    } catch {
+      return null
+    }
+  }
+
+  clearCrashReport(): void {
+    try {
+      if (existsSync(this.reportPath)) unlinkSync(this.reportPath)
+    } catch {
+      // Crash reporter must never throw
+    }
+  }
+
+  clearSentinel(): void {
+    try {
+      if (existsSync(this.sentinelPath)) unlinkSync(this.sentinelPath)
+    } catch {
+      // Crash reporter must never throw
+    }
+  }
+
+  private writeCrashReport(report: CrashReport): void {
+    writeFileSync(this.reportPath, JSON.stringify(report, null, 2))
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,6 +33,7 @@ import { validateBounds, cascadeBounds } from './windowBounds'
 import { TelemetryManager } from './telemetry/TelemetryManager'
 import { RemoteSessionService } from './remote/RemoteSessionService'
 import { PerfHudService } from './perf/PerfHudService'
+import { CrashReporter } from './crash/CrashReporter'
 import type { WindowConfig } from './windowBounds'
 import { performance } from 'perf_hooks'
 
@@ -173,6 +174,7 @@ const scheduleRecurringUpdateCheck = (): void => {
 
 let agentSessionManager: AgentSessionManager | null = null
 let notchOverlay: NotchOverlayManager | null = null
+let crashReporter: CrashReporter | null = null
 
 // Register canopy:// URL scheme
 if (process.defaultApp) {
@@ -376,9 +378,46 @@ app.whenReady().then(async () => {
 
   electronApp.setAppUserModelId('tech.itsol.canopy')
 
+  crashReporter = new CrashReporter()
+
+  if (app.isPackaged) {
+    crashReporter!.init()
+
+    process.on('uncaughtException', (error) => {
+      crashReporter?.recordCrash('uncaughtException', error)
+    })
+
+    process.on('unhandledRejection', (reason) => {
+      crashReporter?.recordCrash(
+        'unhandledRejection',
+        reason instanceof Error ? reason : new Error(String(reason)),
+      )
+    })
+
+    app.on('child-process-gone', (_event, details) => {
+      if (details.reason !== 'clean-exit') {
+        crashReporter?.recordCrash(
+          'childProcessGone',
+          new Error(`${details.type} process crashed: ${details.reason}`),
+        )
+      }
+    })
+  }
+
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)
     window.on('focus', () => telemetryManager.onWindowFocus())
+
+    if (app.isPackaged) {
+      window.webContents.on('render-process-gone', (_event, details) => {
+        if (details.reason !== 'clean-exit') {
+          crashReporter?.recordCrash(
+            'rendererCrash',
+            new Error(`Renderer crashed: ${details.reason}`),
+          )
+        }
+      })
+    }
   })
 
   buildAppMenu()
@@ -768,6 +807,12 @@ app.whenReady().then(async () => {
       postLaunchSent = true
       if (PERF) performance.mark('app:firstWindowReady')
 
+      const crashData = crashReporter?.getCrashReport()
+      if (crashData) {
+        win.webContents.send('app:crashReport', crashData)
+        crashReporter?.clearCrashReport()
+      }
+
       if (isFirstLaunch) {
         win.webContents.send('app:showOnboarding', { mode: 'first-launch' })
       } else if (versionChanged && lastSeenVersion) {
@@ -879,6 +924,7 @@ app.on('before-quit', (event) => {
       clearInterval(updateCheckIntervalTimer)
       updateCheckIntervalTimer = null
     }
+    crashReporter?.clearSentinel()
     notchOverlay?.dispose()
     agentSessionManager?.dispose()
     remoteSessionService.dispose()
@@ -971,6 +1017,7 @@ app.on('before-quit', (event) => {
     clearInterval(updateCheckIntervalTimer)
     updateCheckIntervalTimer = null
   }
+  crashReporter?.clearSentinel()
   notchOverlay?.dispose()
   agentSessionManager?.dispose()
   remoteSessionService.dispose()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -381,7 +381,7 @@ app.whenReady().then(async () => {
   crashReporter = new CrashReporter()
 
   if (app.isPackaged) {
-    crashReporter!.init()
+    crashReporter.init()
 
     process.on('uncaughtException', (error) => {
       crashReporter?.recordCrash('uncaughtException', error)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -235,6 +235,19 @@ interface CanopyAPI {
   getChangelogSinceVersion: (fromVersion: string) => Promise<ChangelogEntry[] | null>
   onShowChangelog: (callback: (data: { fromVersion: string }) => void) => () => void
 
+  // Crash reports
+  onCrashReport: (
+    callback: (data: {
+      timestamp: string
+      type: string
+      errorMessage: string
+      stack?: string
+      appVersion: string
+      electronVersion: string
+      os: string
+    }) => void,
+  ) => () => void
+
   // PTY
   spawnPty: (options?: { cols?: number; rows?: number; cwd?: string }) => Promise<PtySpawnResult>
   resizePty: (sessionId: string, cols: number, rows: number) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -210,6 +210,26 @@ const api = {
     }
   },
 
+  // Crash reports
+  onCrashReport: (
+    callback: (data: {
+      timestamp: string
+      type: string
+      errorMessage: string
+      stack?: string
+      appVersion: string
+      electronVersion: string
+      os: string
+    }) => void,
+  ) => {
+    const handler = (_event: IpcRendererEvent, data: Parameters<typeof callback>[0]): void =>
+      callback(data)
+    ipcRenderer.on('app:crashReport', handler)
+    return (): void => {
+      ipcRenderer.removeListener('app:crashReport', handler)
+    }
+  },
+
   // About
   getAboutInfo: () => ipcRenderer.invoke('app:getAboutInfo'),
   openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', { url }),

--- a/src/renderer/src/components/dialogs/CrashReportDialog.svelte
+++ b/src/renderer/src/components/dialogs/CrashReportDialog.svelte
@@ -28,6 +28,10 @@
     if (e.key === 'Enter') {
       e.preventDefault()
       e.stopPropagation()
+      if (document.activeElement === dismissBtn) {
+        onDismiss()
+        return
+      }
       onCreateIssue()
     }
   }
@@ -110,7 +114,7 @@
     background: var(--c-bg-overlay);
     border: 1px solid var(--c-border);
     border-radius: 10px;
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+    box-shadow: var(--c-shadow-dialog, 0 16px 48px rgba(0, 0, 0, 0.6));
     padding: 20px;
   }
 

--- a/src/renderer/src/components/dialogs/CrashReportDialog.svelte
+++ b/src/renderer/src/components/dialogs/CrashReportDialog.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { TriangleAlert } from 'lucide-svelte'
+  import type { CrashReportData } from '../../lib/stores/dialogs.svelte'
+
+  let {
+    data,
+    onCreateIssue,
+    onDismiss,
+  }: {
+    data: CrashReportData
+    onCreateIssue: () => void
+    onDismiss: () => void
+  } = $props()
+
+  let dismissBtn: HTMLButtonElement | undefined = $state()
+
+  onMount(() => {
+    dismissBtn?.focus()
+  })
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      e.stopPropagation()
+      onDismiss()
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      e.stopPropagation()
+      onCreateIssue()
+    }
+  }
+
+  const formattedTime = $derived(
+    new Date(data.timestamp).toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'medium',
+    }),
+  )
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="dialog-overlay" onkeydown={handleKeydown} onmousedown={onDismiss}>
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="dialog-container"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="crash-dialog-title"
+    onmousedown={(e) => e.stopPropagation()}
+  >
+    <h3 id="crash-dialog-title" class="dialog-title">
+      <TriangleAlert size={16} />
+      Canopy crashed
+    </h3>
+    <p class="dialog-message">
+      The app did not shut down cleanly last time. You can report this to help us fix it.
+    </p>
+
+    <div class="crash-details">
+      <div class="detail-row">
+        <span class="detail-label">Time</span>
+        <span>{formattedTime}</span>
+      </div>
+      <div class="detail-row">
+        <span class="detail-label">Type</span>
+        <span>{data.type}</span>
+      </div>
+      <div class="detail-row">
+        <span class="detail-label">Version</span>
+        <span>{data.appVersion}</span>
+      </div>
+      <div class="detail-row">
+        <span class="detail-label">Electron</span>
+        <span>{data.electronVersion}</span>
+      </div>
+      <div class="detail-row">
+        <span class="detail-label">OS</span>
+        <span>{data.os}</span>
+      </div>
+    </div>
+
+    {#if data.errorMessage || data.stack}
+      <pre class="crash-stack">{data.errorMessage}{#if data.stack}
+          {data.stack}{/if}</pre>
+    {/if}
+
+    <div class="dialog-actions">
+      <button bind:this={dismissBtn} class="btn btn-cancel" onclick={onDismiss}>Dismiss</button>
+      <button class="btn btn-confirm" onclick={onCreateIssue}>Create issue</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .dialog-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1001;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding-top: 120px;
+    background: var(--c-scrim);
+  }
+
+  .dialog-container {
+    width: 480px;
+    background: var(--c-bg-overlay);
+    border: 1px solid var(--c-border);
+    border-radius: 10px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+    padding: 20px;
+  }
+
+  .dialog-title {
+    margin: 0 0 8px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--c-text);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .dialog-title :global(svg) {
+    color: var(--c-warning);
+    flex-shrink: 0;
+  }
+
+  .dialog-message {
+    margin: 0 0 12px;
+    font-size: 13px;
+    color: var(--c-text-secondary);
+    line-height: 1.5;
+  }
+
+  .crash-details {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 12px;
+    font-size: 12px;
+    color: var(--c-text-muted);
+  }
+
+  .detail-row {
+    display: flex;
+    gap: 8px;
+  }
+
+  .detail-label {
+    min-width: 64px;
+    color: var(--c-text-faint);
+  }
+
+  .crash-stack {
+    margin: 0 0 12px;
+    padding: 8px;
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+    font-family: monospace;
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--c-text-muted);
+    max-height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  .dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 16px;
+  }
+
+  .btn {
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+    border: none;
+    outline: none;
+    transition: background 0.1s;
+  }
+
+  .btn:focus-visible {
+    outline: 2px solid var(--c-focus-ring);
+    outline-offset: 1px;
+  }
+
+  .btn-cancel {
+    background: var(--c-active);
+    color: var(--c-text);
+  }
+
+  .btn-cancel:hover {
+    background: var(--c-border);
+  }
+
+  .btn-confirm {
+    background: var(--c-accent-bg);
+    color: var(--c-accent-text);
+  }
+
+  .btn-confirm:hover {
+    background: var(--c-accent-muted);
+  }
+</style>

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -529,7 +529,12 @@
     onCreateIssue={() => {
       if (dialogState.current.type !== 'crashReport') return
       const d = dialogState.current.data
-      const title = encodeURIComponent(`Crash: ${d.errorMessage.slice(0, 80)}`)
+      // Strip home directory paths from stack traces to avoid leaking local paths
+      const homeDir = d.os.startsWith('win32')
+        ? /[A-Z]:\\Users\\[^\\]+\\/gi
+        : /\/(?:Users|home)\/[^/]+\//g
+      const sanitize = (s: string): string => s.replace(homeDir, '~/')
+      const title = encodeURIComponent(`Crash: ${sanitize(d.errorMessage).slice(0, 80)}`)
       const body = encodeURIComponent(
         `## Crash report\n\n` +
           `- **Timestamp:** ${d.timestamp}\n` +
@@ -537,8 +542,8 @@
           `- **App version:** ${d.appVersion}\n` +
           `- **Electron:** ${d.electronVersion}\n` +
           `- **OS:** ${d.os}\n\n` +
-          `### Error\n\`\`\`\n${d.errorMessage}\n\`\`\`\n\n` +
-          (d.stack ? `### Stack trace\n\`\`\`\n${d.stack.slice(0, 3000)}\n\`\`\`\n` : ''),
+          `### Error\n\`\`\`\n${sanitize(d.errorMessage)}\n\`\`\`\n\n` +
+          (d.stack ? `### Stack trace\n\`\`\`\n${sanitize(d.stack).slice(0, 3000)}\n\`\`\`\n` : ''),
       )
       const url = `https://github.com/itsoltech/canopy-desktop/issues/new?title=${title}&body=${body}&labels=bug,crash`
       window.api.openExternal(url).catch(() => {

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -20,10 +20,12 @@
   import RemoteAcceptDeviceModal from '../dialogs/RemoteAcceptDeviceModal.svelte'
   import RunConfigEditorModal from '../runConfig/RunConfigEditorModal.svelte'
   import RunConfigManagerModal from '../runConfig/RunConfigManagerModal.svelte'
+  import CrashReportDialog from '../dialogs/CrashReportDialog.svelte'
   import WelcomeDashboard from '../dashboard/WelcomeDashboard.svelte'
   import RightPanel from './RightPanel.svelte'
   import Toast from '../shared/Toast.svelte'
   import { getPref, setPref } from '../../lib/stores/preferences.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
   import {
     dialogState,
     closeDialog,
@@ -32,6 +34,7 @@
     showChangelog,
     showOnboardingWizard,
     showFeatureOnboarding,
+    showCrashReport,
   } from '../../lib/stores/dialogs.svelte'
   import {
     workspaceState,
@@ -300,6 +303,13 @@
     })
   })
 
+  // Subscribe to crash report push event
+  $effect(() => {
+    return window.api.onCrashReport((data) => {
+      showCrashReport(data)
+    })
+  })
+
   // Save layouts on window close
   $effect(() => {
     const handler = (): void => saveAllLayouts()
@@ -512,6 +522,31 @@
   <RunConfigManagerModal
     initialConfigDir={dialogState.current.selectConfigDir}
     initialConfigName={dialogState.current.selectConfigName}
+  />
+{:else if dialogState.current.type === 'crashReport'}
+  <CrashReportDialog
+    data={dialogState.current.data}
+    onCreateIssue={() => {
+      if (dialogState.current.type !== 'crashReport') return
+      const d = dialogState.current.data
+      const title = encodeURIComponent(`Crash: ${d.errorMessage.slice(0, 80)}`)
+      const body = encodeURIComponent(
+        `## Crash report\n\n` +
+          `- **Timestamp:** ${d.timestamp}\n` +
+          `- **Type:** ${d.type}\n` +
+          `- **App version:** ${d.appVersion}\n` +
+          `- **Electron:** ${d.electronVersion}\n` +
+          `- **OS:** ${d.os}\n\n` +
+          `### Error\n\`\`\`\n${d.errorMessage}\n\`\`\`\n\n` +
+          (d.stack ? `### Stack trace\n\`\`\`\n${d.stack.slice(0, 3000)}\n\`\`\`\n` : ''),
+      )
+      const url = `https://github.com/itsoltech/canopy-desktop/issues/new?title=${title}&body=${body}&labels=bug,crash`
+      window.api.openExternal(url).catch(() => {
+        addToast('Failed to open browser. Copy the URL from your address bar to report manually.')
+      })
+      closeDialog()
+    }}
+    onDismiss={closeDialog}
   />
 {/if}
 

--- a/src/renderer/src/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/src/lib/stores/dialogs.svelte.ts
@@ -103,6 +103,21 @@ interface RunConfigManagerState {
   selectConfigName?: string
 }
 
+export interface CrashReportData {
+  timestamp: string
+  type: string
+  errorMessage: string
+  stack?: string
+  appVersion: string
+  electronVersion: string
+  os: string
+}
+
+interface CrashReportState {
+  type: 'crashReport'
+  data: CrashReportData
+}
+
 interface NoneState {
   type: 'none'
 }
@@ -124,6 +139,7 @@ type DialogState =
   | RemoteAcceptDeviceState
   | RunConfigEditorState
   | RunConfigManagerState
+  | CrashReportState
 
 export const dialogState: { current: DialogState } = $state({ current: { type: 'none' } })
 
@@ -237,6 +253,10 @@ export function showRunConfigManager(configDir?: string, configName?: string): v
     selectConfigDir: configDir,
     selectConfigName: configName,
   }
+}
+
+export function showCrashReport(data: CrashReportData): void {
+  dialogState.current = { type: 'crashReport', data }
 }
 
 export function closeDialog(): void {


### PR DESCRIPTION
## What

Detect app crashes and show a dialog on next launch with crash details and a "Create issue" button that opens a pre-filled GitHub issue.

## Why

No crash detection existed. When the app crashed, users had no way to report what happened or help us reproduce the problem.

## How it works

- **Sentinel file** (`.canopy-running` in userData): created on startup, removed on graceful quit. If present at next launch, the app crashed.
- **Exception handlers**: `uncaughtException`, `unhandledRejection`, `render-process-gone`, `child-process-gone` write detailed crash data to `crash-report.json`.
- **Crash dialog**: on next launch, if crash data exists, a modal shows timestamp, error type, version info, and stack trace with "Dismiss" and "Create issue" buttons.
- **GitHub issue**: "Create issue" opens the browser with a pre-filled issue (title, body with crash metadata, `bug` + `crash` labels). Stack traces truncated to 3000 chars for URL length safety.
- **Production only**: gated behind `app.isPackaged` to avoid false positives during development.

## How to test

1. Build a production build (`npm run build`)
2. Launch the app, then force-kill it (`kill -9 <pid>`)
3. Relaunch - crash report dialog should appear
4. Click "Create issue" - browser opens GitHub with pre-filled issue
5. Click "Dismiss" - dialog closes, does not reappear on next launch
6. Normal quit + relaunch - no crash dialog

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] No new dependencies added
- [x] Follows existing IPC, preload bridge, and dialog patterns
- [ ] Tested in production build