### PR TITLE
fix(crash): sync untracked-diff reads, recover macos .ips stacks

### DIFF
--- a/docs/diagnostics/crash-reporting.md
+++ b/docs/diagnostics/crash-reporting.md
@@ -17,9 +17,10 @@ The crash reporter is active only in packaged (production) builds. In developmen
 ### Sentinel-based crash detection
 
 1. On startup, `CrashReporter.init()` checks for a sentinel file `.canopy-running` in the user data directory (`app.getPath('userData')`).
-2. If the sentinel exists but no `crash-report.json` is present, the previous session exited without cleaning up. The reporter writes an `ungracefulShutdown` crash report with the message "The app did not shut down cleanly".
-3. The sentinel file is then (re)written with the current process PID.
-4. On graceful shutdown, `clearSentinel()` removes the sentinel file. It is called from three places, in order of preference:
+2. If the sentinel exists but no `crash-report.json` is present, the previous session exited without cleaning up. The reporter writes an `ungracefulShutdown` crash report.
+3. On macOS only, before writing the report the reporter also scans `~/Library/Logs/DiagnosticReports/` (and `…/Retired/`) for a recent `Canopy-*.ips` dump whose mtime is at or after the previous sentinel mtime. If one is found, the reporter parses the header and body JSON, extracts the triggered thread's symbolicated frames from the `.ips`, and attaches them to the report as `stack`, along with structured fields in `nativeCrash` (exception type, codes, termination reason, triggered thread name, incident id, source path). The `errorMessage` becomes e.g. `Native crash: EXC_BREAKPOINT (SIGTRAP) in CrBrowserMain` instead of the generic "did not shut down cleanly" string. If no matching `.ips` is found, the report falls back to the generic message with no stack. Windows and Linux native-dump recovery are not implemented — the same generic fallback applies there.
+4. The sentinel file is then (re)written with the current process PID.
+5. On graceful shutdown, `clearSentinel()` removes the sentinel file. It is called from three places, in order of preference:
    - The main `before-quit` handler (synchronous path, line ~1027 in `index.ts`).
    - The updater-install branch of `before-quit` (line ~934), before Squirrel relaunches.
    - A `process.on('exit')` fallback registered next to `CrashReporter.init()` — fires on any normal Node exit including SIGTERM/SIGINT and the `before-quit` async dialog paths (active-session confirm, tmux close-policy) that `preventDefault()` and return early without reaching the main cleanup block. This fallback cannot run on SIGKILL / Task Manager force-kill.
