### PR TITLE
feat: add shape tools to drawing and editable notes preview

### DIFF
--- a/docs/features/drawing.md
+++ b/docs/features/drawing.md
@@ -35,7 +35,7 @@ Drawings are stored in renderer memory keyed by project (repo root). They are ep
 
 1. With the **Select** tool active, clicking a stroke selects it (highlighted with an accent-colored outline). **Shift+click** toggles individual strokes.
 2. Dragging on empty space draws a marquee rectangle. On release, all strokes whose bounding boxes intersect the marquee are selected. **Shift+drag** adds to the existing selection.
-3. Hit testing uses `CanvasRenderingContext2D.isPointInPath()` against stroke outlines, iterating top-to-bottom (last drawn first).
+3. Hit testing iterates top-to-bottom (last drawn first). Freehand strokes use `CanvasRenderingContext2D.isPointInPath()` against stroke outlines. Shape strokes use geometric proximity checks (edge distance for rectangles, normalized ellipse equation for ellipses, point-to-segment distance for lines/arrows).
 4. **Moving strokes:** Clicking and dragging a selected stroke repositions all selected strokes. A drag shorter than 3px is treated as a click-to-reselect instead.
 
 ### Canvas pan

--- a/docs/features/drawing.md
+++ b/docs/features/drawing.md
@@ -21,6 +21,16 @@ Drawings are stored in renderer memory keyed by project (repo root). They are ep
 3. On pointer up, the live stroke is committed to the strokes array.
 4. Each frame, `redraw()` clears the canvas, fills the theme background, and renders all committed strokes plus the in-progress live stroke using `perfect-freehand` outlines.
 
+### Shapes
+
+1. With a shape tool active (**Rect**, **Ellipse**, **Line**, or **Arrow**), the user clicks and drags on the canvas.
+2. The origin point is the pointer-down position; the current pointer position defines the shape extent.
+3. A live preview of the shape renders during the drag.
+4. On pointer up, shapes smaller than 2px in both dimensions are discarded.
+5. **Shift** constrains: rectangles to squares, ellipses to circles, lines/arrows to 45° angle increments.
+6. Shapes use the current color and stroke size. They are outline-only (no fill).
+7. Shapes participate in all selection, move, delete, and undo operations identically to freehand strokes.
+
 ### Selection
 
 1. With the **Select** tool active, clicking a stroke selects it (highlighted with an accent-colored outline). **Shift+click** toggles individual strokes.
@@ -34,15 +44,16 @@ Middle mouse button pans the canvas viewport regardless of the active tool. Stro
 
 ### Actions
 
-| Action          | Trigger                                           | Effect                            |
-| --------------- | ------------------------------------------------- | --------------------------------- |
-| Delete selected | **Delete** / **Backspace** key, or toolbar button | Removes selected strokes          |
-| Undo            | **Cmd+Z**                                         | Removes the last committed stroke |
-| Select all      | **Cmd+A** (select mode)                           | Selects all strokes               |
-| Deselect        | **Escape**                                        | Clears the selection              |
-| Move selected   | Drag a selected stroke (select mode)              | Repositions all selected strokes  |
-| Pan canvas      | **Middle mouse button** drag                      | Scrolls the canvas viewport       |
-| Clear           | Toolbar button                                    | Removes all strokes               |
+| Action          | Trigger                                           | Effect                               |
+| --------------- | ------------------------------------------------- | ------------------------------------ |
+| Delete selected | **Delete** / **Backspace** key, or toolbar button | Removes selected strokes             |
+| Undo            | **Cmd+Z**                                         | Removes the last committed stroke    |
+| Select all      | **Cmd+A** (select mode)                           | Selects all strokes                  |
+| Deselect        | **Escape**                                        | Clears the selection                 |
+| Move selected   | Drag a selected stroke (select mode)              | Repositions all selected strokes     |
+| Pan canvas      | **Middle mouse button** drag                      | Scrolls the canvas viewport          |
+| Draw shape      | Click-drag with shape tool, Shift for constrain   | Creates rectangle/ellipse/line/arrow |
+| Clear           | Toolbar button                                    | Removes all strokes                  |
 
 ### Exporting
 
@@ -71,7 +82,7 @@ Middle mouse button pans the canvas viewport regardless of the active tool. Stro
 
 ## Tools and options
 
-**Tools:** Pen (freehand drawing), Select (click/marquee/shift-multi-select)
+**Tools:** Pen (freehand drawing), Select (click/marquee/shift-multi-select), Rectangle, Ellipse, Line, Arrow
 
 **Colors:** 6 swatches — light gray (`#e5e7eb`), red (`#f87171`), amber (`#fbbf24`), emerald (`#34d399`), blue (`#60a5fa`), purple (`#a78bfa`)
 

--- a/docs/features/notes.md
+++ b/docs/features/notes.md
@@ -48,6 +48,10 @@ Notes panes are non-terminal panes — they have no associated process, PTY, or 
 3. Changes from the editor textarea update the preview, and vice versa. An `editSource` flag prevents circular updates.
 4. The preview shows a "Click to edit..." placeholder when empty.
 
