### PR TITLE
fix(terminal): debounce resize to prevent flickering

### DIFF
--- a/src/renderer/src/components/terminal/SplitPaneContainer.svelte
+++ b/src/renderer/src/components/terminal/SplitPaneContainer.svelte
@@ -28,14 +28,24 @@
 
   $effect(() => {
     if (!containerEl) return
+    let rafId: number | null = null
     function measure(): void {
       containerWidth = containerEl!.clientWidth || 1
       containerHeight = containerEl!.clientHeight || 1
     }
     measure()
-    const observer = new ResizeObserver(measure)
+    const observer = new ResizeObserver(() => {
+      if (rafId !== null) return
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        measure()
+      })
+    })
     observer.observe(containerEl)
-    return () => observer.disconnect()
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId)
+      observer.disconnect()
+    }
   })
 
   let layout = $derived(buildFlatLayout(node, containerWidth, containerHeight))
@@ -106,6 +116,7 @@
     overflow: hidden;
     min-width: 80px;
     min-height: 60px;
+    contain: layout paint;
   }
 
   .divider-slot {

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -51,6 +51,7 @@
   let pendingData = ''
   let writeScheduled = false
   let writeRafId: number | null = null
+  let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null
   let receivedChars = 0
   let startTerminal: (() => void) | null = null
 
@@ -445,24 +446,30 @@
       }
 
       resizeObserver = new ResizeObserver(() => {
-        if (!containerEl.clientWidth || !containerEl.clientHeight) return
-        const dims = fitAddon.proposeDimensions()
-        // Skip transient tiny sizes (e.g. window restore animation)
-        if (!dims || dims.cols < 10 || dims.rows < 3) return
-        if (dims.cols !== term.cols || dims.rows !== term.rows) {
-          const buffer = term.buffer.active
-          const isAtBottom = buffer.viewportY >= buffer.baseY
-          const savedY = buffer.viewportY
+        // Debounce: wait for resize to settle before re-fitting.
+        // During continuous drag, this skips all intermediate fits,
+        // avoiding WebGL texture churn (RAM spikes) and canvas flicker.
+        if (resizeDebounceTimer !== null) clearTimeout(resizeDebounceTimer)
+        resizeDebounceTimer = setTimeout(() => {
+          resizeDebounceTimer = null
+          if (!containerEl || !containerEl.clientWidth || !containerEl.clientHeight) return
+          const dims = fitAddon.proposeDimensions()
+          if (!dims || dims.cols < 10 || dims.rows < 3) return
+          if (dims.cols !== term.cols || dims.rows !== term.rows) {
+            const buffer = term.buffer.active
+            const isAtBottom = buffer.viewportY >= buffer.baseY
+            const savedY = buffer.viewportY
 
-          fitAddon.fit()
+            fitAddon.fit()
 
-          if (!isAtBottom) {
-            const currentY = term.buffer.active.viewportY
-            if (currentY !== savedY) {
-              term.scrollLines(savedY - currentY)
+            if (!isAtBottom) {
+              const currentY = term.buffer.active.viewportY
+              if (currentY !== savedY) {
+                term.scrollLines(savedY - currentY)
+              }
             }
           }
-        }
+        }, 80)
       })
       resizeObserver.observe(containerEl)
 
@@ -530,6 +537,7 @@
       if (dataDisposable) dataDisposable.dispose()
       const term = termRef
       termRef = null
+      if (resizeDebounceTimer !== null) clearTimeout(resizeDebounceTimer)
       if (resizeObserver) resizeObserver.disconnect()
       if (webglAddonRef) {
         webglAddonRef.dispose()
@@ -579,6 +587,7 @@
   .terminal-container {
     width: 100%;
     height: 100%;
+    contain: strict;
   }
 
   .progress-bar {


### PR DESCRIPTION
## What
Debounce terminal resize handling to eliminate content flickering and RAM
spikes during window resize and panel toggles.

## Why
ResizeObserver fired fitAddon.fit() synchronously on every container size
change — up to 60 times/second during drag. Each fit forced the WebGL addon
to reallocate textures, causing a visible blank flash and memory pressure
from deferred GC.

## How to test
1. `npm run dev`
2. Drag the window edge to resize continuously — terminal content should
   stay visible (no blank flash), RAM should stay stable
3. Toggle sidebar and inspector panel — terminal should refit after ~80ms
   with no flicker
4. Resize split panes — divider drag should feel smooth
5. Verify terminal output alignment after resize (run `ls`, resize, check
   columns still line up)

## Checklist
- [x] Follows conventional commit convention
- [x] No new warnings from `npm run typecheck`
- [x] No new warnings from `npm run svelte-check`
- [ ] Tested on Linux
- [x] Tested on macOS
- [ ] Tested on Windows