### PR TITLE
feat(settings): export and import app settings to JSON

### DIFF
--- a/docs/features/settings-export.md
+++ b/docs/features/settings-export.md
@@ -1,0 +1,143 @@
+# Settings export / import
+
+> Export app settings, AI agent profiles, and integrations to a JSON file and restore them on another machine.
+
+**Status:** Stable
+**Platforms:** macOS, Windows, Linux
+
+## Overview
+
+Canopy stores all app state in a single SQLite database at `app.getPath('userData')/canopy.db`. Secrets (AI API keys, task tracker tokens, saved credentials) are encrypted at rest with Electron's `safeStorage`, which is bound to the source machine's OS keychain — an encrypted blob from machine A cannot be decrypted on machine B.
+
+The Backup & Restore feature works around this by decrypting secrets in the main process before writing them to a JSON file, and re-encrypting them with the destination machine's `safeStorage` on import. The exported file therefore contains plaintext API keys and tokens and must be treated as sensitive.
+
+Export is a merge-friendly operation: import upserts rows by natural key (`key` for preferences, `(agent_type, name)` for profiles, `(domain, username)` for credentials, `id` for custom tools). Local-only entries on the destination machine are preserved. The entire import runs inside a single SQLite transaction — if any row fails validation or the write fails, the whole import rolls back atomically.
+
+## Behavior
+
+### Export
+
+1. User opens Preferences → General → Backup & Restore → **Export Settings…**
+2. A confirmation dialog warns that the file will contain plaintext API keys and tokens. The user either confirms or cancels.
+3. On confirm, the main process presents a native Save dialog (`dialog.showSaveDialog`) pre-filled with `canopy-settings-YYYY-MM-DD.json`.
+4. `SettingsExportService.buildExport()` reads every exportable preference (decrypting encrypted keys with `safeStorage`), every agent profile (with decrypted `apiKey`), every credential (with decrypted password), and every `is_custom = 1` tool definition.
+5. The result is serialized to pretty-printed JSON and written with `fs.promises.writeFile` using mode `0o600` (Unix-only: owner read/write). On Windows NTFS the mode is advisory; users must manage file permissions themselves.
+6. A toast confirms the file path. No settings are modified during export.
+
+### Import
+
+1. User opens Preferences → General → Backup & Restore → **Import Settings…**
+2. A confirmation dialog warns that existing matching entries will be overwritten. The user either confirms or cancels.
+3. On confirm, the main process presents a native Open dialog filtered to `.json` files.
+4. The file is read, `JSON.parse`'d, and handed to `SettingsExportService.applyImport()`.
+5. Validation checks `version === 1`, required top-level shapes, and per-row types. Unknown agent types, empty names, and missing required fields cause the entire import to abort before any write.
+6. On validation success, a single `database.db.transaction(…)` runs:
+   - `PreferencesStore.setMany` upserts every preference; non-exportable keys in the file are silently skipped; encrypted keys are re-encrypted with this machine's `safeStorage`.
+   - `ProfileStore.upsertForImport` upserts by `(agent_type, name)`. Existing rows are updated in place (id and `created_at` preserved). New rows get a fresh UUID. `is_default` is preserved from the existing row.
+   - `CredentialStore.upsertForImport` upserts by `(domain, username)` and re-encrypts passwords.
+   - `ToolRegistry.upsertCustomForImport` upserts by `id` with `is_custom = 1`; shell-metacharacter validation from `addCustom` still applies.
+7. After the transaction commits, the main process broadcasts `profile:changed` and `tools:changed` to every window. The renderer's preferences store re-invokes `loadPrefs()` from the handler for immediate feedback.
+8. A toast reports per-section counts (`Imported N preferences, M profiles, K credentials, L tools`).
+9. On any failure (validation, parse error, write error, version mismatch), the transaction rolls back and a toast surfaces the typed error message. No partial state is left behind.
+
+## What is included
+
+| Section       | Table              | Included rows                                 | Secret handling                                |
+| ------------- | ------------------ | --------------------------------------------- | ---------------------------------------------- |
+| `preferences` | `preferences`      | All keys except the non-exportable list below | Encrypted keys decrypted before serialization  |
+| `profiles`    | `agent_profiles`   | All rows                                      | `apiKey` included as plaintext; `id` omitted   |
+| `credentials` | `credentials`      | All rows                                      | `password` included as plaintext; `id` omitted |
+| `customTools` | `tool_definitions` | Only `is_custom = 1`                          | No secrets                                     |
+
+## What is excluded
+
+Excluded to avoid corrupting destination-local state:
+
+- **Workspace tables** — `workspaces`, `workspace_layouts`. These reference filesystem paths (`/Users/alice/…`) and per-machine workspace UUIDs that would not exist on the destination.
+- **Onboarding completions** — `onboarding_completions`. Each machine runs its own setup wizard.
+- **Built-in tool definitions** — `tool_definitions` where `is_custom = 0`. These are re-seeded on first launch via DB migrations.
+
+Machine-bound or runtime-state preference keys are also filtered from the `preferences` section. The filter is defined in `src/main/db/PreferencesStore.ts` (`NON_EXPORTABLE_KEYS` and `NON_EXPORTABLE_PREFIXES`):
+
+| Key / prefix                         | Reason                                                    |
+| ------------------------------------ | --------------------------------------------------------- |
+| `app.lastSeenVersion`                | "What's new" dialog cursor, per machine                   |
+| `openWindowConfigs`                  | Window geometry and monitor layout                        |
+| `telemetry.lastPingDate`             | Telemetry throttle cursor                                 |
+| `remote.lastPort`                    | Last-used remote control port binding                     |
+| `remote.trustedDevices`              | Per-machine device identity and authorization list        |
+| `taskTracker.migratedToGlobalConfig` | Internal one-shot migration flag                          |
+| `workspace:*`                        | Workspace-UUID–scoped state (e.g. worktree setup configs) |
+
+## File format
+
+```jsonc
+{
+  "version": 1,
+  "exportedAt": "2026-04-13T12:34:56.000Z",
+  "appVersion": "0.11.0-next.8",
+  "preferences": { "theme": "dark", "claude.apiKey": "sk-…" /* … */ },
+  "profiles": [
+    {
+      "agentType": "claude",
+      "name": "Default",
+      "isDefault": true,
+      "sortIndex": 0,
+      "prefs": { "model": "…", "permissionMode": "…" },
+      "apiKey": "sk-…",
+    },
+  ],
+  "credentials": [
+    { "domain": "github.com", "username": "alice", "title": "GH work", "password": "…" },
+  ],
+  "customTools": [
+    {
+      "id": "my-tool",
+      "name": "My Tool",
+      "command": "mytool",
+      "args": [],
+      "icon": "terminal",
+      "category": "system",
+    },
+  ],
+}
+```
+
+Profile `id`, `createdAt`, and `updatedAt` are intentionally omitted. Imports upsert by `(agentType, name)`, which matches the unique index on `agent_profiles`, so destination profile IDs stay stable and UUID collisions across machines are impossible.
+
+## Security
+
+- The export file contains plaintext secrets. Store it in an encrypted container (Keychain-backed disk image, password manager attachment, or similar). **Never commit it to version control, and never upload it to a shared drive.**
+- On macOS and Linux, the file is written with mode `0o600` so only the owning user can read it. On Windows NTFS, the mode is not enforced — verify the parent folder's ACLs manually or store the file under `%USERPROFILE%` where default permissions are user-private.
+- The export warning dialog must be confirmed before the file dialog opens, to prevent accidental exports.
+- `getAllDecrypted` and `listInternal` / `listInternalDecrypted` on the store classes are main-process-only. They are never exposed through IPC. The only way to reach them from outside the main process is via the two IPC handlers `settings:export` and `settings:import`, which always pair read and write with the user-driven file dialog.
+
+## Error states
+
+Error tags live in `src/main/settings/errors.ts` and are formatted by `settingsExportErrorMessage` (`ts-pattern` `.exhaustive()`).
+
+| Tag                     | When it fires                                                        |
+| ----------------------- | -------------------------------------------------------------------- |
+| `ExportReadError`       | A store throws while `buildExport` is assembling the file            |
+| `ExportWriteError`      | `fs.writeFile` fails (permission denied, disk full, etc.)            |
+| `ImportReadError`       | `fs.readFile` fails on the selected import file                      |
+| `ImportParseError`      | The file is not valid JSON                                           |
+| `ImportVersionMismatch` | `version` in the file does not equal `SETTINGS_EXPORT_VERSION` (1)   |
+| `ImportValidationError` | A per-row shape check fails (unknown agent type, missing name, etc.) |
+| `ImportWriteError`      | The outer DB transaction throws during upsert                        |
+
+All errors surface to the renderer as thrown `Error`s from the IPC handlers, caught by the UI and shown as a toast.
+
+## Configuration
+
+Backup & Restore has no user-configurable options. The Export and Import actions live under Preferences → General → Backup & Restore.
+
+## Source files
+
+- Service: `src/main/settings/SettingsExport.ts`
+- Types: `src/main/settings/types.ts`
+- Errors: `src/main/settings/errors.ts`
+- Store helpers: `src/main/db/PreferencesStore.ts` (`getAllDecrypted`, `setMany`, `NON_EXPORTABLE_KEYS`), `src/main/profiles/ProfileStore.ts` (`listInternal`, `upsertForImport`), `src/main/db/CredentialStore.ts` (`listInternalDecrypted`, `upsertForImport`), `src/main/tools/ToolRegistry.ts` (`listCustom`, `upsertCustomForImport`)
+- IPC handlers: `src/main/ipc/handlers.ts` (`settings:export`, `settings:import`)
+- Preload bridge: `src/preload/index.ts` (`exportSettings`, `importSettings`)
+- UI: `src/renderer/src/components/preferences/GeneralPrefs.svelte` (Backup & Restore section)