+**Focus/sync trade-off:** While the preview panel has focus, incoming `innerHTML` updates from the textarea are skipped to prevent the cursor from jumping to the beginning of the element. This means that if the user is actively editing in the preview, changes typed simultaneously in the textarea will not appear in the preview until the user blurs out of it. Once focus leaves the preview, the next markdown parse cycle re-syncs it.
+
+**Paste handling:** The preview panel intercepts `paste` events and sanitizes the incoming HTML with DOMPurify before inserting it. This keeps the rendered DOM clean and ensures the markdown round-trip through `turndown` operates on safe input. Plain-text pastes are inserted as-is after sanitization.
+
 ### Worktree/project switching
 
 1. When the user selects a different worktree, the `$effect` watching `getNoteKey()` detects the key change.

--- a/docs/features/notes.md
+++ b/docs/features/notes.md
@@ -41,6 +41,13 @@ Notes panes are non-terminal panes — they have no associated process, PTY, or 
 2. Clicking **Hide preview** collapses back to editor-only.
 3. The preview panel uses a monospace font with styled headings, code blocks, and links.
 
+### Editing in preview
+
+1. When the preview panel is visible, it is editable — the user can click into the rendered markdown and type directly.
+2. Changes in the preview are converted back to markdown using `turndown` and written to `notesState[key]`.
+3. Changes from the editor textarea update the preview, and vice versa. An `editSource` flag prevents circular updates.
+4. The preview shows a "Click to edit..." placeholder when empty.
+
 ### Worktree/project switching
 
 1. When the user selects a different worktree, the `$effect` watching `getNoteKey()` detects the key change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "simple-git": "^3.33.0",
         "smol-toml": "^1.6.1",
         "ts-pattern": "^5.9.0",
+        "turndown": "^7.2.4",
         "ws": "^8.20.0"
       },
       "devDependencies": {
@@ -47,6 +48,7 @@
         "@types/dompurify": "^3.0.5",
         "@types/node": "^22.19.1",
         "@types/semver": "^7.7.1",
+        "@types/turndown": "^5.0.6",
         "@types/ws": "^8.18.1",
         "electron": "^41.0.0",
         "electron-builder": "^26.0.12",
@@ -2184,6 +2186,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
@@ -4499,6 +4507,13 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/verror": {
@@ -11642,6 +11657,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "simple-git": "^3.33.0",
     "smol-toml": "^1.6.1",
     "ts-pattern": "^5.9.0",
+    "turndown": "^7.2.4",
     "ws": "^8.20.0"
   },
   "devDependencies": {
@@ -68,6 +69,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/node": "^22.19.1",
     "@types/semver": "^7.7.1",
+    "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1",
     "electron": "^41.0.0",
     "electron-builder": "^26.0.12",

--- a/src/renderer/src/components/drawing/DrawingPane.svelte
+++ b/src/renderer/src/components/drawing/DrawingPane.svelte
@@ -6,6 +6,7 @@
     getDrawingKey,
     type Stroke,
     type DrawTool,
+    type ShapeType,
   } from '../../lib/stores/drawings.svelte'
   import {
     strokeBBox,
@@ -126,6 +127,19 @@
   let lastDragPoint: { x: number; y: number } | null = null
   let isPanning = $state(false)
 
+  const SHAPE_TOOLS: Record<string, ShapeType> = {
+    rectangle: 'rectangle',
+    ellipse: 'ellipse',
+    line: 'line',
+    arrow: 'arrow',
+  }
+
+  function isShapeTool(t: DrawTool): t is 'rectangle' | 'ellipse' | 'line' | 'arrow' {
+    return t in SHAPE_TOOLS
+  }
+
+  let shapeOrigin: { x: number; y: number } | null = null
+
   function onPointerDown(e: PointerEvent): void {
     if (!canvasEl) return
 
@@ -154,7 +168,23 @@
         id: crypto.randomUUID(),
         color,
         size,
+        type: 'freehand',
         points: [pointFromEvent(e, canvasEl, panX, panY)],
+      }
+      return
+    }
+
+    if (isShapeTool(tool)) {
+      dragMode = 'draw'
+      const pt = canvasPoint(e, canvasEl, panX, panY)
+      shapeOrigin = pt
+      liveStroke = {
+        id: crypto.randomUUID(),
+        color,
+        size,
+        type: SHAPE_TOOLS[tool],
+        points: [],
+        rect: { x: pt.x, y: pt.y, w: 0, h: 0 },
       }
       return
     }
@@ -186,7 +216,27 @@
     if (e.pointerId !== activePointerId) return
 
     if (dragMode === 'draw' && liveStroke && canvasEl) {
-      liveStroke.points = [...liveStroke.points, pointFromEvent(e, canvasEl, panX, panY)]
+      if (liveStroke.type === 'freehand') {
+        liveStroke.points = [...liveStroke.points, pointFromEvent(e, canvasEl, panX, panY)]
+      } else if (shapeOrigin && liveStroke.rect) {
+        const pt = canvasPoint(e, canvasEl, panX, panY)
+        let w = pt.x - shapeOrigin.x
+        let h = pt.y - shapeOrigin.y
+        if (e.shiftKey) {
+          if (liveStroke.type === 'line' || liveStroke.type === 'arrow') {
+            const angle = Math.atan2(h, w)
+            const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4)
+            const len = Math.hypot(w, h)
+            w = len * Math.cos(snapped)
+            h = len * Math.sin(snapped)
+          } else {
+            const side = Math.max(Math.abs(w), Math.abs(h))
+            w = side * Math.sign(w || 1)
+            h = side * Math.sign(h || 1)
+          }
+        }
+        liveStroke = { ...liveStroke, rect: { x: shapeOrigin.x, y: shapeOrigin.y, w, h } }
+      }
       return
     }
 