@@ -75,7 +76,20 @@ The `crash-report.json` file stored in `app.getPath('userData')` contains:
 }
 ```
 
-The `stack` field is optional and absent for `ungracefulShutdown` reports (no error object is available in that case).
+The `stack` field is optional. For `ungracefulShutdown` reports it is absent unless a matching macOS `.ips` native dump was recovered, in which case the reporter also populates an optional `nativeCrash` object:
+
+```json
+{
+  "nativeCrash": {
+    "exceptionType": "EXC_BREAKPOINT (SIGTRAP)",
+    "exceptionCodes": "0x0000000000000001, 0x0000000113060e1c",
+    "terminationReason": "Trace/BPT trap: 5 (by exc handler)",
+    "triggeredThread": "CrBrowserMain",
+    "incidentId": "A1CE2AD8-CF3F-4E78-A2F1-7AA8328E8857",
+    "sourceFile": "/Users/you/Library/Logs/DiagnosticReports/Canopy-...-ips"
+  }
+}
+```
 
 ## Configuration
 
@@ -97,6 +111,7 @@ Home directory paths are stripped from stack traces before they are placed in th
 ## Source files
 
 - Main: `src/main/crash/CrashReporter.ts`
+- Native dump reader (macOS `.ips`): `src/main/crash/NativeCrashReader.ts`
 - IPC wiring: `src/main/index.ts` (crash handler registration near line 381, push to renderer near line 810)
 - Preload: `src/preload/index.ts` (`onCrashReport` listener)
 - Dialog: `src/renderer/src/components/dialogs/CrashReportDialog.svelte`

--- a/src/main/crash/CrashReporter.ts
+++ b/src/main/crash/CrashReporter.ts
@@ -1,7 +1,8 @@
 import { app } from 'electron'
 import os from 'os'
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
+import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs'
 import { join } from 'path'
+import { findRecentNativeCrash, type NativeCrashInfo } from './NativeCrashReader'
 
 export interface CrashReport {
   timestamp: string
@@ -16,7 +17,17 @@ export interface CrashReport {
   appVersion: string
   electronVersion: string
   os: string
+  nativeCrash?: {
+    exceptionType?: string
+    exceptionCodes?: string
+    terminationReason?: string
+    triggeredThread?: string
+    incidentId?: string
+    sourceFile?: string
+  }
 }
+
+const NATIVE_CRASH_PROCESS_NAME = 'Canopy'
 
 export class CrashReporter {
   private readonly sentinelPath: string
@@ -31,14 +42,9 @@ export class CrashReporter {
   init(): void {
     try {
       if (existsSync(this.sentinelPath) && !existsSync(this.reportPath)) {
-        this.writeCrashReport({
-          timestamp: new Date().toISOString(),
-          type: 'ungracefulShutdown',
-          errorMessage: 'The app did not shut down cleanly',
-          appVersion: app.getVersion(),
-          electronVersion: process.versions.electron,
-          os: `${os.platform()} ${os.release()} ${os.arch()}`,
-        })
+        const prevSentinelMs = this.readSentinelMtime()
+        const native = findRecentNativeCrash(NATIVE_CRASH_PROCESS_NAME, prevSentinelMs)
+        this.writeCrashReport(this.buildUngracefulShutdownReport(native))
       }
       writeFileSync(this.sentinelPath, String(process.pid))
     } catch {
@@ -85,6 +91,48 @@ export class CrashReporter {
       if (existsSync(this.sentinelPath)) unlinkSync(this.sentinelPath)
     } catch {
       // Crash reporter must never throw
+    }
+  }
+
+  private readSentinelMtime(): number {
+    try {
+      return statSync(this.sentinelPath).mtimeMs
+    } catch {
+      return 0
+    }
+  }
+
+  private buildUngracefulShutdownReport(native: NativeCrashInfo | null): CrashReport {
+    const base = {
+      type: 'ungracefulShutdown' as const,
+      appVersion: app.getVersion(),
+      electronVersion: process.versions.electron,
+      os: `${os.platform()} ${os.release()} ${os.arch()}`,
+    }
+
+    if (!native) {
+      return {
+        ...base,
+        timestamp: new Date().toISOString(),
+        errorMessage: 'The app did not shut down cleanly',
+      }
+    }
+
+    const where = native.triggeredThread ? ` in ${native.triggeredThread}` : ''
+    const what = native.exceptionType ?? 'unknown exception'
+    return {
+      ...base,
+      timestamp: native.timestamp || new Date().toISOString(),
+      errorMessage: `Native crash: ${what}${where}`,
+      stack: native.stack,
+      nativeCrash: {
+        exceptionType: native.exceptionType,
+        exceptionCodes: native.exceptionCodes,
+        terminationReason: native.terminationReason,
+        triggeredThread: native.triggeredThread,
+        incidentId: native.incidentId,
+        sourceFile: native.sourceFile,
+      },
     }
   }
 

--- a/src/main/crash/NativeCrashReader.ts
+++ b/src/main/crash/NativeCrashReader.ts
@@ -134,7 +134,7 @@ function parseIpsFile(filePath: string): NativeCrashInfo | null {
   let body: IpsBody
   try {
     header = JSON.parse(raw.slice(0, newlineIdx)) as IpsHeader
-    body = JSON.parse(raw.slice(newlineIdx + 1)) as IpsBody
+    body = JSON.parse(raw.slice(newlineIdx + 1).trim()) as IpsBody
   } catch {
     return null
   }

--- a/src/main/crash/NativeCrashReader.ts
+++ b/src/main/crash/NativeCrashReader.ts
@@ -1,0 +1,199 @@
+import { readdirSync, readFileSync, statSync } from 'fs'
+import os from 'os'
+import { join } from 'path'
+
+export interface NativeCrashInfo {
+  timestamp: string
+  exceptionType?: string
+  exceptionCodes?: string
+  terminationReason?: string
+  triggeredThread?: string
+  stack: string
+  incidentId?: string
+  sourceFile: string
+}
+
+interface IpsFrame {
+  imageIndex?: number
+  imageOffset?: number
+  symbol?: string
+  symbolLocation?: number
+}
+
+interface IpsThread {
+  name?: string
+  queue?: string
+  triggered?: boolean
+  frames?: IpsFrame[]
+}
+
+interface IpsImage {
+  name?: string
+}
+
+interface IpsHeader {
+  app_name?: string
+  timestamp?: string
+  incident_id?: string
+}
+
+interface IpsBody {
+  exception?: {
+    type?: string
+    signal?: string
+    codes?: string
+  }
+  termination?: {
+    indicator?: string
+    byProc?: string
+  }
+  threads?: IpsThread[]
+  usedImages?: IpsImage[]
+}
+
+const MAX_FRAMES = 40
+const MAX_STACK_CHARS = 4000
+const CLOCK_SKEW_MS = 60_000
+
+export function findRecentNativeCrash(
+  processName: string,
+  sinceEpochMs: number,
+  nowEpochMs: number = Date.now(),
+): NativeCrashInfo | null {
+  if (process.platform !== 'darwin') return null
+
+  try {
+    const candidate = findCandidateFile(processName, sinceEpochMs, nowEpochMs)
+    if (!candidate) return null
+    return parseIpsFile(candidate)
+  } catch {
+    return null
+  }
+}
+
+function findCandidateFile(
+  processName: string,
+  sinceEpochMs: number,
+  nowEpochMs: number,
+): string | null {
+  const home = os.homedir()
+  const dirs = [
+    join(home, 'Library', 'Logs', 'DiagnosticReports'),
+    join(home, 'Library', 'Logs', 'DiagnosticReports', 'Retired'),
+  ]
+
+  const lowerBound = sinceEpochMs - CLOCK_SKEW_MS
+  const upperBound = nowEpochMs + CLOCK_SKEW_MS
+  const prefix = `${processName}-`
+
+  let best: { path: string; mtimeMs: number } | null = null
+
+  for (const dir of dirs) {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      continue
+    }
+
+    for (const entry of entries) {
+      if (!entry.endsWith('.ips')) continue
+      if (!entry.startsWith(prefix)) continue
+
+      const fullPath = join(dir, entry)
+      let mtimeMs: number
+      try {
+        mtimeMs = statSync(fullPath).mtimeMs
+      } catch {
+        continue
+      }
+
+      if (mtimeMs < lowerBound || mtimeMs > upperBound) continue
+
+      if (!best || mtimeMs > best.mtimeMs) {
+        best = { path: fullPath, mtimeMs }
+      }
+    }
+  }
+
+  return best ? best.path : null
+}
+
+function parseIpsFile(filePath: string): NativeCrashInfo | null {
+  let raw: string
+  try {
+    raw = readFileSync(filePath, 'utf-8')
+  } catch {
+    return null
+  }
+
+  const newlineIdx = raw.indexOf('\n')
+  if (newlineIdx < 0) return null
+
+  let header: IpsHeader
+  let body: IpsBody
+  try {
+    header = JSON.parse(raw.slice(0, newlineIdx)) as IpsHeader
+    body = JSON.parse(raw.slice(newlineIdx + 1)) as IpsBody
+  } catch {
+    return null
+  }
+
+  const triggered = (body.threads ?? []).find((t) => t.triggered === true)
+  const stack = formatFrames(triggered?.frames ?? [], body.usedImages ?? [])
+
+  const exceptionType = formatException(body.exception)
+  const terminationReason = formatTermination(body.termination)
+
+  return {
+    timestamp: toIsoTimestamp(header.timestamp),
+    exceptionType,
+    exceptionCodes: body.exception?.codes,
+    terminationReason,
+    triggeredThread: triggered?.name ?? triggered?.queue,
+    stack,
+    incidentId: header.incident_id,
+    sourceFile: filePath,
+  }
+}
+
+function toIsoTimestamp(raw: string | undefined): string {
+  if (raw) {
+    const ms = Date.parse(raw)
+    if (!Number.isNaN(ms)) return new Date(ms).toISOString()
+  }
+  return new Date().toISOString()
+}
+
+function formatException(exception: IpsBody['exception']): string | undefined {
+  if (!exception) return undefined
+  const { type, signal } = exception
+  if (type && signal) return `${type} (${signal})`
+  return type ?? signal
+}
+
+function formatTermination(termination: IpsBody['termination']): string | undefined {
+  if (!termination) return undefined
+  const { indicator, byProc } = termination
+  if (indicator && byProc) return `${indicator} (by ${byProc})`
+  return indicator ?? byProc
+}
+
+function formatFrames(frames: IpsFrame[], images: IpsImage[]): string {
+  const lines: string[] = []
+
+  for (let i = 0; i < frames.length && i < MAX_FRAMES; i++) {
+    const frame = frames[i]
+    const imageName =
+      frame.imageIndex !== undefined ? (images[frame.imageIndex]?.name ?? '???') : '???'
+    const symbol = frame.symbol ?? '???'
+    const offset = frame.symbolLocation ?? 0
+    const idx = String(i).padStart(3, ' ')
+    const img = imageName.padEnd(32, ' ')
+    lines.push(`${idx}  ${img}  ${symbol} + ${offset}`)
+  }
+
+  const joined = lines.join('\n')
+  if (joined.length <= MAX_STACK_CHARS) return joined
+  return `${joined.slice(0, MAX_STACK_CHARS - 20)}\n… (truncated)`
+}

--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -1,6 +1,6 @@
 import { ok, err, okAsync, type Result, type ResultAsync } from 'neverthrow'
 import simpleGit from 'simple-git'
-import { readFile } from 'fs/promises'
+import { readFileSync } from 'fs'
 import { join } from 'path'
 import type { GitError } from './errors'
 import type { ParsedDiff, DiffFile } from './types'
@@ -20,39 +20,45 @@ function gitCall<T>(command: string, promise: Promise<T>): ResultAsync<T, GitErr
   return fromExternalCall(promise, (e) => gitErr(command, e))
 }
 
-function buildUntrackedDiffFile(
-  repoRoot: string,
-  filePath: string,
-): ResultAsync<DiffFile, GitError> {
-  return fromExternalCall(readFile(join(repoRoot, filePath), 'utf-8'), (e) =>
-    gitErr('readFile', e),
-  ).map((content) => {
-    const lines = content.split('\n')
-    if (lines[lines.length - 1] === '') lines.pop()
-    const changes = lines.map((line, i) => ({
-      type: 'add' as const,
-      content: line,
-      newLine: i + 1,
-    }))
-    return {
-      path: filePath,
-      status: 'added' as const,
-      hunks:
-        changes.length > 0
-          ? [
-              {
-                oldStart: 0,
-                oldLines: 0,
-                newStart: 1,
-                newLines: changes.length,
-                header: `@@ -0,0 +1,${changes.length} @@`,
-                changes,
-              },
-            ]
-          : [],
-      additions: changes.length,
-      deletions: 0,
-    }
+// Sync read instead of fs.promises.readFile: this function is called in a
+// hot loop (ChangesPanel/DiffPane refresh on every files:changed event,
+// debounced 200 ms), once per untracked file in parallel. The async
+// FileHandle code path was the trigger for the FileHandle::CloseReq::Resolve
+// crash in #150. Untracked files in a working copy are typically small and
+// few, so a synchronous read is cheap and removes the crash surface.
+function buildUntrackedDiffFile(repoRoot: string, filePath: string): Result<DiffFile, GitError> {
+  let content: string
+  try {
+    content = readFileSync(join(repoRoot, filePath), 'utf-8')
+  } catch (e) {
+    return err(gitErr('readFile', e))
+  }
+
+  const lines = content.split('\n')
+  if (lines[lines.length - 1] === '') lines.pop()
+  const changes = lines.map((line, i) => ({
+    type: 'add' as const,
+    content: line,
+    newLine: i + 1,
+  }))
+  return ok({
+    path: filePath,
+    status: 'added' as const,
+    hunks:
+      changes.length > 0
+        ? [
+            {
+              oldStart: 0,
+              oldLines: 0,
+              newStart: 1,
+              newLines: changes.length,
+              header: `@@ -0,0 +1,${changes.length} @@`,
+              changes,
+            },
+          ]
+        : [],
+    additions: changes.length,
+    deletions: 0,
   })
 }
 
@@ -451,19 +457,13 @@ export class GitRepository {
       untrackedFiles.andThen((files) => {
         if (files.length === 0) return okAsync<ParsedDiff, GitError>(parsed)
 
-        return fromExternalCall(
-          Promise.all(
-            files.map((file) =>
-              buildUntrackedDiffFile(repoRoot, file).match(
-                (f) => f as DiffFile | null,
-                () => null,
-              ),
-            ),
-          ).then((results) => results.filter((f): f is DiffFile => f !== null)),
-          (e) => gitErr('ls-files', e),
-        ).map((untrackedDiffFiles) => ({
+        const untrackedDiffFiles = files
+          .map((file) => buildUntrackedDiffFile(repoRoot, file).unwrapOr(null))
+          .filter((f): f is DiffFile => f !== null)
+
+        return okAsync<ParsedDiff, GitError>({
           files: [...parsed.files, ...untrackedDiffFiles],
-        }))
+        })
       }),
     )
   }

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1393,8 +1393,9 @@ export function registerIpcHandlers(
   ipcMain.handle('fs:readFile', async (event, payload: { filePath: string; maxBytes?: number }) => {
     await validatePathAccess(event.sender.id, payload.filePath)
     const maxBytes = Math.min(payload.maxBytes ?? 1_048_576, 10_485_760)
-    const stat = await fs.promises.stat(payload.filePath)
-    const size = stat.size
+    // Sync stat too: closes the TOCTOU gap with the openSync below and removes
+    // the last await between validatePathAccess and the fd trio.
+    const size = fs.statSync(payload.filePath).size
     const readSize = Math.min(size, maxBytes)
 
     // Sync fd trio instead of async FileHandle: avoids holding a JS FileHandle

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1395,27 +1395,36 @@ export function registerIpcHandlers(
     const maxBytes = Math.min(payload.maxBytes ?? 1_048_576, 10_485_760)
     const stat = await fs.promises.stat(payload.filePath)
     const size = stat.size
+    const readSize = Math.min(size, maxBytes)
 
-    const fd = await fs.promises.open(payload.filePath, 'r')
+    // Sync fd trio instead of async FileHandle: avoids holding a JS FileHandle
+    // across multiple `await` points, which is the only call site in this
+    // codebase that exposes us to FileHandle::CloseReq::Resolve races (#150).
+    // A bounded read (≤10 MB) from local disk is fast enough to run inline.
+    const fd = fs.openSync(payload.filePath, 'r')
     try {
-      const readSize = Math.min(size, maxBytes)
       const buf = Buffer.alloc(readSize)
-      await fd.read(buf, 0, readSize, 0)
+      let offset = 0
+      while (offset < readSize) {
+        const bytesRead = fs.readSync(fd, buf, offset, readSize - offset, offset)
+        if (bytesRead === 0) break
+        offset += bytesRead
+      }
 
       // Binary detection: check first 8KB for null bytes
-      const detectEnd = Math.min(readSize, 8192)
+      const detectEnd = Math.min(offset, 8192)
       for (let i = 0; i < detectEnd; i++) {
         if (buf[i] === 0) return { binary: true, size }
       }
 
       return {
-        content: buf.toString('utf-8'),
+        content: buf.subarray(0, offset).toString('utf-8'),
         truncated: size > maxBytes,
         size,
         binary: false,
       }
     } finally {
-      await fd.close()
+      fs.closeSync(fd)
     }
   })
 


### PR DESCRIPTION
## What

Three commits addressing #150:

1. **`fix(crash):`** macOS `CrashReporter.init()` now scans
   `~/Library/Logs/DiagnosticReports` for a recent `Canopy-*.ips` whose
   mtime post-dates the previous sentinel and attaches the triggered
   thread's symbolicated stack + exception info to `crash-report.json`.
   New module `src/main/crash/NativeCrashReader.ts`.
2. **`fix(git):`** `GitRepository.buildUntrackedDiffFile` switched from
   `fs.promises.readFile` to `readFileSync`. This is the root-cause fix.
3. **`fix(fs):`** `fs:readFile` IPC handler switched from
   `fs.promises.open`/`read`/`close` to `openSync`/`readSync`/`closeSync`.
   Defensive — same class of bug, different (user-triggered) call site.

## Why

#150 was filed as an `ungracefulShutdown` report with the message
"The app did not shut down cleanly" and no stack. The user attached the
real macOS `.ips` dump, which showed a native crash on Thread 0
`CrBrowserMain` ~4.7 h after launch in Background role:

```
EXC_BREAKPOINT (SIGTRAP) brk 0
…
node::fs::FileHandle::CloseReq::Resolve()
node::MakeLibuvRequestCallback<uv_fs_s, …>::Wrapper
uv__work_done → uv__io_poll → uv_run
```

The crash had nothing to do with shutdown — the sentinel-only detector
mislabels every native runtime crash as "ungracefulShutdown" because
the sentinel is still on disk on next launch. We were blind to what
was actually happening.

**Root cause (fix 2):** `ChangesPanel.svelte` and `DiffPane.svelte`
both subscribe to `onFilesChanged` (200 ms debounce) **and**
`onGitChanged`, and they stay mounted via `class:hidden` (CSS-only),
so subscriptions remain active even when the panel is not visible and
even when the window is in the background. Each event fires
`window.api.gitDiff()` → `GitRepository.getDiffParsed()` →
`Promise.all(buildUntrackedDiffFile)` — N parallel
`fs.promises.readFile` calls per refresh cycle, one per untracked
file. Each `readFile` allocates a JS `FileHandle` whose async close
goes through `FileHandle::CloseReq::Resolve()`. Over hours of
unattended background file activity (build watch, AI agent edits, git
fetch, etc.) this exposes a V8 CHECK race in Electron 41 that aborts
the process. Sync read removes the JS `FileHandle` allocation entirely
from the hot path. Untracked working-copy files are typically few and
small, so the read is cheap.

**Diagnostics (fix 1):** the next time someone hits a native runtime
crash on macOS, the report will contain the actual triggered-thread
stack and exception type instead of "did not shut down cleanly".

**Defensive (fix 3):** the only other JS-side `FileHandle` in `src/main`
is the `fs:readFile` IPC handler used by the file-preview pane. Same
class of bug, sync trio fixes it without affecting partial-read
behaviour.

Refs #150.

## How to test

1. `npm run typecheck && npm run lint && npm run build` — green.
2. **Diff hot path:** open a workspace with at least one untracked file,
   show the Changes tab, then trigger filesystem activity in the repo:
   ```fish
   for i in (seq 1 50); touch test_$i.txt; sleep 0.05; rm test_$i.txt; end
   ```
   The Changes panel should keep updating without errors. Verify the
   list of untracked files renders correctly and the diff content for
   each is shown.
3. **File preview:** click a file in the file tree to preview it.
   Verify small text files, large text files (≥1 MB), and binary files
   all behave as before. Verify `truncated: true` is set when the file
   exceeds 1 MB.
4. **Native crash recovery (macOS):** with a packaged build, force a
   main-process crash (`process.abort()` from a dev menu item, or
   `kill -SEGV <main_pid>`). Confirm a fresh `Canopy-*.ips` lands in
   `~/Library/Logs/DiagnosticReports/`. Relaunch the app — the Crash
   Report dialog should display the symbolicated native stack instead
   of "The app did not shut down cleanly", and
   `~/Library/Application Support/canopy-code/crash-report.json`
   should contain `stack` plus a `nativeCrash` object with
   `exceptionType`, `triggeredThread`, `incidentId`, `sourceFile`.
5. **Negative path:** delete every `Canopy-*.ips` from
   `~/Library/Logs/DiagnosticReports/` (and `Retired/`),
   `touch ~/Library/Application\ Support/canopy-code/.canopy-running`
   to simulate a stale sentinel without a matching dump, relaunch,
   verify the report falls back to the original "The app did not shut
   down cleanly" message with no stack.
6. **Non-macOS:** Linux/Windows behaviour is unchanged — the reader
   returns `null` on `process.platform !== 'darwin'`.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default) — N/A,
      bug fix
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell
      commands (macOS-only path is gated behind `process.platform`)
- [x] Keyboard accessible — N/A, no UI changes
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle` —
      no IPC changes
- [x] Renderer code does not import Node.js modules directly — N/A
- [x] Feature docs in `docs/` updated
      (`docs/diagnostics/crash-reporting.md` documents the new native
      `.ips` recovery path and the `nativeCrash` field shape)