--- a/src/main/db/CredentialStore.ts
+++ b/src/main/db/CredentialStore.ts
@@ -131,6 +131,66 @@ export class CredentialStore {
     }))
   }
 
+  /**
+   * Returns every credential with decrypted password. Main-process-only;
+   * never expose via IPC. Used for settings export.
+   */
+  listInternalDecrypted(): Credential[] {
+    const rows = this.db
+      .prepare('SELECT * FROM credentials ORDER BY domain, username')
+      .all() as CredentialRow[]
+    return rows.map((row) => ({
+      id: row.id,
+      domain: row.domain,
+      username: row.username,
+      password: this.decrypt(row.password_enc),
+      title: row.title,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }))
+  }
+
+  /**
+   * Upsert credentials from an import file, keyed by (domain, username).
+   * Existing rows are updated in place (id preserved); new rows get a fresh
+   * UUID. Re-encrypts passwords with this machine's safeStorage. Does not
+   * open a transaction — the caller wraps the full import in one outer
+   * transaction.
+   */
+  upsertForImport(
+    creds: {
+      domain: string
+      username: string
+      password: string
+      title?: string
+    }[],
+  ): number {
+    const findStmt = this.db.prepare('SELECT id FROM credentials WHERE domain = ? AND username = ?')
+    const updateStmt = this.db.prepare(
+      `UPDATE credentials
+         SET password_enc = ?, title = ?, updated_at = datetime('now')
+         WHERE id = ?`,
+    )
+    const insertStmt = this.db.prepare(
+      `INSERT INTO credentials (id, domain, username, password_enc, title, updated_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+    )
+
+    let count = 0
+    for (const c of creds) {
+      if (!c.domain || !c.username) continue
+      const enc = this.encrypt(c.password)
+      const existing = findStmt.get(c.domain, c.username) as { id: string } | undefined
+      if (existing) {
+        updateStmt.run(enc, c.title ?? '', existing.id)
+      } else {
+        insertStmt.run(randomUUID(), c.domain, c.username, enc, c.title ?? '')
+      }
+      count++
+    }
+    return count
+  }
+
   /** Get single credential with decrypted password (for autofill) */
   getById(id: string): Credential | null {
     const row = this.db.prepare('SELECT * FROM credentials WHERE id = ?').get(id) as

--- a/src/main/db/PreferencesStore.ts
+++ b/src/main/db/PreferencesStore.ts
@@ -5,9 +5,31 @@ import type { Database } from './Database'
 const ENCRYPTED_KEYS = new Set(['claude.apiKey', 'gemini.apiKey', 'opencode.apiKey'])
 const ENCRYPTED_KEY_PREFIXES = ['taskTracker.token.']
 
+/**
+ * Preference keys that are bound to this specific machine or represent
+ * transient runtime state. They must never be written to a settings export,
+ * because restoring them on another machine would corrupt local state
+ * (orphan workspace IDs, stale window geometry, wrong device identity, etc).
+ */
+const NON_EXPORTABLE_KEYS = new Set([
+  'app.lastSeenVersion',
+  'openWindowConfigs',
+  'telemetry.lastPingDate',
+  'remote.lastPort',
+  'remote.trustedDevices',
+  'taskTracker.migratedToGlobalConfig',
+])
+
+const NON_EXPORTABLE_PREFIXES = ['workspace:']
+
 function isEncryptedKey(key: string): boolean {
   if (ENCRYPTED_KEYS.has(key)) return true
   return ENCRYPTED_KEY_PREFIXES.some((prefix) => key.startsWith(prefix))
+}
+
+function isExportableKey(key: string): boolean {
+  if (NON_EXPORTABLE_KEYS.has(key)) return false
+  return !NON_EXPORTABLE_PREFIXES.some((prefix) => key.startsWith(prefix))
 }
 
 export class PreferencesStore {
@@ -55,6 +77,56 @@ export class PreferencesStore {
       result[row.key] = row.value
     }
     return result
+  }
+
+  /**
+   * Main-process-only: returns every exportable preference including
+   * encrypted keys, decrypted to plaintext. Machine-bound and runtime
+   * state keys (window geometry, device identity, version tracking, etc)
+   * are filtered out. Never expose via IPC — used for settings export.
+   */
+  getAllDecrypted(): Record<string, string> {
+    const rows = this.db.prepare('SELECT key, value FROM preferences').all() as {
+      key: string
+      value: string
+    }[]
+    const result: Record<string, string> = {}
+    for (const row of rows) {
+      if (!isExportableKey(row.key)) continue
+      if (isEncryptedKey(row.key) && safeStorage.isEncryptionAvailable()) {
+        try {
+          result[row.key] = safeStorage.decryptString(Buffer.from(row.value, 'base64'))
+          continue
+        } catch {
+          // Value was stored before encryption; fall through to raw value
+        }
+      }
+      result[row.key] = row.value
+    }
+    return result
+  }
+
+  /**
+   * Bulk upsert for settings import. Re-encrypts known encrypted keys with
+   * this machine's safeStorage. Non-exportable keys are silently skipped as
+   * a defense in depth — if an older export file contains them, they must
+   * not be allowed to overwrite destination-local state. Runs no internal
+   * transaction — the caller (SettingsExportService) wraps this and sibling
+   * calls in one outer transaction so a partial import rolls back atomically.
+   */
+  setMany(entries: Record<string, string>): number {
+    const stmt = this.db.prepare('INSERT OR REPLACE INTO preferences (key, value) VALUES (?, ?)')
+    let count = 0
+    for (const [key, value] of Object.entries(entries)) {
+      if (!isExportableKey(key)) continue
+      const stored =
+        isEncryptedKey(key) && safeStorage.isEncryptionAvailable()
+          ? safeStorage.encryptString(value).toString('base64')
+          : value
+      stmt.run(key, stored)
+      count++
+    }
+    return count
   }
 
   delete(key: string): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,7 @@ import { resolveLoginEnv } from './shell/loginEnv'
 import { WindowManager } from './WindowManager'
 import { BrowserManager } from './browser/BrowserManager'
 import { CredentialStore } from './db/CredentialStore'
+import { SettingsExportService } from './settings/SettingsExport'
 import { NotchOverlayManager } from './notch/NotchOverlayManager'
 import { TmuxManager } from './pty/TmuxManager'
 import { TaskTrackerManager } from './taskTracker/TaskTrackerManager'
@@ -106,6 +107,13 @@ const telemetryManager = new TelemetryManager(preferencesStore)
 const windowManager = new WindowManager(ptyManager, wsBridge)
 const browserManager = new BrowserManager()
 const credentialStore = new CredentialStore(database)
+const settingsExportService = new SettingsExportService(
+  database,
+  preferencesStore,
+  profileStore,
+  credentialStore,
+  toolRegistry,
+)
 const tmuxManager = new TmuxManager(app.getPath('userData'))
 const remoteSessionService = new RemoteSessionService(preferencesStore)
 const perfHudService = new PerfHudService()
@@ -642,6 +650,7 @@ app.whenReady().then(async () => {
     remoteSessionService,
     runConfigManager,
     profileStore,
+    settingsExportService,
   )
 
   if (PERF) performance.mark('app:ipcHandlersRegistered')

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -69,6 +69,8 @@ import type { ProfileStore } from '../profiles/ProfileStore'
 import { profileToReader } from '../profiles/ProfileStore'
 import { profileErrorMessage } from '../profiles/errors'
 import { KNOWN_AGENT_TYPES, type ProfileInput } from '../profiles/types'
+import type { SettingsExportService } from '../settings/SettingsExport'
+import { settingsExportErrorMessage } from '../settings/errors'
 import type { AgentType, PreferencesReader } from '../agents/types'
 import { resolveShell } from '../pty/PtyManager'
 
@@ -104,6 +106,7 @@ export function registerIpcHandlers(
   remoteSessionService: RemoteSessionService,
   runConfigManager: RunConfigManager,
   profileStore: ProfileStore,
+  settingsExportService: SettingsExportService,
 ): void {
   function broadcastToolsChanged(): void {
     const tools = toolRegistry.getAll()
@@ -470,6 +473,92 @@ export function registerIpcHandlers(
 
   ipcMain.handle('db:prefs:delete', (_event, payload: { key: string }) => {
     preferencesStore.delete(payload.key)
+  })
+
+  // --- Settings Export / Import ---
+
+  ipcMain.handle('settings:export', async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win || win.isDestroyed()) return null
+
+    const today = new Date().toISOString().slice(0, 10)
+    const defaultFilename = `canopy-settings-${today}.json`
+
+    const saveResult = await dialog.showSaveDialog(win, {
+      title: 'Export Canopy Settings',
+      defaultPath: defaultFilename,
+      filters: [{ name: 'JSON', extensions: ['json'] }],
+    })
+    if (saveResult.canceled || !saveResult.filePath) return null
+
+    const buildResult = await settingsExportService.buildExport()
+    const file = unwrapOrThrow(buildResult, settingsExportErrorMessage)
+    const json = JSON.stringify(file, null, 2)
+
+    try {
+      await fs.promises.writeFile(saveResult.filePath, json, { encoding: 'utf8', mode: 0o600 })
+    } catch (e) {
+      throw new Error(
+        settingsExportErrorMessage({
+          _tag: 'ExportWriteError',
+          reason: e instanceof Error ? e.message : String(e),
+        }),
+      )
+    }
+
+    return {
+      path: saveResult.filePath,
+      counts: {
+        preferences: Object.keys(file.preferences).length,
+        profiles: file.profiles.length,
+        credentials: file.credentials.length,
+        customTools: file.customTools.length,
+      },
+    }
+  })
+
+  ipcMain.handle('settings:import', async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win || win.isDestroyed()) return null
+
+    const openResult = await dialog.showOpenDialog(win, {
+      title: 'Import Canopy Settings',
+      filters: [{ name: 'JSON', extensions: ['json'] }],
+      properties: ['openFile'],
+    })
+    if (openResult.canceled || openResult.filePaths.length === 0) return null
+
+    let raw: string
+    try {
+      raw = await fs.promises.readFile(openResult.filePaths[0], 'utf8')
+    } catch (e) {
+      throw new Error(
+        settingsExportErrorMessage({
+          _tag: 'ImportReadError',
+          reason: e instanceof Error ? e.message : String(e),
+        }),
+      )
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch (e) {
+      throw new Error(
+        settingsExportErrorMessage({
+          _tag: 'ImportParseError',
+          reason: e instanceof Error ? e.message : String(e),
+        }),
+      )
+    }
+
+    const applyResult = await settingsExportService.applyImport(parsed)
+    const counts = unwrapOrThrow(applyResult, settingsExportErrorMessage)
+
+    await broadcastProfilesChanged()
+    broadcastToolsChanged()
+
+    return { counts }
   })
 
   // --- Tools ---

--- a/src/main/profiles/ProfileStore.ts
+++ b/src/main/profiles/ProfileStore.ts
@@ -253,6 +253,78 @@ export class ProfileStore {
     }
   }
 
+  // --- Export / Import (main-process-only) ---
+
+  /**
+   * Returns every profile with decrypted apiKey. Never expose via IPC —
+   * used for settings export.
+   */
+  listInternal(): AgentProfile[] {
+    const rows = this.db
+      .prepare('SELECT * FROM agent_profiles ORDER BY agent_type, sort_index, name')
+      .all() as ProfileRow[]
+    return rows.map((r) => this.rowToProfile(r))
+  }
+
+  /**
+   * Upsert profiles from an import file, keyed by (agent_type, name).
+   * Existing profiles are updated in-place (preserves id, createdAt, and
+   * is_default). New profiles get a fresh UUID. Does not open a transaction —
+   * the caller wraps the full import in one outer transaction.
+   */
+  upsertForImport(
+    profiles: {
+      agentType: AgentType
+      name: string
+      isDefault?: boolean
+      sortIndex?: number
+      prefs: ProfilePrefs
+      apiKey: string | null
+    }[],
+  ): number {
+    const findStmt = this.db.prepare(
+      'SELECT * FROM agent_profiles WHERE agent_type = ? AND name = ?',
+    )
+    const updateStmt = this.db.prepare(
+      `UPDATE agent_profiles
+         SET prefs_json = ?, api_key_enc = ?, sort_index = ?, updated_at = datetime('now')
+         WHERE id = ?`,
+    )
+    const insertStmt = this.db.prepare(
+      `INSERT INTO agent_profiles
+         (id, agent_type, name, is_default, sort_index, prefs_json, api_key_enc)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+
+    let count = 0
+    for (const p of profiles) {
+      if (!isAgentType(p.agentType)) continue
+      const trimmed = p.name.trim()
+      if (!trimmed) continue
+
+      const prefsJson = JSON.stringify(p.prefs ?? {})
+      const apiKeyEnc =
+        typeof p.apiKey === 'string' && p.apiKey.length > 0 ? this.encrypt(p.apiKey) : null
+
+      const existing = findStmt.get(p.agentType, trimmed) as ProfileRow | undefined
+      if (existing) {
+        updateStmt.run(prefsJson, apiKeyEnc, p.sortIndex ?? existing.sort_index, existing.id)
+      } else {
+        insertStmt.run(
+          randomUUID(),
+          p.agentType,
+          trimmed,
+          p.isDefault ? 1 : 0,
+          p.sortIndex ?? 0,
+          prefsJson,
+          apiKeyEnc,
+        )
+      }
+      count++
+    }
+    return count
+  }
+
   // --- Migration of legacy global prefs into Default profiles ---
 
   ensureDefaults(): void {

--- a/src/main/settings/SettingsExport.ts
+++ b/src/main/settings/SettingsExport.ts
@@ -1,0 +1,277 @@
+import { app } from 'electron'
+import { ok, err, errAsync, okAsync, type Result, type ResultAsync } from 'neverthrow'
+import { match, P } from 'ts-pattern'
+import type { Database } from '../db/Database'
+import type { PreferencesStore } from '../db/PreferencesStore'
+import type { CredentialStore } from '../db/CredentialStore'
+import type { ToolRegistry } from '../tools/ToolRegistry'
+import type { ProfileStore } from '../profiles/ProfileStore'
+import { KNOWN_AGENT_TYPES, type AgentType, type ProfilePrefs } from '../profiles/types'
+import {
+  SETTINGS_EXPORT_VERSION,
+  type ExportFile,
+  type ExportedCredential,
+  type ExportedCustomTool,
+  type ExportedProfile,
+  type ImportCounts,
+} from './types'
+import type { SettingsExportError } from './errors'
+
+const KNOWN_AGENT_SET = new Set<string>(KNOWN_AGENT_TYPES)
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export class SettingsExportService {
+  constructor(
+    private database: Database,
+    private preferencesStore: PreferencesStore,
+    private profileStore: ProfileStore,
+    private credentialStore: CredentialStore,
+    private toolRegistry: ToolRegistry,
+  ) {}
+
+  buildExport(): ResultAsync<ExportFile, SettingsExportError> {
+    try {
+      const profiles: ExportedProfile[] = this.profileStore.listInternal().map((p) => ({
+        agentType: p.agentType,
+        name: p.name,
+        isDefault: p.isDefault,
+        sortIndex: p.sortIndex,
+        prefs: p.prefs,
+        apiKey: p.apiKey,
+      }))
+
+      const credentials: ExportedCredential[] = this.credentialStore
+        .listInternalDecrypted()
+        .map((c) => ({
+          domain: c.domain,
+          username: c.username,
+          title: c.title,
+          password: c.password,
+        }))
+
+      const customTools: ExportedCustomTool[] = this.toolRegistry.listCustom().map((t) => ({
+        id: t.id,
+        name: t.name,
+        command: t.command,
+        args: t.args,
+        icon: t.icon,
+        category: t.category,
+      }))
+
+      const file: ExportFile = {
+        version: SETTINGS_EXPORT_VERSION,
+        exportedAt: new Date().toISOString(),
+        appVersion: app.getVersion(),
+        preferences: this.preferencesStore.getAllDecrypted(),
+        profiles,
+        credentials,
+        customTools,
+      }
+      return okAsync(file)
+    } catch (e) {
+      return errAsync({
+        _tag: 'ExportReadError',
+        reason: e instanceof Error ? e.message : String(e),
+      })
+    }
+  }
+
+  applyImport(raw: unknown): ResultAsync<ImportCounts, SettingsExportError> {
+    const parsed = this.validate(raw)
+    if (parsed.isErr()) return errAsync(parsed.error)
+    const file = parsed.value
+
+    const counts: ImportCounts = {
+      preferences: 0,
+      profiles: 0,
+      credentials: 0,
+      customTools: 0,
+    }
+
+    const txn = this.database.db.transaction(() => {
+      counts.preferences = this.preferencesStore.setMany(file.preferences)
+      counts.profiles = this.profileStore.upsertForImport(file.profiles)
+      counts.credentials = this.credentialStore.upsertForImport(file.credentials)
+      counts.customTools = this.toolRegistry.upsertCustomForImport(file.customTools)
+    })
+
+    try {
+      txn()
+    } catch (e) {
+      return errAsync({
+        _tag: 'ImportWriteError',
+        reason: e instanceof Error ? e.message : String(e),
+      })
+    }
+    return okAsync(counts)
+  }
+
+  private validate(raw: unknown): Result<ExportFile, SettingsExportError> {
+    if (!isRecord(raw)) {
+      return err({ _tag: 'ImportValidationError', reason: 'top-level value is not an object' })
+    }
+
+    if (typeof raw.version !== 'number') {
+      return err({ _tag: 'ImportValidationError', reason: 'missing or non-numeric "version"' })
+    }
+    if (raw.version !== SETTINGS_EXPORT_VERSION) {
+      return err({
+        _tag: 'ImportVersionMismatch',
+        found: raw.version,
+        expected: SETTINGS_EXPORT_VERSION,
+      })
+    }
+
+    if (!isRecord(raw.preferences)) {
+      return err({ _tag: 'ImportValidationError', reason: '"preferences" must be an object' })
+    }
+    const preferences: Record<string, string> = {}
+    for (const [key, value] of Object.entries(raw.preferences)) {
+      if (typeof value !== 'string') {
+        return err({
+          _tag: 'ImportValidationError',
+          reason: `preferences["${key}"] must be a string`,
+        })
+      }
+      preferences[key] = value
+    }
+
+    const profilesResult = this.validateProfiles(raw.profiles)
+    if (profilesResult.isErr()) return err(profilesResult.error)
+
+    const credentialsResult = this.validateCredentials(raw.credentials)
+    if (credentialsResult.isErr()) return err(credentialsResult.error)
+
+    const toolsResult = this.validateCustomTools(raw.customTools)
+    if (toolsResult.isErr()) return err(toolsResult.error)
+
+    return ok({
+      version: SETTINGS_EXPORT_VERSION,
+      exportedAt: typeof raw.exportedAt === 'string' ? raw.exportedAt : '',
+      appVersion: typeof raw.appVersion === 'string' ? raw.appVersion : '',
+      preferences,
+      profiles: profilesResult.value,
+      credentials: credentialsResult.value,
+      customTools: toolsResult.value,
+    })
+  }
+
+  private validateProfiles(raw: unknown): Result<ExportedProfile[], SettingsExportError> {
+    if (!Array.isArray(raw)) {
+      return err({ _tag: 'ImportValidationError', reason: '"profiles" must be an array' })
+    }
+    const out: ExportedProfile[] = []
+    for (const [i, entry] of raw.entries()) {
+      if (!isRecord(entry)) {
+        return err({ _tag: 'ImportValidationError', reason: `profiles[${i}] is not an object` })
+      }
+      if (typeof entry.agentType !== 'string' || !KNOWN_AGENT_SET.has(entry.agentType)) {
+        return err({
+          _tag: 'ImportValidationError',
+          reason: `profiles[${i}].agentType is not a known agent type`,
+        })
+      }
+      if (typeof entry.name !== 'string' || entry.name.trim() === '') {
+        return err({ _tag: 'ImportValidationError', reason: `profiles[${i}].name is empty` })
+      }
+      if (!isRecord(entry.prefs)) {
+        return err({
+          _tag: 'ImportValidationError',
+          reason: `profiles[${i}].prefs must be an object`,
+        })
+      }
+      const apiKey = match(entry.apiKey)
+        .with(P.string, (s) => s)
+        .with(null, () => null)
+        .with(undefined, () => null)
+        .otherwise(() => null)
+
+      out.push({
+        agentType: entry.agentType as AgentType,
+        name: entry.name,
+        isDefault: entry.isDefault === true,
+        sortIndex: typeof entry.sortIndex === 'number' ? entry.sortIndex : 0,
+        prefs: entry.prefs as ProfilePrefs,
+        apiKey,
+      })
+    }
+    return ok(out)
+  }
+
+  private validateCredentials(raw: unknown): Result<ExportedCredential[], SettingsExportError> {
+    if (!Array.isArray(raw)) {
+      return err({ _tag: 'ImportValidationError', reason: '"credentials" must be an array' })
+    }
+    const out: ExportedCredential[] = []
+    for (const [i, entry] of raw.entries()) {
+      if (!isRecord(entry)) {
+        return err({ _tag: 'ImportValidationError', reason: `credentials[${i}] is not an object` })
+      }
+      if (typeof entry.domain !== 'string' || entry.domain === '') {
+        return err({ _tag: 'ImportValidationError', reason: `credentials[${i}].domain is empty` })
+      }
+      if (typeof entry.username !== 'string' || entry.username === '') {
+        return err({
+          _tag: 'ImportValidationError',
+          reason: `credentials[${i}].username is empty`,
+        })
+      }
+      if (typeof entry.password !== 'string') {
+        return err({
+          _tag: 'ImportValidationError',
+          reason: `credentials[${i}].password must be a string`,
+        })
+      }
+      out.push({
+        domain: entry.domain,
+        username: entry.username,
+        password: entry.password,
+        title: typeof entry.title === 'string' ? entry.title : '',
+      })
+    }
+    return ok(out)
+  }
+
+  private validateCustomTools(raw: unknown): Result<ExportedCustomTool[], SettingsExportError> {
+    if (!Array.isArray(raw)) {
+      return err({ _tag: 'ImportValidationError', reason: '"customTools" must be an array' })
+    }
+    const out: ExportedCustomTool[] = []
+    for (const [i, entry] of raw.entries()) {
+      if (!isRecord(entry)) {
+        return err({ _tag: 'ImportValidationError', reason: `customTools[${i}] is not an object` })
+      }
+      if (typeof entry.id !== 'string' || entry.id === '') {
+        return err({ _tag: 'ImportValidationError', reason: `customTools[${i}].id is empty` })
+      }
+      if (typeof entry.name !== 'string') {
+        return err({
+          _tag: 'ImportValidationError',
+          reason: `customTools[${i}].name must be a string`,
+        })
+      }
+      if (typeof entry.command !== 'string') {
+        return err({
+          _tag: 'ImportValidationError',
+          reason: `customTools[${i}].command must be a string`,
+        })
+      }
+      const args =
+        Array.isArray(entry.args) && entry.args.every((a) => typeof a === 'string')
+          ? (entry.args as string[])
+          : []
+      out.push({
+        id: entry.id,
+        name: entry.name,
+        command: entry.command,
+        args,
+        icon: typeof entry.icon === 'string' ? entry.icon : 'terminal',
+        category: typeof entry.category === 'string' ? entry.category : 'system',
+      })
+    }
+    return ok(out)
+  }
+}

--- a/src/main/settings/errors.ts
+++ b/src/main/settings/errors.ts
@@ -1,0 +1,27 @@
+import { match } from 'ts-pattern'
+
+export type SettingsExportError =
+  | { _tag: 'ExportReadError'; reason: string }
+  | { _tag: 'ExportWriteError'; reason: string }
+  | { _tag: 'ImportReadError'; reason: string }
+  | { _tag: 'ImportParseError'; reason: string }
+  | { _tag: 'ImportVersionMismatch'; found: number; expected: number }
+  | { _tag: 'ImportValidationError'; reason: string }
+  | { _tag: 'ImportWriteError'; reason: string }
+
+export function settingsExportErrorMessage(error: SettingsExportError): string {
+  return match(error)
+    .with({ _tag: 'ExportReadError' }, (e) => `Failed to read settings: ${e.reason}`)
+    .with({ _tag: 'ExportWriteError' }, (e) => `Failed to write export file: ${e.reason}`)
+    .with({ _tag: 'ImportReadError' }, (e) => `Failed to read import file: ${e.reason}`)
+    .with({ _tag: 'ImportParseError' }, (e) => `Import file is not valid JSON: ${e.reason}`)
+    .with(
+      { _tag: 'ImportVersionMismatch' },
+      (e) =>
+        `Import file version ${e.found} is not supported (expected ${e.expected}). ` +
+        `Export from a newer or older version of Canopy.`,
+    )
+    .with({ _tag: 'ImportValidationError' }, (e) => `Import file is invalid: ${e.reason}`)
+    .with({ _tag: 'ImportWriteError' }, (e) => `Failed to apply import: ${e.reason}`)
+    .exhaustive()
+}

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -1,0 +1,46 @@
+import type { AgentType } from '../agents/types'
+import type { ProfilePrefs } from '../profiles/types'
+
+export const SETTINGS_EXPORT_VERSION = 1
+
+export interface ExportedProfile {
+  agentType: AgentType
+  name: string
+  isDefault: boolean
+  sortIndex: number
+  prefs: ProfilePrefs
+  apiKey: string | null
+}
+
+export interface ExportedCredential {
+  domain: string
+  username: string
+  title: string
+  password: string
+}
+
+export interface ExportedCustomTool {
+  id: string
+  name: string
+  command: string
+  args: string[]
+  icon: string
+  category: string
+}
+
+export interface ExportFile {
+  version: typeof SETTINGS_EXPORT_VERSION
+  exportedAt: string
+  appVersion: string
+  preferences: Record<string, string>
+  profiles: ExportedProfile[]
+  credentials: ExportedCredential[]
+  customTools: ExportedCustomTool[]
+}
+
+export interface ImportCounts {
+  preferences: number
+  profiles: number
+  credentials: number
+  customTools: number
+}

--- a/src/main/tools/ToolRegistry.ts
+++ b/src/main/tools/ToolRegistry.ts
@@ -82,6 +82,58 @@ export class ToolRegistry {
     this.reload()
   }
 
+  /** Return only user-added tools. Used for settings export. */
+  listCustom(): ToolDefinition[] {
+    return this.getAll().filter((t) => t.isCustom)
+  }
+
+  /**
+   * Upsert custom tools from an import file, keyed by id. Reuses the
+   * validation from addCustom. Does not open a transaction — the caller
+   * wraps the full import in one outer transaction.
+   */
+  upsertCustomForImport(
+    tools: {
+      id: string
+      name: string
+      command: string
+      args?: string[]
+      icon?: string
+      category?: string
+    }[],
+  ): number {
+    const stmt = this.db.prepare(
+      `INSERT INTO tool_definitions (id, name, command, args_json, icon, category, is_custom)
+       VALUES (?, ?, ?, ?, ?, ?, 1)
+       ON CONFLICT(id) DO UPDATE SET
+         name = excluded.name,
+         command = excluded.command,
+         args_json = excluded.args_json,
+         icon = excluded.icon,
+         category = excluded.category,
+         is_custom = 1`,
+    )
+    const SHELL_META = /[;|&$`<>%^!()\\"]/
+    let count = 0
+    for (const tool of tools) {
+      this.validateId(tool.id)
+      if (!tool.command.trim()) continue
+      if (/[/\\;|&$`<>%^!()"]/.test(tool.command)) continue
+      if (tool.args?.some((arg) => SHELL_META.test(arg))) continue
+      stmt.run(
+        tool.id,
+        tool.name,
+        tool.command,
+        JSON.stringify(tool.args ?? []),
+        tool.icon ?? 'terminal',
+        tool.category ?? 'system',
+      )
+      count++
+    }
+    this.reload()
+    return count
+  }
+
   removeCustom(id: string): void {
     this.validateId(id)
     this.db.prepare('DELETE FROM tool_definitions WHERE id = ? AND is_custom = 1').run(id)

--- a/src/main/tools/ToolRegistry.ts
+++ b/src/main/tools/ToolRegistry.ts
@@ -102,6 +102,9 @@ export class ToolRegistry {
       category?: string
     }[],
   ): number {
+    // WHERE clause prevents a crafted import from hijacking a built-in tool
+    // (e.g. id: "shell"). On conflict with a non-custom row, the UPDATE is
+    // skipped and SQLite resolves the conflict as a silent no-op.
     const stmt = this.db.prepare(
       `INSERT INTO tool_definitions (id, name, command, args_json, icon, category, is_custom)
        VALUES (?, ?, ?, ?, ?, ?, 1)
@@ -111,12 +114,17 @@ export class ToolRegistry {
          args_json = excluded.args_json,
          icon = excluded.icon,
          category = excluded.category,
-         is_custom = 1`,
+         is_custom = 1
+       WHERE tool_definitions.is_custom = 1`,
     )
     const SHELL_META = /[;|&$`<>%^!()\\"]/
     let count = 0
     for (const tool of tools) {
-      this.validateId(tool.id)
+      try {
+        this.validateId(tool.id)
+      } catch {
+        continue
+      }
       if (!tool.command.trim()) continue
       if (/[/\\;|&$`<>%^!()"]/.test(tool.command)) continue
       if (tool.args?.some((arg) => SHELL_META.test(arg))) continue

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -337,6 +337,25 @@ interface CanopyAPI {
   // Dialog
   openFolder: (defaultPath?: string) => Promise<string | null>
 
+  // Settings export / import
+  exportSettings: () => Promise<{
+    path: string
+    counts: {
+      preferences: number
+      profiles: number
+      credentials: number
+      customTools: number
+    }
+  } | null>
+  importSettings: () => Promise<{
+    counts: {
+      preferences: number
+      profiles: number
+      credentials: number
+      customTools: number
+    }
+  } | null>
+
   // Workspace Git Status
   refreshWorkspaceGitStatus: (id: string, path: string) => Promise<WorkspaceRow | null>
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -256,6 +256,27 @@ const api = {
   openFolder: (defaultPath?: string) =>
     ipcRenderer.invoke('dialog:openFolder', defaultPath ? { defaultPath } : undefined),
 
+  // Settings export / import
+  exportSettings: () =>
+    ipcRenderer.invoke('settings:export') as Promise<{
+      path: string
+      counts: {
+        preferences: number
+        profiles: number
+        credentials: number
+        customTools: number
+      }
+    } | null>,
+  importSettings: () =>
+    ipcRenderer.invoke('settings:import') as Promise<{
+      counts: {
+        preferences: number
+        profiles: number
+        credentials: number
+        customTools: number
+      }
+    } | null>,
+
   // Git
   refreshWorkspaceGitStatus: (id: string, path: string) =>
     ipcRenderer.invoke('db:workspace:refreshGitStatus', { id, path }),

--- a/src/renderer/src/components/preferences/GeneralPrefs.svelte
+++ b/src/renderer/src/components/preferences/GeneralPrefs.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { prefs, setPref } from '../../lib/stores/preferences.svelte'
+  import { prefs, setPref, loadPrefs } from '../../lib/stores/preferences.svelte'
   import { getTools, getToolAvailability } from '../../lib/stores/tools.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
-  import { closeDialog, showOnboardingWizard } from '../../lib/stores/dialogs.svelte'
+  import { closeDialog, confirm, showOnboardingWizard } from '../../lib/stores/dialogs.svelte'
   import { initOnboarding } from '../../lib/stores/onboarding.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
 
   const isMac = navigator.userAgent.includes('Mac')
 
@@ -40,6 +41,51 @@
     await initOnboarding('first-launch')
     closeDialog()
     showOnboardingWizard()
+  }
+
+  async function handleExportSettings(): Promise<void> {
+    const ok = await confirm({
+      title: 'Export settings',
+      message: 'Save all app settings and integrations to a JSON file?',
+      details:
+        'The file will contain your AI agent API keys, Linear/Jira tokens, and saved credentials as plaintext. Store it somewhere only you can access.',
+      confirmLabel: 'Export',
+    })
+    if (!ok) return
+
+    try {
+      const result = await window.api.exportSettings()
+      if (!result) return
+      addToast(`Settings exported to ${result.path}`)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      addToast(`Export failed: ${message}`)
+    }
+  }
+
+  async function handleImportSettings(): Promise<void> {
+    const ok = await confirm({
+      title: 'Import settings',
+      message: 'Load settings from a JSON file?',
+      details:
+        'Existing settings with matching keys will be overwritten. Profiles, credentials, and custom tools not in the file are kept as-is.',
+      confirmLabel: 'Import',
+      destructive: true,
+    })
+    if (!ok) return
+
+    try {
+      const result = await window.api.importSettings()
+      if (!result) return
+      const { preferences, profiles, credentials, customTools } = result.counts
+      addToast(
+        `Imported ${preferences} preferences, ${profiles} profiles, ${credentials} credentials, ${customTools} tools`,
+      )
+      await loadPrefs()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      addToast(`Import failed: ${message}`)
+    }
   }
 </script>
 
@@ -92,6 +138,18 @@
 
   <div class="action-row">
     <button class="action-btn" onclick={rerunSetupWizard}>Re-run setup wizard</button>
+  </div>
+</div>
+
+<div class="section">
+  <h3 class="section-title">Backup & Restore</h3>
+  <div class="hint-row backup-hint">
+    Export all app settings, AI agent profiles, and integrations to a JSON file so you can restore
+    them on another machine. The file contains plaintext API keys and tokens — store it securely.
+  </div>
+  <div class="action-row action-row-gap">
+    <button class="action-btn" onclick={handleExportSettings}>Export Settings…</button>
+    <button class="action-btn" onclick={handleImportSettings}>Import Settings…</button>
   </div>
 </div>
 
@@ -160,8 +218,18 @@
     padding-left: 0;
   }
 
+  .hint-row.backup-hint {
+    padding-left: 0;
+    margin-top: 0;
+  }
+
   .action-row {
     padding-top: 4px;
+  }
+
+  .action-row-gap {
+    display: flex;
+    gap: 8px;
   }
 
   .action-btn {


### PR DESCRIPTION
## What

Add a Backup & Restore section under Preferences → General that exports
preferences, AI agent profiles, saved credentials, and custom tools to
a JSON file and restores them on another machine.

## Why

Users migrating between computers had no way to carry over their
configuration — API keys, tracker tokens, agent profiles, and custom
tools all had to be re-entered by hand. safeStorage-encrypted blobs
are bound to the source machine's keychain and cannot be copied directly,
so this feature decrypts secrets in the main process before serialization
and re-encrypts them with the destination machine's safeStorage on import.

## How to test

1. `npm run dev`
2. Preferences → General → Backup & Restore → **Export Settings…**
3. Accept the plaintext warning, pick a path, confirm the success toast.
4. Open the JSON and verify:
   - `preferences`, `profiles`, `credentials`, `customTools` are populated
   - API keys / tokens appear as plaintext
   - No `app.lastSeenVersion`, `openWindowConfigs`, `remote.trustedDevices`, `telemetry.lastPingDate`, or `workspace:*` keys are present
5. Toggle a preference (e.g. "Reopen last workspace"), then **Import Settings…** on the same file and verify it reverts with a counts toast.
6. Cross-machine simulation: quit, `mv ~/Library/Application\ Support/Canopy/canopy.db{,.bak}`, relaunch through onboarding, import the JSON, and confirm AI profiles, tracker tokens, credentials, and custom tools all come back. Restore the original DB afterwards.
7. Error paths: import a JSON with `version: 999` → version-mismatch toast, no DB changes. Hand-corrupt the JSON → parse-error toast, no DB changes. Cancel either dialog → no toast, no changes.
8. `npm run typecheck && npm run lint` pass.

## Screenshots / recordings

New "Backup & Restore" section at the bottom of Preferences → General with two buttons: **Export Settings…** and **Import Settings…**.

## Checklist

- [x] No secrets, tokens, or credentials logged (only the user-chosen export file receives plaintext, gated by an explicit warning dialog — documented in `docs/features/settings-export.md#security`)
- [ ] Non-core feature is behind a feature flag (N/A — core action)
- [x] Cross-platform: uses `dialog.showSaveDialog` / `showOpenDialog`; `0o600` file perms documented as Unix-only
- [x] Keyboard accessible (native `<button>`, reuses existing confirm modal)
- [x] IPC follows `feature:action`: `settings:export`, `settings:import`
- [x] Renderer does not import Node.js modules directly
- [x] Feature docs added: `docs/features/settings-export.md`