### PR TITLE
fix(ui): settings button in status bar + section spacing fix

### DIFF
--- a/src/renderer/src/components/layout/StatusBar.svelte
+++ b/src/renderer/src/components/layout/StatusBar.svelte
@@ -8,6 +8,7 @@
   import { prefs } from '../../lib/stores/preferences.svelte'
   import { perfHudState, enablePerfHud, disablePerfHud } from '../../lib/stores/perfHud.svelte'
   import { showPreferences } from '../../lib/stores/dialogs.svelte'
+  import { Settings } from '@lucide/svelte'
 
   const AI_TOOL_IDS = new Set(['claude', 'codex', 'opencode', 'gemini'])
 
@@ -366,6 +367,15 @@
           />
         </svg>
       </button>
+
+      <button
+        class="status-item settings-btn"
+        aria-label="Open Settings"
+        title="Open Settings"
+        onclick={() => showPreferences()}
+      >
+        <Settings size={13} />
+      </button>
     </div>
   </footer>
 {/if}
@@ -512,6 +522,10 @@
 
   .inspector-toggle:hover {
     color: var(--c-text);
+  }
+
+  .settings-btn {
+    color: var(--c-text-muted);
   }
 
   @keyframes badge-pulse {

--- a/src/renderer/src/components/preferences/GeneralPrefs.svelte
+++ b/src/renderer/src/components/preferences/GeneralPrefs.svelte
@@ -160,6 +160,10 @@
     gap: 16px;
   }
 
+  .section + .section {
+    margin-top: 24px;
+  }
+
   .section-title {
     font-size: 15px;
     font-weight: 600;

--- a/src/renderer/src/lib/onboarding/steps.ts
+++ b/src/renderer/src/lib/onboarding/steps.ts
@@ -138,6 +138,14 @@ export const onboardingSteps: OnboardingStep[] = [
     introducedIn: '0.11.0',
     category: 'feature',
   },
+  {
+    id: 'status-bar-settings',
+    title: 'Quick Settings access',
+    description:
+      'The gear icon at the right of the status bar opens Settings directly. You can also use ⌘, / Ctrl+, or the command palette.',
+    introducedIn: '0.12.0',
+    category: 'feature',
+  },
 ]
 
 export function getFirstLaunchSteps(): OnboardingStep[] {


### PR DESCRIPTION
## What
Adds a gear icon button to the status bar (next to the inspector/eye toggle) that opens the Settings modal. Also fixes "Backup & Restore" section being too close to the "Re-run setup wizard" button in General preferences.

## Why
The settings button gives quick access to preferences directly from the status bar. The spacing fix makes the General prefs layout less cramped.

## How to test
1. Open the app — status bar should show a ⚙ icon at the far right, next to the eye icon
2. Click the gear → Settings modal opens on the General tab
3. Open Settings → General → confirm visible gap between "Shell" row and "Backup & Restore" heading

## Screenshots / recordings
*(UI changes — add screenshots when reviewing)*

## Checklist
- [x] No new dependencies introduced (uses existing `@lucide/svelte`)
- [x] No breaking changes
- [ ] Docs updated (n/a)