### PR TITLE
fix(credentials): cache auth and decrypted credentials per session

### DIFF
--- a/docs/integrations/browser.md
+++ b/docs/integrations/browser.md
@@ -81,7 +81,7 @@ Users can add custom viewport presets stored in the `viewports.custom` preferenc
 ### Credential autofill
 
 1. User triggers autofill for a stored credential on the current page.
-2. The renderer calls `getCredentialDecrypted(id, domain)`. On the first call of the session the main process prompts the OS for authentication (Touch ID on macOS, `UserConsentVerifier` on Windows, a confirmation dialog on Linux). After a successful prompt the session is flagged as authenticated and subsequent autofills within the same app session skip the OS prompt — matching Chrome's behavior. The flag lives only in memory and is cleared automatically when the app quits.
+2. The renderer calls `getCredentialDecrypted(id, domain, 'autofill')`. On the first autofill of the session the main process prompts the OS for authentication (Touch ID on macOS, `UserConsentVerifier` on Windows, a confirmation dialog on Linux). After a successful prompt the session is flagged as authenticated and subsequent autofills within the same app session skip both the OS prompt and `safeStorage.decryptString()` — matching Chrome's autofill behavior. The flag and the in-memory decrypted credential cache live only in the main process and are cleared on app quit or on any credential save/delete/import. The `'reveal'` purpose used by Settings → Saved Passwords always re-authenticates and never consults the cache, so revealing a plaintext password in the UI always requires a fresh OS prompt — matching Chrome's `chrome://password-manager`.
 3. With the decrypted credential the renderer calls `fillBrowserCredential(browserId, username, password)`.
 4. `BrowserManager.fillCredential()` executes JavaScript in an isolated world (ID 999) that:
    - Finds the first `<input type="password">` on the page.

--- a/docs/integrations/browser.md
+++ b/docs/integrations/browser.md
@@ -80,12 +80,13 @@ Users can add custom viewport presets stored in the `viewports.custom` preferenc
 ### Credential autofill
 
 1. User triggers autofill for a stored credential on the current page.
-2. The renderer calls `fillBrowserCredential(browserId, username, password)`.
-3. `BrowserManager.fillCredential()` executes JavaScript in an isolated world (ID 999) that:
+2. The renderer calls `getCredentialDecrypted(id, domain)`. On the first call of the session the main process prompts the OS for authentication (Touch ID on macOS, `UserConsentVerifier` on Windows, a confirmation dialog on Linux). After a successful prompt the session is flagged as authenticated and subsequent autofills within the same app session skip the OS prompt — matching Chrome's behavior. The flag lives only in memory and is cleared automatically when the app quits.
+3. With the decrypted credential the renderer calls `fillBrowserCredential(browserId, username, password)`.
+4. `BrowserManager.fillCredential()` executes JavaScript in an isolated world (ID 999) that:
    - Finds the first `<input type="password">` on the page.
    - Locates the nearest username field within the same form (by type `email`/`text` or name attributes containing `user`/`email`/`login`, or `autocomplete="username"`).
    - Sets values on both fields and dispatches `input` and `change` events with `bubbles: true` so frameworks detect the change.
-4. The isolated world prevents page scripts from intercepting the injected values.
+5. The isolated world prevents page scripts from intercepting the injected values.
 
 ### Screenshot capture
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -14,7 +14,7 @@ import type { ToolRegistry } from '../tools/ToolRegistry'
 import type { AgentSessionManager } from '../agents/AgentSessionManager'
 import type { WindowManager } from '../WindowManager'
 import type { BrowserManager } from '../browser/BrowserManager'
-import type { CredentialStore } from '../db/CredentialStore'
+import type { CredentialStore, Credential } from '../db/CredentialStore'
 import { TmuxManager } from '../pty/TmuxManager'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
@@ -88,6 +88,19 @@ function shellExecArgs(command: string): { command: string; args: string[] } {
   const flag = os.platform() === 'win32' ? '-Command' : '-lc'
   return { command: shell.command, args: [flag, command] }
 }
