### PR TITLE
fix(updater): allow pre-release users to update to newer stable

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -156,7 +156,7 @@ const checkWithChannelResolution = async (): Promise<void> => {
     if (ch === 'next') {
       const effective = await resolveUpdateChannel(app.getVersion()).unwrapOr('next' as const)
       autoUpdater.channel = effective
-      autoUpdater.allowPrerelease = true
+      autoUpdater.allowPrerelease = effective === 'next'
     } else {
       autoUpdater.channel = 'latest'
       autoUpdater.allowPrerelease = false


### PR DESCRIPTION
## What
When a user on the pre-release channel was on a prerelease (e.g. `0.11.0-next.8`) and a newer stable shipped (e.g. `0.11.0`), the update check failed with an error in the banner instead of installing the stable. This ties `autoUpdater.allowPrerelease` to the resolved effective channel so the updater drops down to stable cleanly.

## Why
`resolveUpdateChannel()` already correctly returns `'latest'` when stable ≥ newest prerelease, but `checkWithChannelResolution` was unconditionally setting `allowPrerelease = true` in the `next` branch. That combination (`channel='latest'` + `allowPrerelease=true`) puts electron-updater's `GitHubProvider.getLatestVersion()` into its prerelease iteration loop with `currentChannel='latest'`, which is hardcoded to only match `null`/`alpha`/`beta`. The loop walks every release, picks none, and throws — surfaced as "Update failed: …" in the banner. Pre-release users therefore got stuck on `0.11.0-next.8` once `0.11.0` shipped.

With `allowPrerelease = false` when riding down, electron-updater takes the simple else branch (`getLatestTagName()` → `/releases/latest`), finds `v0.11.0`, fetches `latest-mac.yml`, and updates normally.

## How to test
Manual end-to-end on a packaged build (no automated tests for this path):

1. Pin a packaged build to `0.11.0-next.8`, set Preferences → Updates → channel = "Pre-release".
2. Trigger "Check for Updates…". On `main` this errors. With this fix, it should find `0.11.0`, download, and offer restart.
3. Regression sweep on the patched build:
   - Stable channel on `0.11.0` → no update.
   - Pre-release channel on `0.11.0` with a newer `0.12.0-next.1` → updates to `0.12.0-next.1`.
   - Pre-release channel on `0.11.0-next.8` with a newer `0.11.0-next.9` (no newer stable) → updates to `0.11.0-next.9`.
4. Offline check (block `api.github.com`): `resolveUpdateChannel` falls back to `'next'`, `allowPrerelease` stays `true` — same behavior as before, no regression.

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] Manually verified on a packaged build against a real GitHub release (requires a published `0.11.0` against an installed `0.11.0-next.8` — not done in the worktree)