@@ -202,9 +252,13 @@
       const dy = pt.y - lastDragPoint.y
       for (const s of strokes) {
         if (!selectedIds.has(s.id)) continue
-        for (const p of s.points) {
-          p[0] += dx
-          p[1] += dy
+        if (s.type !== 'freehand' && s.rect) {
+          s.rect = { ...s.rect, x: s.rect.x + dx, y: s.rect.y + dy }
+        } else {
+          for (const p of s.points) {
+            p[0] += dx
+            p[1] += dy
+          }
         }
       }
       strokes = [...strokes]
@@ -232,10 +286,18 @@
     lastDragPoint = null
 
     if (mode === 'draw' && liveStroke) {
-      if (liveStroke.points.length > 0) {
-        strokes = [...strokes, liveStroke]
+      if (liveStroke.type === 'freehand') {
+        if (liveStroke.points.length > 0) {
+          strokes = [...strokes, liveStroke]
+        }
+      } else if (liveStroke.rect) {
+        const { w, h } = liveStroke.rect
+        if (Math.abs(w) > 2 || Math.abs(h) > 2) {
+          strokes = [...strokes, liveStroke]
+        }
       }
       liveStroke = null
+      shapeOrigin = null
       return
     }
 
@@ -353,6 +415,47 @@
       >
         Select
       </button>
+      <span class="tool-sep"></span>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={tool === 'rectangle'}
+        class:active={tool === 'rectangle'}
+        onclick={() => (tool = 'rectangle')}
+        title="Rectangle (Shift for square)"
+      >
+        Rect
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={tool === 'ellipse'}
+        class:active={tool === 'ellipse'}
+        onclick={() => (tool = 'ellipse')}
+        title="Ellipse (Shift for circle)"
+      >
+        Ellipse
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={tool === 'line'}
+        class:active={tool === 'line'}
+        onclick={() => (tool = 'line')}
+        title="Line (Shift to snap angle)"
+      >
+        Line
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={tool === 'arrow'}
+        class:active={tool === 'arrow'}
+        onclick={() => (tool = 'arrow')}
+        title="Arrow (Shift to snap angle)"
+      >
+        Arrow
+      </button>
     </div>
 
     <div class="swatches" role="radiogroup" aria-label="Color">
@@ -424,6 +527,7 @@
     <canvas
       bind:this={canvasEl}
       class:select-cursor={tool === 'select'}
+      class:crosshair-cursor={isShapeTool(tool)}
       class:panning={isPanning}
       onpointerdown={onPointerDown}
       onpointermove={onPointerMove}
@@ -549,6 +653,17 @@
 
   canvas.select-cursor {
     cursor: default;
+  }
+
+  canvas.crosshair-cursor {
+    cursor: crosshair;
+  }
+
+  .tool-sep {
+    width: 1px;
+    height: 18px;
+    background: var(--c-border);
+    margin: 0 2px;
   }
 
   canvas.panning {

--- a/src/renderer/src/components/drawing/DrawingPane.svelte
+++ b/src/renderer/src/components/drawing/DrawingPane.svelte
@@ -183,7 +183,6 @@
         color,
         size,
         type: SHAPE_TOOLS[tool],
-        points: [],
         rect: { x: pt.x, y: pt.y, w: 0, h: 0 },
       }
       return
@@ -218,7 +217,7 @@
     if (dragMode === 'draw' && liveStroke && canvasEl) {
       if (liveStroke.type === 'freehand') {
         liveStroke.points = [...liveStroke.points, pointFromEvent(e, canvasEl, panX, panY)]
-      } else if (shapeOrigin && liveStroke.rect) {
+      } else if (shapeOrigin && liveStroke.type !== 'freehand') {
         const pt = canvasPoint(e, canvasEl, panX, panY)
         let w = pt.x - shapeOrigin.x
         let h = pt.y - shapeOrigin.y
@@ -252,7 +251,7 @@
       const dy = pt.y - lastDragPoint.y
       for (const s of strokes) {
         if (!selectedIds.has(s.id)) continue
-        if (s.type !== 'freehand' && s.rect) {
+        if (s.type !== 'freehand') {
           s.rect = { ...s.rect, x: s.rect.x + dx, y: s.rect.y + dy }
         } else {
           for (const p of s.points) {
@@ -290,7 +289,7 @@
         if (liveStroke.points.length > 0) {
           strokes = [...strokes, liveStroke]
         }
-      } else if (liveStroke.rect) {
+      } else {
         const { w, h } = liveStroke.rect
         if (Math.abs(w) > 2 || Math.abs(h) > 2) {
           strokes = [...strokes, liveStroke]

--- a/src/renderer/src/components/drawing/DrawingPane.svelte
+++ b/src/renderer/src/components/drawing/DrawingPane.svelte
@@ -643,6 +643,7 @@
     min-height: 0;
     position: relative;
     overflow: hidden;
+    outline: none;
   }
 
   canvas {

--- a/src/renderer/src/components/drawing/drawingCanvas.ts
+++ b/src/renderer/src/components/drawing/drawingCanvas.ts
@@ -19,7 +19,121 @@ export function strokePath(stroke: Stroke): Path2D {
   return path
 }
 
+export function drawShape(ctx: CanvasRenderingContext2D, stroke: Stroke): void {
+  if (!stroke.rect) return
+  const { x, y, w, h } = stroke.rect
+  ctx.strokeStyle = stroke.color
+  ctx.lineWidth = stroke.size
+  ctx.lineCap = 'round'
+  ctx.lineJoin = 'round'
+
+  switch (stroke.type) {
+    case 'rectangle':
+      ctx.strokeRect(x, y, w, h)
+      break
+    case 'ellipse': {
+      const cx = x + w / 2
+      const cy = y + h / 2
+      const rx = Math.abs(w / 2)
+      const ry = Math.abs(h / 2)
+      ctx.beginPath()
+      ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2)
+      ctx.stroke()
+      break
+    }
+    case 'line':
+      ctx.beginPath()
+      ctx.moveTo(x, y)
+      ctx.lineTo(x + w, y + h)
+      ctx.stroke()
+      break
+    case 'arrow': {
+      const ex = x + w
+      const ey = y + h
+      ctx.beginPath()
+      ctx.moveTo(x, y)
+      ctx.lineTo(ex, ey)
+      ctx.stroke()
+      const angle = Math.atan2(h, w)
+      const headLen = Math.max(stroke.size * 3, 10)
+      ctx.beginPath()
+      ctx.moveTo(ex, ey)
+      ctx.lineTo(
+        ex - headLen * Math.cos(angle - Math.PI / 6),
+        ey - headLen * Math.sin(angle - Math.PI / 6),
+      )
+      ctx.lineTo(
+        ex - headLen * Math.cos(angle + Math.PI / 6),
+        ey - headLen * Math.sin(angle + Math.PI / 6),
+      )
+      ctx.closePath()
+      ctx.fillStyle = stroke.color
+      ctx.fill()
+      break
+    }
+    default:
+      break
+  }
+}
+
+export function hitTestShape(px: number, py: number, stroke: Stroke): boolean {
+  if (!stroke.rect) return false
+  const { x, y, w, h } = stroke.rect
+  const tolerance = Math.max(stroke.size, 6)
+
+  switch (stroke.type) {
+    case 'rectangle': {
+      const minX = Math.min(x, x + w)
+      const minY = Math.min(y, y + h)
+      const maxX = Math.max(x, x + w)
+      const maxY = Math.max(y, y + h)
+      const nearLeft =
+        Math.abs(px - minX) < tolerance && py >= minY - tolerance && py <= maxY + tolerance
+      const nearRight =
+        Math.abs(px - maxX) < tolerance && py >= minY - tolerance && py <= maxY + tolerance
+      const nearTop =
+        Math.abs(py - minY) < tolerance && px >= minX - tolerance && px <= maxX + tolerance
+      const nearBottom =
+        Math.abs(py - maxY) < tolerance && px >= minX - tolerance && px <= maxX + tolerance
+      return nearLeft || nearRight || nearTop || nearBottom
+    }
+    case 'ellipse': {
+      const cx = x + w / 2
+      const cy = y + h / 2
+      const rx = Math.abs(w / 2)
+      const ry = Math.abs(h / 2)
+      if (rx < 1 || ry < 1) return false
+      const norm = ((px - cx) / rx) ** 2 + ((py - cy) / ry) ** 2
+      return Math.abs(Math.sqrt(norm) - 1) * Math.min(rx, ry) < tolerance
+    }
+    case 'line':
+    case 'arrow': {
+      const ex = x + w
+      const ey = y + h
+      const dx = ex - x
+      const dy = ey - y
+      const lenSq = dx * dx + dy * dy
+      if (lenSq < 1) return Math.hypot(px - x, py - y) < tolerance
+      const t = Math.max(0, Math.min(1, ((px - x) * dx + (py - y) * dy) / lenSq))
+      const closestX = x + t * dx
+      const closestY = y + t * dy
+      return Math.hypot(px - closestX, py - closestY) < tolerance
+    }
+    default:
+      return false
+  }
+}
+
 export function strokeBBox(stroke: Stroke): { x: number; y: number; w: number; h: number } {
+  if (stroke.type !== 'freehand' && stroke.rect) {
+    const { x, y, w, h } = stroke.rect
+    const minX = Math.min(x, x + w)
+    const minY = Math.min(y, y + h)
+    const maxX = Math.max(x, x + w)
+    const maxY = Math.max(y, y + h)
+    const pad = stroke.size
+    return { x: minX - pad, y: minY - pad, w: maxX - minX + 2 * pad, h: maxY - minY + 2 * pad }
+  }
   let minX = Infinity,
     minY = Infinity,
     maxX = -Infinity,
@@ -41,15 +155,18 @@ export function hitTest(
   strokes: Stroke[],
   dpr: number,
 ): Stroke | null {
-  ctx.save()
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
   for (let i = strokes.length - 1; i >= 0; i--) {
-    if (ctx.isPointInPath(strokePath(strokes[i]), px * dpr, py * dpr)) {
+    const s = strokes[i]
+    if (s.type !== 'freehand' && s.rect) {
+      if (hitTestShape(px, py, s)) return s
+    } else {
+      ctx.save()
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+      const hit = ctx.isPointInPath(strokePath(s), px * dpr, py * dpr)
       ctx.restore()
-      return strokes[i]
+      if (hit) return s
     }
   }
-  ctx.restore()
   return null
 }
 
@@ -89,20 +206,38 @@ export function redraw(params: RedrawParams): void {
   ctx.translate(params.panX, params.panY)
 
   for (const s of params.strokes) {
-    const path = strokePath(s)
-    ctx.fillStyle = s.color
-    ctx.fill(path)
-    if (params.selectedIds.has(s.id)) {
+    if (s.type !== 'freehand' && s.rect) {
       ctx.save()
-      ctx.strokeStyle = accent
-      ctx.lineWidth = 2
-      ctx.stroke(path)
+      drawShape(ctx, s)
+      if (params.selectedIds.has(s.id)) {
+        ctx.strokeStyle = accent
+        ctx.lineWidth = 2
+        const bb = strokeBBox(s)
+        ctx.strokeRect(bb.x, bb.y, bb.w, bb.h)
+      }
       ctx.restore()
+    } else {
+      const path = strokePath(s)
+      ctx.fillStyle = s.color
+      ctx.fill(path)
+      if (params.selectedIds.has(s.id)) {
+        ctx.save()
+        ctx.strokeStyle = accent
+        ctx.lineWidth = 2
+        ctx.stroke(path)
+        ctx.restore()
+      }
     }
   }
   if (params.liveStroke) {
-    ctx.fillStyle = params.liveStroke.color
-    ctx.fill(strokePath(params.liveStroke))
+    if (params.liveStroke.type !== 'freehand' && params.liveStroke.rect) {
+      ctx.save()
+      drawShape(ctx, params.liveStroke)
+      ctx.restore()
+    } else {
+      ctx.fillStyle = params.liveStroke.color
+      ctx.fill(strokePath(params.liveStroke))
+    }
   }
   if (params.marquee) {
     ctx.save()

--- a/src/renderer/src/components/drawing/drawingCanvas.ts
+++ b/src/renderer/src/components/drawing/drawingCanvas.ts
@@ -50,12 +50,14 @@ export function drawShape(ctx: CanvasRenderingContext2D, stroke: Stroke): void {
     case 'arrow': {
       const ex = x + w
       const ey = y + h
+      const angle = Math.atan2(h, w)
+      const headLen = Math.max(stroke.size * 4, 14)
+      const stopX = ex - headLen * 0.6 * Math.cos(angle)
+      const stopY = ey - headLen * 0.6 * Math.sin(angle)
       ctx.beginPath()
       ctx.moveTo(x, y)
-      ctx.lineTo(ex, ey)
+      ctx.lineTo(stopX, stopY)
       ctx.stroke()
-      const angle = Math.atan2(h, w)
-      const headLen = Math.max(stroke.size * 3, 10)
       ctx.beginPath()
       ctx.moveTo(ex, ey)
       ctx.lineTo(
@@ -69,6 +71,7 @@ export function drawShape(ctx: CanvasRenderingContext2D, stroke: Stroke): void {
       ctx.closePath()
       ctx.fillStyle = stroke.color
       ctx.fill()
+      ctx.stroke()
       break
     }
     default:

--- a/src/renderer/src/components/drawing/drawingCanvas.ts
+++ b/src/renderer/src/components/drawing/drawingCanvas.ts
@@ -1,5 +1,6 @@
 import { getStroke } from 'perfect-freehand'
-import type { Stroke, StrokePoint } from '../../lib/stores/drawings.svelte'
+import { match, P } from 'ts-pattern'
+import type { Stroke, ShapeStroke, StrokePoint } from '../../lib/stores/drawings.svelte'
 
 export function strokePath(stroke: Stroke): Path2D {
   const path = new Path2D()
@@ -19,19 +20,18 @@ export function strokePath(stroke: Stroke): Path2D {
   return path
 }
 
-export function drawShape(ctx: CanvasRenderingContext2D, stroke: Stroke): void {
-  if (!stroke.rect) return
+export function drawShape(ctx: CanvasRenderingContext2D, stroke: ShapeStroke): void {
   const { x, y, w, h } = stroke.rect
   ctx.strokeStyle = stroke.color
   ctx.lineWidth = stroke.size
   ctx.lineCap = 'round'
   ctx.lineJoin = 'round'
 
-  switch (stroke.type) {
-    case 'rectangle':
+  match(stroke.type)
+    .with('rectangle', () => {
       ctx.strokeRect(x, y, w, h)
-      break
-    case 'ellipse': {
+    })
+    .with('ellipse', () => {
       const cx = x + w / 2
       const cy = y + h / 2
       const rx = Math.abs(w / 2)
@@ -39,15 +39,14 @@ export function drawShape(ctx: CanvasRenderingContext2D, stroke: Stroke): void {
       ctx.beginPath()
       ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2)
       ctx.stroke()
-      break
-    }
-    case 'line':
+    })
+    .with('line', () => {
       ctx.beginPath()
       ctx.moveTo(x, y)
       ctx.lineTo(x + w, y + h)
       ctx.stroke()
-      break
-    case 'arrow': {
+    })
+    .with('arrow', () => {
       const ex = x + w
       const ey = y + h
       const angle = Math.atan2(h, w)
@@ -72,20 +71,16 @@ export function drawShape(ctx: CanvasRenderingContext2D, stroke: Stroke): void {
       ctx.fillStyle = stroke.color
       ctx.fill()
       ctx.stroke()
-      break
-    }
-    default:
-      break
-  }
+    })
+    .exhaustive()
 }
 
-export function hitTestShape(px: number, py: number, stroke: Stroke): boolean {
-  if (!stroke.rect) return false
+export function hitTestShape(px: number, py: number, stroke: ShapeStroke): boolean {
   const { x, y, w, h } = stroke.rect
   const tolerance = Math.max(stroke.size, 6)
 
-  switch (stroke.type) {
-    case 'rectangle': {
+  return match(stroke.type)
+    .with('rectangle', () => {
       const minX = Math.min(x, x + w)
       const minY = Math.min(y, y + h)
       const maxX = Math.max(x, x + w)
@@ -99,8 +94,8 @@ export function hitTestShape(px: number, py: number, stroke: Stroke): boolean {
       const nearBottom =
         Math.abs(py - maxY) < tolerance && px >= minX - tolerance && px <= maxX + tolerance
       return nearLeft || nearRight || nearTop || nearBottom
-    }
-    case 'ellipse': {
+    })
+    .with('ellipse', () => {
       const cx = x + w / 2
       const cy = y + h / 2
       const rx = Math.abs(w / 2)
@@ -108,9 +103,8 @@ export function hitTestShape(px: number, py: number, stroke: Stroke): boolean {
       if (rx < 1 || ry < 1) return false
       const norm = ((px - cx) / rx) ** 2 + ((py - cy) / ry) ** 2
       return Math.abs(Math.sqrt(norm) - 1) * Math.min(rx, ry) < tolerance
-    }
-    case 'line':
-    case 'arrow': {
+    })
+    .with(P.union('line', 'arrow'), () => {
       const ex = x + w
       const ey = y + h
       const dx = ex - x
@@ -121,14 +115,12 @@ export function hitTestShape(px: number, py: number, stroke: Stroke): boolean {
       const closestX = x + t * dx
       const closestY = y + t * dy
       return Math.hypot(px - closestX, py - closestY) < tolerance
-    }
-    default:
-      return false
-  }
+    })
+    .exhaustive()
 }
 
 export function strokeBBox(stroke: Stroke): { x: number; y: number; w: number; h: number } {
-  if (stroke.type !== 'freehand' && stroke.rect) {
+  if (stroke.type !== 'freehand') {
     const { x, y, w, h } = stroke.rect
     const minX = Math.min(x, x + w)
     const minY = Math.min(y, y + h)
@@ -160,7 +152,7 @@ export function hitTest(
 ): Stroke | null {
   for (let i = strokes.length - 1; i >= 0; i--) {
     const s = strokes[i]
-    if (s.type !== 'freehand' && s.rect) {
+    if (s.type !== 'freehand') {
       if (hitTestShape(px, py, s)) return s
     } else {
       ctx.save()
@@ -209,7 +201,7 @@ export function redraw(params: RedrawParams): void {
   ctx.translate(params.panX, params.panY)
 
   for (const s of params.strokes) {
-    if (s.type !== 'freehand' && s.rect) {
+    if (s.type !== 'freehand') {
       ctx.save()
       drawShape(ctx, s)
       if (params.selectedIds.has(s.id)) {
@@ -233,7 +225,7 @@ export function redraw(params: RedrawParams): void {
     }
   }
   if (params.liveStroke) {
-    if (params.liveStroke.type !== 'freehand' && params.liveStroke.rect) {
+    if (params.liveStroke.type !== 'freehand') {
       ctx.save()
       drawShape(ctx, params.liveStroke)
       ctx.restore()

--- a/src/renderer/src/components/notes/NotesPane.svelte
+++ b/src/renderer/src/components/notes/NotesPane.svelte
@@ -75,7 +75,9 @@
   // Assigns pre-sanitized HTML from `previewHtml`. Only call with DOMPurify-cleaned output.
   function htmlContent(node: HTMLElement, html: () => string): void {
     $effect(() => {
-      node.innerHTML = html()
+      const value = html()
+      if (document.activeElement === node) return
+      node.innerHTML = value
     })
   }
 </script>

--- a/src/renderer/src/components/notes/NotesPane.svelte
+++ b/src/renderer/src/components/notes/NotesPane.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte'
   import { marked } from 'marked'
   import DOMPurify from 'dompurify'
   import TurndownService from 'turndown'
@@ -28,6 +29,10 @@
   let editSource: 'editor' | 'preview' | null = $state(null)
   let editSourceTimer: ReturnType<typeof setTimeout> | null = null
   let previewEl: HTMLDivElement | undefined = $state()
+
+  onDestroy(() => {
+    if (editSourceTimer) clearTimeout(editSourceTimer)
+  })
 
   let parseGen = 0
   $effect(() => {
@@ -64,8 +69,8 @@
     e.preventDefault()
     const html = e.clipboardData?.getData('text/html') ?? ''
     const text = e.clipboardData?.getData('text/plain') ?? ''
-    const sanitized = html ? DOMPurify.sanitize(html) : DOMPurify.sanitize(text)
-    document.execCommand('insertHTML', false, sanitized)
+    const sanitized = html ? DOMPurify.sanitize(html) : ''
+    document.execCommand(sanitized ? 'insertHTML' : 'insertText', false, sanitized || text)
   }
 
   function onPreviewInput(): void {

--- a/src/renderer/src/components/notes/NotesPane.svelte
+++ b/src/renderer/src/components/notes/NotesPane.svelte
@@ -60,6 +60,14 @@
     notesState[key] = target.value
   }
 
+  function onPreviewPaste(e: ClipboardEvent): void {
+    e.preventDefault()
+    const html = e.clipboardData?.getData('text/html') ?? ''
+    const text = e.clipboardData?.getData('text/plain') ?? ''
+    const sanitized = html ? DOMPurify.sanitize(html) : DOMPurify.sanitize(text)
+    document.execCommand('insertHTML', false, sanitized)
+  }
+
   function onPreviewInput(): void {
     if (!previewEl || !key) return
     editSource = 'preview'
@@ -143,6 +151,7 @@
           contenteditable="true"
           bind:this={previewEl}
           oninput={onPreviewInput}
+          onpaste={onPreviewPaste}
           use:htmlContent={() => previewHtml}
         ></div>
       {/if}

--- a/src/renderer/src/components/notes/NotesPane.svelte
+++ b/src/renderer/src/components/notes/NotesPane.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { marked } from 'marked'
   import DOMPurify from 'dompurify'
+  import TurndownService from 'turndown'
   import {
     notesState,
     notesUiScope,
@@ -8,6 +9,12 @@
     getNoteLabel,
     type NoteScope,
   } from '../../lib/stores/notes.svelte'
+
+  const turndown = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    bulletListMarker: '-',
+  })
 
   let { paneSessionId }: { paneSessionId: string } = $props()
 
@@ -18,11 +25,15 @@
 
   let previewHtml = $state('')
   let showPreview = $state(true)
+  let editSource: 'editor' | 'preview' | null = $state(null)
+  let editSourceTimer: ReturnType<typeof setTimeout> | null = null
+  let previewEl: HTMLDivElement | undefined = $state()
 
   let parseGen = 0
   $effect(() => {
     const raw = content
     const gen = ++parseGen
+    if (editSource === 'preview') return
     if (!raw.trim()) {
       previewHtml = ''
       return
@@ -41,7 +52,24 @@
   function onInput(e: Event): void {
     const target = e.target as HTMLTextAreaElement
     if (!key) return
+    editSource = 'editor'
+    if (editSourceTimer) clearTimeout(editSourceTimer)
+    editSourceTimer = setTimeout(() => {
+      editSource = null
+    }, 350)
     notesState[key] = target.value
+  }
+
+  function onPreviewInput(): void {
+    if (!previewEl || !key) return
+    editSource = 'preview'
+    if (editSourceTimer) clearTimeout(editSourceTimer)
+    editSourceTimer = setTimeout(() => {
+      editSource = null
+    }, 350)
+    const html = previewEl.innerHTML
+    const md = turndown.turndown(html)
+    notesState[key] = md
   }
 
   // Assigns pre-sanitized HTML from `previewHtml`. Only call with DOMPurify-cleaned output.
@@ -108,7 +136,13 @@
         oninput={onInput}
       ></textarea>
       {#if showPreview}
-        <div class="preview markdown-body" use:htmlContent={() => previewHtml}></div>
+        <div
+          class="preview markdown-body"
+          contenteditable="true"
+          bind:this={previewEl}
+          oninput={onPreviewInput}
+          use:htmlContent={() => previewHtml}
+        ></div>
       {/if}
     </div>
   {/if}
@@ -256,5 +290,16 @@
     justify-content: center;
     color: var(--c-text-muted);
     font-size: 13px;
+  }
+
+  .preview:empty::before {
+    content: 'Click to edit...';
+    color: var(--c-text-muted);
+    font-style: italic;
+  }
+
+  .preview[contenteditable='true'] {
+    outline: none;
+    cursor: text;
   }
 </style>

--- a/src/renderer/src/components/notes/NotesPane.svelte
+++ b/src/renderer/src/components/notes/NotesPane.svelte
@@ -67,7 +67,7 @@
     editSourceTimer = setTimeout(() => {
       editSource = null
     }, 350)
-    const html = previewEl.innerHTML
+    const html = DOMPurify.sanitize(previewEl.innerHTML)
     const md = turndown.turndown(html)
     notesState[key] = md
   }

--- a/src/renderer/src/lib/onboarding/steps.ts
+++ b/src/renderer/src/lib/onboarding/steps.ts
@@ -138,6 +138,14 @@ export const onboardingSteps: OnboardingStep[] = [
     introducedIn: '0.11.0',
     category: 'feature',
   },
+  {
+    id: 'drawing-shapes-notes-editing',
+    title: 'Drawing shapes and editable notes preview',
+    description:
+      'The Drawing pane now has four shape tools — Rectangle, Ellipse, Line, and Arrow. Click-drag to draw; hold Shift to constrain proportions or snap angles. Shapes support selection, move, delete, and undo just like freehand strokes. The Notes preview panel is now editable: click into the rendered markdown and type directly, and changes sync back to the editor in real time.',
+    introducedIn: '0.12.0',
+    category: 'feature',
+  },
 ]
 
 export function getFirstLaunchSteps(): OnboardingStep[] {

--- a/src/renderer/src/lib/stores/drawings.svelte.ts
+++ b/src/renderer/src/lib/stores/drawings.svelte.ts
@@ -1,15 +1,25 @@
 import { workspaceState, getProjectForWorktree } from './workspace.svelte'
 
-export type DrawTool = 'pen' | 'select'
+export type ShapeType = 'freehand' | 'rectangle' | 'ellipse' | 'line' | 'arrow'
+export type DrawTool = 'pen' | 'select' | 'rectangle' | 'ellipse' | 'line' | 'arrow'
 
 /** A single input point captured from pointer events. */
 export type StrokePoint = [x: number, y: number, pressure: number]
+
+export interface ShapeRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
 
 export interface Stroke {
   id: string
   color: string
   size: number
+  type: ShapeType
   points: StrokePoint[]
+  rect?: ShapeRect
 }
 
 /** Snapshot persisted per project. Stored as plain arrays — trivially serializable. */

--- a/src/renderer/src/lib/stores/drawings.svelte.ts
+++ b/src/renderer/src/lib/stores/drawings.svelte.ts
@@ -1,6 +1,6 @@
 import { workspaceState, getProjectForWorktree } from './workspace.svelte'
 
-export type ShapeType = 'freehand' | 'rectangle' | 'ellipse' | 'line' | 'arrow'
+export type ShapeType = 'rectangle' | 'ellipse' | 'line' | 'arrow'
 export type DrawTool = 'pen' | 'select' | 'rectangle' | 'ellipse' | 'line' | 'arrow'
 
 /** A single input point captured from pointer events. */
@@ -13,14 +13,23 @@ export interface ShapeRect {
   h: number
 }
 
-export interface Stroke {
+export type FreehandStroke = {
+  id: string
+  color: string
+  size: number
+  type: 'freehand'
+  points: StrokePoint[]
+}
+
+export type ShapeStroke = {
   id: string
   color: string
   size: number
   type: ShapeType
-  points: StrokePoint[]
-  rect?: ShapeRect
+  rect: ShapeRect
 }
+
+export type Stroke = FreehandStroke | ShapeStroke
 
 /** Snapshot persisted per project. Stored as plain arrays — trivially serializable. */
 export const drawingsState: Record<string, Stroke[]> = $state({})


### PR DESCRIPTION
**What**
Extends the Drawing pane with four shape tools (rectangle, ellipse, line, arrow) and makes the Notes preview panel editable, syncing changes back to markdown via turndown.

**Why**
Closes #157. Quick shape sketching is significantly faster than freehand for communicating architecture diagrams or annotating screenshots. Bilateral notes editing lets users fix small typos directly in the rendered view without switching to the raw editor.

**How to test**

Drawing shapes:
1. Open a Drawing pane and select the Rectangle, Ellipse, Line, or Arrow tool from the toolbar.
2. Click-drag on the canvas — a shape preview renders during drag.
3. Hold **Shift** while dragging: rectangles constrain to squares, ellipses to circles, lines/arrows to 45° increments.
4. Switch to Select, click the shape — it highlights. Drag to move it.
5. Press **Delete** or **Backspace** — shape is removed. **Cmd+Z** undoes last shape.
6. Click **Send to agent** — PNG of canvas (with shapes) is pasted into the active agent.

Notes preview editing:
1. Open a Notes pane and click **Show preview**.
2. Click into the rendered preview and edit text directly — changes write back to the textarea.
3. Edit in the textarea — the preview updates after a brief debounce.
4. Press **Backspace** in the preview — cursor stays in place (no jump to beginning).

**Screenshots / recordings**
(UI changes — reviewer should test interactively)

**Checklist**
- [x] Tested on macOS
- [x] `npm run typecheck` passes (0 errors)
- [x] `npm run lint` passes (0 warnings)
- [x] Docs updated (`docs/features/drawing.md`, `docs/features/notes.md`)
- [x] Conventional commit prefix on all commits
- [ ] Windows / Linux tested