### PR TITLE
fix(browser): open target="_blank" links in new tab

### DIFF
--- a/docs/integrations/browser.md
+++ b/docs/integrations/browser.md
@@ -10,7 +10,7 @@
 
 Canopy includes a built-in browser tab that renders web content using Electron's `<webview>` tag backed by a `WebContentsView` for DevTools. Users can browse web pages, open an embedded DevTools panel, emulate mobile devices, autofill login credentials, capture screenshots, and manage a favorites list. Each browser tab runs in a shared persistent session partition (`persist:browser`) that is isolated from the main app's session.
 
-The `BrowserManager` in the main process handles security enforcement (popup blocking, navigation filtering, permission denial, keyboard shortcut interception) and DevTools lifecycle. The renderer tracks per-tab state (URL, title, favicon, loading, navigation, errors) in a reactive `browserSessions` record.
+The `BrowserManager` in the main process handles security enforcement (popup handling, navigation filtering, permission denial, keyboard shortcut interception) and DevTools lifecycle. The renderer tracks per-tab state (URL, title, favicon, loading, navigation, errors) in a reactive `browserSessions` record.
 
 ## Behavior
 
@@ -19,7 +19,7 @@ The `BrowserManager` in the main process handles security enforcement (popup blo
 1. User creates a new browser tab or opens a URL from elsewhere in the app.
 2. The renderer creates a `<webview>` element with `partition="persist:browser"` and calls `initBrowserSession(browserId)` to initialize the reactive state.
 3. The renderer calls `setupBrowserWebview(browserId, webContentsId)` via IPC.
-4. `BrowserManager.setup()` registers the webview's guest `WebContents` and attaches event listeners for popup blocking, navigation filtering, keyboard interception, focus forwarding, favicon detection, and context menu.
+4. `BrowserManager.setup()` registers the webview's guest `WebContents` and attaches event listeners for popup forwarding, navigation filtering, keyboard interception, focus forwarding, favicon detection, and context menu.
 
 ### Navigation
 
@@ -27,6 +27,7 @@ The `BrowserManager` in the main process handles security enforcement (popup blo
 2. The `will-navigate` handler blocks any navigation to non-HTTP(S) protocols (e.g., `javascript:`, `file:`, `data:`). Blocked navigations are silently prevented.
 3. On successful navigation, the renderer updates `url`, `title`, `canGoBack`, `canGoForward`, and clears any previous error state.
 4. Mouse back/forward buttons (app-command `browser-backward`/`browser-forward`) are handled at the window level and forwarded to the focused browser webview.
+5. Links with `target="_blank"` (and `window.open()` calls) are intercepted by `setWindowOpenHandler`. Valid HTTP(S) URLs are forwarded to the renderer via `browser:openUrl`, which opens them as a new browser pane tab in the same worktree using `openTool('browser', ...)`. Forwarding is throttled to one popup per 500ms per webview.
 
 ### Loading states and errors
 
@@ -129,7 +130,7 @@ When a browser tab is closed, the renderer calls `teardownBrowserWebview(browser
 | ---------------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
 | Page load failure      | Error overlay with Chromium error code and description | DNS failure, connection refused, SSL error, timeout                  |
 | Blocked navigation     | Nothing (silently prevented)                           | Page attempted navigation to non-HTTP(S) protocol                    |
-| Blocked popup          | Nothing (silently denied)                              | Page called `window.open()`                                          |
+| Throttled popup        | Nothing (silently denied)                              | Multiple `window.open()` / `target="_blank"` within 500ms            |
 | Blocked permission     | Nothing (silently denied)                              | Page requested camera, microphone, geolocation, or other permissions |
 | DevTools view creation | DevTools button has no effect                          | `WebContents` for the webview guest could not be found               |
 | Favicon fetch failure  | Tab shows no favicon                                   | CORS error, network error, or invalid favicon URL                    |
@@ -138,7 +139,7 @@ When a browser tab is closed, the renderer calls `teardownBrowserWebview(browser
 
 - The browser runs in a dedicated Electron session partition (`persist:browser`), isolated from the app's main session. Cookies, storage, and cache are separate.
 - All permission requests (camera, microphone, geolocation, notifications, etc.) are denied via `setPermissionRequestHandler`.
-- Popups (`window.open()`) are blocked via `setWindowOpenHandler(() => ({ action: 'deny' }))`.
+- Popups (`window.open()`, `target="_blank"`) are denied at the Electron level via `setWindowOpenHandler`. Valid HTTP(S) URLs are instead forwarded to the renderer, which opens them as a new browser pane tab in the same worktree. The `<webview>` has `allowpopups` set so the handler is actually invoked. Forwarding is throttled to one popup per 500ms per webview to prevent flooding from malicious pages.
 - Navigation is restricted to `http:` and `https:` protocols.
 - Credential autofill runs in isolated JavaScript world 999 to prevent page scripts from observing the injected values.
 - The Chrome Debugger Protocol is attached only when device emulation is active and detached when emulation is cleared.

--- a/docs/integrations/browser.md
+++ b/docs/integrations/browser.md
@@ -27,7 +27,7 @@ The `BrowserManager` in the main process handles security enforcement (popup han
 2. The `will-navigate` handler blocks any navigation to non-HTTP(S) protocols (e.g., `javascript:`, `file:`, `data:`). Blocked navigations are silently prevented.
 3. On successful navigation, the renderer updates `url`, `title`, `canGoBack`, `canGoForward`, and clears any previous error state.
 4. Mouse back/forward buttons (app-command `browser-backward`/`browser-forward`) are handled at the window level and forwarded to the focused browser webview.
-5. Links with `target="_blank"` (and `window.open()` calls) are intercepted by `setWindowOpenHandler`. Valid HTTP(S) URLs are forwarded to the renderer via `browser:openUrl`, which opens them as a new browser pane tab in the same worktree using `openTool('browser', ...)`. Forwarding is throttled to one popup per 500ms per webview.
+5. Links with `target="_blank"` (and `window.open()` calls) are intercepted by `setWindowOpenHandler`. Valid HTTP(S) URLs are forwarded to the renderer via `browser:openUrl`. The renderer honors the `urlOpenMode` preference: `canopy` opens a new browser pane tab in the same worktree via `openTool('browser', ...)`, `system` delegates to `shell.openExternal`, and `ask` shows a toast letting the user pick. Forwarding is throttled to one popup per 500ms per webview.
 
 ### Loading states and errors
 

--- a/src/main/browser/BrowserManager.ts
+++ b/src/main/browser/BrowserManager.ts
@@ -110,10 +110,15 @@ export class BrowserManager {
     this.entries.set(browserId, entry)
 
     // target="_blank" / window.open → forward URL to renderer so it can open a new browser tab
+    // Throttled to prevent a malicious page from flooding the app via window.open() in a loop
+    let lastPopupAt = 0
     wc.setWindowOpenHandler(({ url }) => {
+      const now = Date.now()
+      if (now - lastPopupAt < 500) return { action: 'deny' }
       try {
         const parsed = new URL(url)
         if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+          lastPopupAt = now
           this.sendToRenderer(browserId, 'browser:openUrl', { browserId, url })
         }
       } catch {

--- a/src/main/browser/BrowserManager.ts
+++ b/src/main/browser/BrowserManager.ts
@@ -109,8 +109,18 @@ export class BrowserManager {
     }
     this.entries.set(browserId, entry)
 
-    // Block popups
-    wc.setWindowOpenHandler(() => ({ action: 'deny' }))
+    // target="_blank" / window.open → forward URL to renderer so it can open a new browser tab
+    wc.setWindowOpenHandler(({ url }) => {
+      try {
+        const parsed = new URL(url)
+        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+          this.sendToRenderer(browserId, 'browser:openUrl', { browserId, url })
+        }
+      } catch {
+        // Invalid URL, ignore
+      }
+      return { action: 'deny' }
+    })
 
     // Only allow http(s) navigation
     wc.on('will-navigate', (event, url) => {

--- a/src/main/browser/BrowserManager.ts
+++ b/src/main/browser/BrowserManager.ts
@@ -95,7 +95,7 @@ export class BrowserManager {
 
   /**
    * Register a renderer-created <webview> for keyboard interception,
-   * popup blocking, navigation filtering, and favicon forwarding.
+   * popup handling, navigation filtering, and favicon forwarding.
    */
   setup(browserId: string, wcId: number, win: BrowserWindow, sender: WebContents): void {
     const wc = this.guestContents.get(wcId) ?? findWebContents(wcId)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -460,6 +460,7 @@ interface CanopyAPI {
   ) => () => void
   onBrowserDevToolsOpened: (callback: (data: { browserId: string }) => void) => () => void
   onBrowserFocused: (callback: (data: { browserId: string }) => void) => () => void
+  onBrowserOpenUrl: (callback: (data: { browserId: string; url: string }) => void) => () => void
 
   // Worktree Setup
   runWorktreeSetup: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -461,6 +461,15 @@ const api = {
     }
   },
 
+  onBrowserOpenUrl: (callback: (data: { browserId: string; url: string }) => void) => {
+    const handler = (_event: IpcRendererEvent, data: { browserId: string; url: string }): void =>
+      callback(data)
+    ipcRenderer.on('browser:openUrl', handler)
+    return (): void => {
+      ipcRenderer.removeListener('browser:openUrl', handler)
+    }
+  },
+
   // Worktree Setup
   runWorktreeSetup: (workspaceId: string, repoRoot: string, newWorktreePath: string) =>
     ipcRenderer.invoke('worktree:runSetup', { workspaceId, repoRoot, newWorktreePath }),

--- a/src/renderer/src/components/browser/BrowserPane.svelte
+++ b/src/renderer/src/components/browser/BrowserPane.svelte
@@ -30,6 +30,7 @@
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import AiSessionPicker from './AiSessionPicker.svelte'
   import { showUrlToast } from '../../lib/stores/toast.svelte'
+  import { prefs } from '../../lib/stores/preferences.svelte'
   import { dragState } from '../../lib/stores/dragState.svelte'
   import type { WebviewElement } from '../../lib/browser/browserState.svelte'
 
@@ -871,8 +872,14 @@
         }
       }),
       window.api.onBrowserOpenUrl((data) => {
-        if (data.browserId === browserId) {
+        if (data.browserId !== browserId) return
+        const mode = prefs.urlOpenMode || 'ask'
+        if (mode === 'canopy') {
           openTool('browser', worktreePath, { initialUrl: data.url })
+        } else if (mode === 'system') {
+          window.api.openExternal(data.url)
+        } else {
+          showUrlToast(data.url)
         }
       }),
     ]

--- a/src/renderer/src/components/browser/BrowserPane.svelte
+++ b/src/renderer/src/components/browser/BrowserPane.svelte
@@ -25,6 +25,7 @@
     updateBrowserPaneUrl,
     getAiSessions,
     focusSessionByPtyId,
+    openTool,
   } from '../../lib/stores/tabs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import AiSessionPicker from './AiSessionPicker.svelte'
@@ -34,6 +35,7 @@
 
   let {
     browserId,
+    worktreePath,
     active,
     focused,
     initialUrl,
@@ -41,6 +43,7 @@
     onFocus,
   }: {
     browserId: string
+    worktreePath: string
     active: boolean
     focused?: boolean
     initialUrl?: string
@@ -867,6 +870,11 @@
           updateDevToolsState(true)
         }
       }),
+      window.api.onBrowserOpenUrl((data) => {
+        if (data.browserId === browserId) {
+          openTool('browser', worktreePath, { initialUrl: data.url })
+        }
+      }),
     ]
 
     // Listen for app-level overlays (Preferences, Command Palette, etc.)
@@ -1198,6 +1206,7 @@
           src="about:blank"
           partition="persist:browser"
           webpreferences="contextIsolation=yes,nodeIntegration=no,sandbox=yes"
+          allowpopups
           class="browser-webview"
           class:hidden={!!session?.error && !activeDevice}
           class:no-events={dragState.isDragging}

--- a/src/renderer/src/components/preferences/ViewportsPrefs.svelte
+++ b/src/renderer/src/components/preferences/ViewportsPrefs.svelte
@@ -108,7 +108,7 @@
   <h3 class="section-title">Web Browser</h3>
 
   <div class="select-row">
-    <span class="select-label">Open URLs from terminal in</span>
+    <span class="select-label">Open external URLs in</span>
     <CustomSelect
       value={urlOpenMode}
       options={[
@@ -120,7 +120,10 @@
       maxWidth="180px"
     />
   </div>
-  <div class="hint-row">Where to open links clicked or detected in terminal output</div>
+  <div class="hint-row">
+    Where to open links clicked in terminal output or <code>target="_blank"</code> links from the browser
+    pane
+  </div>
 
   <h4 class="subsection-title">Default Viewports</h4>
 

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -184,6 +184,7 @@
   {#if pane.paneType === 'browser'}
     <BrowserPane
       browserId={pane.sessionId}
+      {worktreePath}
       {active}
       {focused}
       initialUrl={pane.url}


### PR DESCRIPTION
## What
Enable `target="_blank"` / `window.open()` links in the browser pane to open as new browser tabs within Canopy.

## Why
The `<webview>` element was missing the `allowpopups` attribute, so Electron silently ignored all popup requests and `setWindowOpenHandler` was never invoked. On top of that, the handler always returned `{ action: 'deny' }`. Result: clicking any `target="_blank"` link did nothing.

Closes #155

## How to test
1. Open a browser pane
2. Navigate to https://www.w3schools.com/tags/att_a_target.asp
3. Click the "Try it Yourself" button (`target="_blank"`)
4. Expect: new browser tab opens in the same worktree with the target page
5. Also verify on any other page with `target="_blank"` anchors

## Checklist
- [x] Typecheck passes
- [x] Build passes
- [x] Manually verified by reporter
- [x] Conventional commit format