### PR TITLE
fix(telemetry): deduplicate daily ping and disable in dev mode

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -378,7 +378,7 @@ app.whenReady().then(async () => {
 
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)
-    window.on('focus', () => telemetryManager.onWindowFocus())
+    if (app.isPackaged) window.on('focus', () => telemetryManager.onWindowFocus())
   })
 
   buildAppMenu()

--- a/src/main/telemetry/TelemetryManager.ts
+++ b/src/main/telemetry/TelemetryManager.ts
@@ -6,11 +6,12 @@ const UMAMI_URL = 'https://analytics.itsol.tech/api/send'
 const WEBSITE_ID = 'e2ef58e3-bbc0-490c-9afb-263cbfce1640'
 
 export class TelemetryManager {
-  private lastPingDate: string | null = null
+  private cachedPingDate: string | null = null
 
   constructor(private readonly prefs: PreferencesStore) {}
 
   init(): void {
+    this.cachedPingDate = this.prefs.get('telemetry.lastPingDate') ?? null
     this.tryPing()
   }
 
@@ -22,12 +23,15 @@ export class TelemetryManager {
     if (this.prefs.get('telemetry.enabled') === 'false') return
 
     const today = new Date().toISOString().slice(0, 10)
-    if (this.lastPingDate === today) return
+    if (this.cachedPingDate === today) return
 
     this.sendPing(today)
   }
 
   private sendPing(today: string): void {
+    this.cachedPingDate = today
+    this.prefs.set('telemetry.lastPingDate', today)
+
     const display = screen.getPrimaryDisplay()
     const { width, height } = display.size
 
@@ -57,10 +61,14 @@ export class TelemetryManager {
         body,
       })
       .then((res) => {
-        if (res.ok) this.lastPingDate = today
+        if (!res.ok) {
+          this.cachedPingDate = null
+          this.prefs.delete('telemetry.lastPingDate')
+        }
       })
       .catch(() => {
-        // silently ignore — next focus will retry
+        this.cachedPingDate = null
+        this.prefs.delete('telemetry.lastPingDate')
       })
   }
 }


### PR DESCRIPTION
## What
- Persist `lastPingDate` via `PreferencesStore` so it survives app restarts, preventing duplicate pings within the same day
- Gate `onWindowFocus` telemetry behind `app.isPackaged` to disable pings in dev mode
- Use in-memory cache to avoid DB reads on every window focus event
- Clear persisted date on non-ok HTTP responses or network failures to allow retry

## Why
Umami analytics pings were firing multiple times per day because `lastPingDate` was stored only in memory and lost on every app restart. The `onWindowFocus` listener was also registered outside the `app.isPackaged` guard, causing pings in dev mode.

## Test plan
- [ ] Launch packaged app, verify single Umami ping per day (check network tab or analytics dashboard)
- [ ] Restart app within same day, verify no additional ping is sent
- [ ] Run in dev mode (`npm run dev`), verify no Umami requests are made
- [ ] Kill network during ping, refocus window, verify retry occurs