+
+// Session-level flag: once the user has successfully authenticated to reveal
+// a saved credential in the current app session, subsequent autofills reuse
+// that authentication instead of prompting the OS every time. Matches Chrome's
+// behavior and is cleared automatically on app quit (in-memory only).
+let credentialSessionAuthenticated = false
+
+// Session cache of already-decrypted credentials (keyed by id). Each cache hit
+// avoids a fresh safeStorage.decryptString() call, which on macOS triggers a
+// Keychain prompt for the "Safe Storage" item whenever the app binary
+// signature changes (e.g. after a rebuild). Cleared on any save/delete/import
+// so the cache never serves stale plaintext, and of course on app quit.
+const credentialSessionCache = new Map<string, Credential>()
 
 function resolveShellArgs(): string[] {
   if (os.platform() === 'win32') return []
@@ -573,6 +586,7 @@ export function registerIpcHandlers(
 
     const applyResult = await settingsExportService.applyImport(parsed)
     const counts = unwrapOrThrow(applyResult, settingsExportErrorMessage)
+    credentialSessionCache.clear()
 
     await broadcastProfilesChanged()
     broadcastToolsChanged()
@@ -1361,11 +1375,13 @@ export function registerIpcHandlers(
     'credentials:save',
     (_event, payload: { domain: string; username: string; password: string; title?: string }) => {
       credentialStore.save(payload.domain, payload.username, payload.password, payload.title)
+      credentialSessionCache.clear()
     },
   )
 
   ipcMain.handle('credentials:delete', (_event, payload: { id: string }) => {
     credentialStore.delete(payload.id)
+    credentialSessionCache.delete(payload.id)
   })
 
   ipcMain.handle('credentials:getAll', () => {
@@ -1382,47 +1398,63 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'credentials:getDecrypted',
     async (event, payload: { id: string; domain: string }) => {
-      // Require system authentication before revealing passwords
-      const authed = await match(process.platform)
-        .with('darwin', async () => {
-          try {
-            await systemPreferences.promptTouchID('reveal a saved password')
-            return true
-          } catch {
-            return false
-          }
-        })
-        .with('win32', async () => {
-          try {
-            const ps = `
-              Add-Type -AssemblyName System.Runtime.WindowsRuntime
-              $null = [Windows.Security.Credentials.UI.UserConsentVerifier,Windows.Security.Credentials.UI,ContentType=WindowsRuntime]
-              $result = [Windows.Security.Credentials.UI.UserConsentVerifier]::RequestVerificationAsync('Canopy wants to reveal a saved password').GetAwaiter().GetResult()
-              if ($result -ne 'Verified') { exit 1 }
-            `
-            await execFileAsync('powershell', ['-NoProfile', '-Command', ps])
-            return true
-          } catch {
-            return false
-          }
-        })
-        .otherwise(async () => {
-          const win =
-            BrowserWindow.fromWebContents(event.sender) ?? BrowserWindow.getFocusedWindow()
-          if (!win) return false
-          const { response } = await dialog.showMessageBox(win, {
-            type: 'warning',
-            buttons: ['Reveal Password', 'Cancel'],
-            defaultId: 1,
-            cancelId: 1,
-            title: 'Authentication Required',
-            message: 'Reveal saved password?',
-            detail: `You are about to reveal the password for ${payload.domain}. Make sure no one is looking at your screen.`,
-          })
-          return response === 0
-        })
+      // Fast path: if we've already decrypted this credential in the current
+      // session, return the cached plaintext without hitting safeStorage or
+      // the OS auth prompt at all.
+      const cached = credentialSessionCache.get(payload.id)
+      if (cached && cached.domain === payload.domain) return cached
+
+      // Require OS authentication the first time credentials are revealed in
+      // this session; subsequent requests reuse the cached session flag so the
+      // user isn't re-prompted on every autofill.
+      const authed = credentialSessionAuthenticated
+        ? true
+        : await match(process.platform)
+            .with('darwin', async () => {
+              try {
+                await systemPreferences.promptTouchID('reveal a saved password')
+                return true
+              } catch {
+                return false
+              }
+            })
+            .with('win32', async () => {
+              try {
+                const ps = `
+                  Add-Type -AssemblyName System.Runtime.WindowsRuntime
+                  $null = [Windows.Security.Credentials.UI.UserConsentVerifier,Windows.Security.Credentials.UI,ContentType=WindowsRuntime]
+                  $result = [Windows.Security.Credentials.UI.UserConsentVerifier]::RequestVerificationAsync('Canopy wants to reveal a saved password').GetAwaiter().GetResult()
+                  if ($result -ne 'Verified') { exit 1 }
+                `
+                await execFileAsync('powershell', ['-NoProfile', '-Command', ps])
+                return true
+              } catch {
+                return false
+              }
+            })
+            .otherwise(async () => {
+              const win =
+                BrowserWindow.fromWebContents(event.sender) ?? BrowserWindow.getFocusedWindow()
+              if (!win) return false
+              const { response } = await dialog.showMessageBox(win, {
+                type: 'warning',
+                buttons: ['Reveal Password', 'Cancel'],
+                defaultId: 1,
+                cancelId: 1,
+                title: 'Authentication Required',
+                message: 'Reveal saved password?',
+                detail: `You are about to reveal the password for ${payload.domain}. Make sure no one is looking at your screen.`,
+              })
+              return response === 0
+            })
       if (!authed) return null
-      return credentialStore.getForDomain(payload.domain).find((c) => c.id === payload.id) ?? null
+      credentialSessionAuthenticated = true
+      // Fetch + decrypt only the requested credential (one safeStorage call),
+      // instead of decrypting every credential stored for this domain.
+      const cred = credentialStore.getById(payload.id)
+      if (!cred || cred.domain !== payload.domain) return null
+      credentialSessionCache.set(cred.id, cred)
+      return cred
     },
   )
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1,5 +1,12 @@
 import { match } from 'ts-pattern'
-import { ipcMain, dialog, shell, BrowserWindow, systemPreferences } from 'electron'
+import {
+  ipcMain,
+  dialog,
+  shell,
+  BrowserWindow,
+  systemPreferences,
+  type IpcMainInvokeEvent,
+} from 'electron'
 import os from 'os'
 import fs from 'fs'
 import path from 'path'
@@ -92,15 +99,64 @@ function shellExecArgs(command: string): { command: string; args: string[] } {
 // Session-level flag: once the user has successfully authenticated to reveal
 // a saved credential in the current app session, subsequent autofills reuse
 // that authentication instead of prompting the OS every time. Matches Chrome's
-// behavior and is cleared automatically on app quit (in-memory only).
+// autofill behavior and is cleared automatically on app quit (in-memory only).
+// Only the 'autofill' code path reads or writes this — the Settings "Reveal
+// Password" UI always re-authenticates.
 let credentialSessionAuthenticated = false
 
 // Session cache of already-decrypted credentials (keyed by id). Each cache hit
 // avoids a fresh safeStorage.decryptString() call, which on macOS triggers a
 // Keychain prompt for the "Safe Storage" item whenever the app binary
-// signature changes (e.g. after a rebuild). Cleared on any save/delete/import
-// so the cache never serves stale plaintext, and of course on app quit.
+// signature changes (e.g. after a rebuild). Only the 'autofill' path uses
+// this cache; 'reveal' always fetches fresh. Cleared on any save/delete/import
+// so stale plaintext is never returned, and on app quit.
 const credentialSessionCache = new Map<string, Credential>()
+
+// Dedupe concurrent first-use OS auth prompts for the autofill path. When two
+// autofill requests race past `credentialSessionAuthenticated === false` at
+// the same time (e.g. a form with both username and password fields), they
+// share one in-flight prompt instead of stacking two Touch ID dialogs.
+let credentialAutofillAuthInflight: Promise<boolean> | null = null
+
+async function runCredentialOsAuth(event: IpcMainInvokeEvent, domain: string): Promise<boolean> {
+  return match(process.platform)
+    .with('darwin', async () => {
+      try {
+        await systemPreferences.promptTouchID('reveal a saved password')
+        return true
+      } catch {
+        return false
+      }
+    })
+    .with('win32', async () => {
+      try {
+        const ps = `
+          Add-Type -AssemblyName System.Runtime.WindowsRuntime
+          $null = [Windows.Security.Credentials.UI.UserConsentVerifier,Windows.Security.Credentials.UI,ContentType=WindowsRuntime]
+          $result = [Windows.Security.Credentials.UI.UserConsentVerifier]::RequestVerificationAsync('Canopy wants to reveal a saved password').GetAwaiter().GetResult()
+          if ($result -ne 'Verified') { exit 1 }
+        `
+        await execFileAsync('powershell', ['-NoProfile', '-Command', ps])
+        return true
+      } catch {
+        return false
+      }
+    })
+    .otherwise(async () => {
+      const win = BrowserWindow.fromWebContents(event.sender) ?? BrowserWindow.getFocusedWindow()
+      if (!win) return false
+      const { response } = await dialog.showMessageBox(win, {
+        type: 'warning',
+        buttons: ['Reveal Password', 'Cancel'],
+        defaultId: 1,
+        cancelId: 1,
+        title: 'Authentication Required',
+        message: 'Reveal saved password?',
+        detail: `You are about to reveal the password for ${domain}. Make sure no one is looking at your screen.`,
+      })
+      return response === 0
+    })
+}
 
 function resolveShellArgs(): string[] {
   if (os.platform() === 'win32') return []
@@ -1397,56 +1453,36 @@ export function registerIpcHandlers(
 
   ipcMain.handle(
     'credentials:getDecrypted',
-    async (event, payload: { id: string; domain: string }) => {
-      // Fast path: if we've already decrypted this credential in the current
-      // session, return the cached plaintext without hitting safeStorage or
-      // the OS auth prompt at all.
+    async (event, payload: { id: string; domain: string; purpose: 'autofill' | 'reveal' }) => {
+      // Settings "Reveal Password" UI: always re-authenticate, never consult
+      // the session cache or flag, never update them. Matches Chrome's
+      // chrome://password-manager which re-prompts on every reveal regardless
+      // of whether autofill has already happened this session.
+      if (payload.purpose === 'reveal') {
+        const authed = await runCredentialOsAuth(event, payload.domain)
+        if (!authed) return null
+        const cred = credentialStore.getById(payload.id)
+        return cred && cred.domain === payload.domain ? cred : null
+      }
+
+      // Autofill path. Fast path: if we've already decrypted this credential
+      // in the current session, return the cached plaintext without hitting
+      // safeStorage or the OS auth prompt at all.
       const cached = credentialSessionCache.get(payload.id)
       if (cached && cached.domain === payload.domain) return cached
 
-      // Require OS authentication the first time credentials are revealed in
-      // this session; subsequent requests reuse the cached session flag so the
-      // user isn't re-prompted on every autofill.
+      // Require OS auth on first autofill of the session; subsequent autofills
+      // reuse the session flag. Concurrent first-use calls dedupe through
+      // credentialAutofillAuthInflight so only one Touch ID prompt appears
+      // even when two requests race.
       const authed = credentialSessionAuthenticated
         ? true
-        : await match(process.platform)
-            .with('darwin', async () => {
-              try {
-                await systemPreferences.promptTouchID('reveal a saved password')
-                return true
-              } catch {
-                return false
-              }
-            })
-            .with('win32', async () => {
-              try {
-                const ps = `
-                  Add-Type -AssemblyName System.Runtime.WindowsRuntime
-                  $null = [Windows.Security.Credentials.UI.UserConsentVerifier,Windows.Security.Credentials.UI,ContentType=WindowsRuntime]
-                  $result = [Windows.Security.Credentials.UI.UserConsentVerifier]::RequestVerificationAsync('Canopy wants to reveal a saved password').GetAwaiter().GetResult()
-                  if ($result -ne 'Verified') { exit 1 }
-                `
-                await execFileAsync('powershell', ['-NoProfile', '-Command', ps])
-                return true
-              } catch {
-                return false
-              }
-            })
-            .otherwise(async () => {
-              const win =
-                BrowserWindow.fromWebContents(event.sender) ?? BrowserWindow.getFocusedWindow()
-              if (!win) return false
-              const { response } = await dialog.showMessageBox(win, {
-                type: 'warning',
-                buttons: ['Reveal Password', 'Cancel'],
-                defaultId: 1,
-                cancelId: 1,
-                title: 'Authentication Required',
-                message: 'Reveal saved password?',
-                detail: `You are about to reveal the password for ${payload.domain}. Make sure no one is looking at your screen.`,
-              })
-              return response === 0
-            })
+        : await (credentialAutofillAuthInflight ??= runCredentialOsAuth(
+            event,
+            payload.domain,
+          ).finally(() => {
+            credentialAutofillAuthInflight = null
+          }))
       if (!authed) return null
       credentialSessionAuthenticated = true
       // Fetch + decrypt only the requested credential (one safeStorage call),

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -441,6 +441,7 @@ interface CanopyAPI {
   getCredentialDecrypted: (
     id: string,
     domain: string,
+    purpose: 'autofill' | 'reveal',
   ) => Promise<{ id: string; username: string; password: string } | null>
   deleteCredential: (id: string) => Promise<void>
   listCredentials: () => Promise<

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -419,8 +419,8 @@ const api = {
     >,
   saveCredential: (domain: string, username: string, password: string, title?: string) =>
     ipcRenderer.invoke('credentials:save', { domain, username, password, title }),
-  getCredentialDecrypted: (id: string, domain: string) =>
-    ipcRenderer.invoke('credentials:getDecrypted', { id, domain }) as Promise<{
+  getCredentialDecrypted: (id: string, domain: string, purpose: 'autofill' | 'reveal') =>
+    ipcRenderer.invoke('credentials:getDecrypted', { id, domain, purpose }) as Promise<{
       id: string
       username: string
       password: string

--- a/src/renderer/src/components/browser/BrowserPane.svelte
+++ b/src/renderer/src/components/browser/BrowserPane.svelte
@@ -469,7 +469,7 @@
     const url = w.getURL()
     if (!url) return
     const domain = new URL(url).host
-    const cred = await window.api.getCredentialDecrypted(credId, domain)
+    const cred = await window.api.getCredentialDecrypted(credId, domain, 'autofill')
     if (!cred) return
     // Fill via main process isolated world — page scripts cannot intercept
     await window.api.fillBrowserCredential(browserId, cred.username, cred.password)

--- a/src/renderer/src/components/preferences/ViewportsPrefs.svelte
+++ b/src/renderer/src/components/preferences/ViewportsPrefs.svelte
@@ -42,7 +42,7 @@
       if (revealTimer) clearTimeout(revealTimer)
       return
     }
-    const cred = await window.api.getCredentialDecrypted(id, domain)
+    const cred = await window.api.getCredentialDecrypted(id, domain, 'reveal')
     if (cred) {
       revealedId = id
       revealedPassword = cred.password


### PR DESCRIPTION
## What

Caches both the OS auth state and decrypted credentials per Canopy
session, so password autofill stops re-prompting on every click.

## Why

Closes #156. Previously, every autofill triggered a fresh Touch ID /
Windows Hello / Linux dialog (`systemPreferences.promptTouchID`). On top
of that, after any rebuild that changes the Electron binary signature,
macOS also shows a Keychain prompt for the "canopy Safe Storage" item on
every `safeStorage.decryptString()` call — a single autofill could surface
2–3 dialogs. Expected behavior is to match Chrome: once per session.

## How

- Module-level flag `credentialSessionAuthenticated` in
  `src/main/ipc/handlers.ts` — set after first successful OS auth,
  checked on subsequent calls.
- Module-level `Map<id, Credential>` `credentialSessionCache` —
  populated after first successful decrypt; subsequent autofills skip
  both the OS prompt and `safeStorage` entirely.
- Handler now calls `CredentialStore.getById()` instead of
  `getForDomain().filter()`, so even on a cache miss only the requested
  credential is decrypted (one `safeStorage` call, not N).
- Cache invalidated in `credentials:save` / `credentials:delete` /
  `settings:import` so stale plaintext is never returned.
- Everything lives in memory only — cleared on app quit.

## How to test

1. `npm run build` (or `npm run dev`) on this branch.
2. In the browser pane, have credentials saved for 2+ different sites.
3. First autofill in a session → Touch ID prompt **once**; optionally a
   Keychain prompt for `canopy Safe Storage` once (cleared permanently
   by clicking "Always Allow").
4. Autofill the same credential again → zero prompts.
5. Autofill a different saved credential in the same session → no
   Touch ID prompt (flag reuse).
6. Edit/delete a credential in Settings → next autofill prompts again
   (cache cleared).
7. Restart Canopy → back to first-time behavior.

## Checklist

- [x] Typecheck + build pass (`npm run build` — EXIT 0)
- [x] Docs updated (`docs/integrations/browser.md`)
- [x] Manual test on macOS
- [ ] Manual test on Windows
- [ ] Manual test on Linux
