### PR TITLE
fix(git): coalesce GitWatcher refreshes to fix shutdown crash (#147)

### DIFF
--- a/docs/diagnostics/crash-reporting.md
+++ b/docs/diagnostics/crash-reporting.md
@@ -19,7 +19,10 @@ The crash reporter is active only in packaged (production) builds. In developmen
 1. On startup, `CrashReporter.init()` checks for a sentinel file `.canopy-running` in the user data directory (`app.getPath('userData')`).
 2. If the sentinel exists but no `crash-report.json` is present, the previous session exited without cleaning up. The reporter writes an `ungracefulShutdown` crash report with the message "The app did not shut down cleanly".
 3. The sentinel file is then (re)written with the current process PID.
-4. On graceful shutdown (`before-quit` or `window-all-closed`), `clearSentinel()` removes the sentinel file.
+4. On graceful shutdown, `clearSentinel()` removes the sentinel file. It is called from three places, in order of preference:
+   - The main `before-quit` handler (synchronous path, line ~1027 in `index.ts`).
+   - The updater-install branch of `before-quit` (line ~934), before Squirrel relaunches.
+   - A `process.on('exit')` fallback registered next to `CrashReporter.init()` — fires on any normal Node exit including SIGTERM/SIGINT and the `before-quit` async dialog paths (active-session confirm, tmux close-policy) that `preventDefault()` and return early without reaching the main cleanup block. This fallback cannot run on SIGKILL / Task Manager force-kill.
 
 ### Runtime crash recording
 

--- a/src/main/git/GitWatcher.ts
+++ b/src/main/git/GitWatcher.ts
@@ -44,6 +44,10 @@ export class GitWatcher {
     dirty: false,
     aheadBehind: false,
   }
+  // In-flight guard: prevents overlapping refresh batches from piling up git subprocesses (#147)
+  private refreshInFlight = false
+  private pendingWhileInFlight: GitRefreshFlags | null = null
+  private stopped = false
   private lastInfo: GitInfo | null
 
   constructor(
@@ -74,10 +78,12 @@ export class GitWatcher {
   }
 
   async stop(): Promise<void> {
+    this.stopped = true
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer)
       this.debounceTimer = null
     }
+    this.pendingWhileInFlight = null
     const sub = this.subscription
     if (!sub) return
     this.subscription = null
@@ -136,23 +142,59 @@ export class GitWatcher {
   }
 
   private scheduleRefresh(changedPath: string): void {
+    if (this.stopped) return
     this.markPendingRefresh(changedPath)
+
+    if (this.refreshInFlight) {
+      if (!this.pendingWhileInFlight) {
+        this.pendingWhileInFlight = { ...this.pendingRefresh }
+      } else {
+        this.mergeFlags(this.pendingWhileInFlight, this.pendingRefresh)
+      }
+      this.pendingRefresh = {
+        branch: false,
+        worktrees: false,
+        dirty: false,
+        aheadBehind: false,
+      }
+      return
+    }
 
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer)
     }
-    this.debounceTimer = setTimeout(async () => {
+    this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null
-      try {
-        const changes = this.consumePendingRefresh()
-        const info = await this.refreshInfo(changes)
-        this.onChange(info, changes)
-      } catch {
-        // Ignore errors from git commands during refresh
-      } finally {
-        this.lastRefreshCompletedAt = Date.now()
-      }
+      if (this.stopped) return
+      void this.runRefresh(this.consumePendingRefresh())
     }, this.debounceMs)
+  }
+
+  private async runRefresh(changes: GitRefreshFlags): Promise<void> {
+    if (this.stopped) return
+    this.refreshInFlight = true
+    try {
+      const info = await this.refreshInfo(changes)
+      if (this.stopped) return
+      this.onChange(info, changes)
+    } catch {
+      // Ignore errors from git commands during refresh
+    } finally {
+      this.lastRefreshCompletedAt = Date.now()
+      this.refreshInFlight = false
+      if (!this.stopped && this.pendingWhileInFlight) {
+        const next = this.pendingWhileInFlight
+        this.pendingWhileInFlight = null
+        void this.runRefresh(next)
+      }
+    }
+  }
+
+  private mergeFlags(target: GitRefreshFlags, extra: GitRefreshFlags): void {
+    target.branch ||= extra.branch
+    target.worktrees ||= extra.worktrees
+    target.dirty ||= extra.dirty
+    target.aheadBehind ||= extra.aheadBehind
   }
 
   private consumePendingRefresh(): GitRefreshFlags {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -385,6 +385,11 @@ app.whenReady().then(async () => {
   if (app.isPackaged) {
     crashReporter.init()
 
+    // Fallback for before-quit async paths that return without clearing the sentinel (#147)
+    process.on('exit', () => {
+      crashReporter?.clearSentinel()
+    })
+
     process.on('uncaughtException', (error) => {
       crashReporter?.recordCrash('uncaughtException', error)
     })


### PR DESCRIPTION
## What

Coalesce overlapping `GitWatcher` refresh batches so concurrent `.git/` events no longer stack fresh `git` subprocess batches on top. Also add a `process.on('exit')` fallback that clears the crash sentinel on any normal exit.

## Why

Fixes #147. `GitWatcher` had no in-flight guard: every debounced refresh spawned up to 4 concurrent `git` processes (`simple-git`). Under Windows antivirus I/O pressure, each batch could take seconds, and new `.git/` events kept stacking more batches on top — producing a subprocess pileup that left the app unresponsive, forcing users to Task-Manager-kill it. The sentinel was left behind, producing an `ungracefulShutdown` crash report on next launch.

Two tight changes:

1. `GitWatcher` coalesces new events into a single tail-dispatched pass instead of launching overlapping batches, and a `stopped` flag blocks new work after teardown.
2. `process.on('exit')` → `clearSentinel()` safety net covers the `before-quit` async dialog paths that `preventDefault()` and return early (active-session confirm, tmux close-policy).

## How to test

1. `npm run typecheck && npm run lint && npm run build` — all green.
2. `npm run dev`, open a workspace on the canopy repo, then in a terminal run `for i in (seq 1 20); git commit --allow-empty -m t$i; end` and watch `ps -ef | rg '[c]anopy.*git '`. Subprocess count should plateau at ~4 instead of spiking into the dozens.
3. Kill the dev app with `kill -TERM <main pid>`, relaunch, verify no `ungracefulShutdown` dialog appears and `~/Library/Application Support/canopy-code/.canopy-running` is gone.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default) — N/A, bug fix
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (all interactive elements reachable via keyboard) — N/A, no UI
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle` — N/A
- [x] Renderer code does not import Node.js modules directly — N/A
- [x] Feature docs in `docs/` updated (`docs/diagnostics/crash-reporting.md` documents the new `clearSentinel()` fallback path)