### PR TITLE
feat: add pane tab strip for split terminal management

### DIFF
--- a/docs/core/terminal.md
+++ b/docs/core/terminal.md
@@ -48,6 +48,22 @@ The WsBridge maintains a circular buffer of up to 1 MB of PTY output per session
 4. The resize callback calls `window.api.resizePty(sessionId, cols, rows)` which forwards to `PtyManager.resize()`.
 5. When the user clicks back into a terminal after a remote peer resized the PTY, the component always sends `resizePty` on `pointerdown`/`focus` to reclaim the desktop dimensions.
 
+### Pane tab strip controls
+
+In split layouts, each pane shows a strip above the pane body with the pane title and actions:
+
+- **Detach pane to tab**: removes that pane from the current split and opens it as a new top-level tab.
+- **Close pane**: closes only that pane. If it is running processes, the same termination confirmation flow is shown before closing.
+
+Clicking the strip also focuses the pane.
+
+### Pane dragging via strip
+
+1. The user drags a pane by pressing and moving on its strip (left mouse button; action buttons are excluded).
+2. If dropped over another pane's edge zone, the pane is inserted on the corresponding side (left/right/top/bottom).
+3. While dragging over the main tab bar, hovering a tab for 300ms switches to that tab so the pane can be dropped there.
+4. Dropping over empty space in the tab bar detaches the pane into a new tab (same result as the detach button).
+
 ### File drag and drop
 
 1. User drags files onto the terminal.

--- a/src/renderer/src/components/terminal/PaneTabStrip.svelte
+++ b/src/renderer/src/components/terminal/PaneTabStrip.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import { ExternalLink, X } from '@lucide/svelte'
+  import type { PaneSession } from '../../lib/stores/splitTree'
+  import { closePane, detachPaneToTab, movePaneToTarget } from '../../lib/stores/tabs.svelte'
+  import {
+    dragState,
+    startPaneDrag,
+    activateDrag,
+    clearDrag,
+  } from '../../lib/stores/dragState.svelte'
+
+  let {
+    pane,
+    tabId,
+    worktreePath,
+    focused,
+    onFocus,
+  }: {
+    pane: PaneSession
+    tabId: string
+    worktreePath: string
+    focused: boolean
+    onFocus: () => void
+  } = $props()
+
+  const DRAG_THRESHOLD = 5
+
+  let dragStartX = 0
+  let dragStartY = 0
+  let dragActive = false
+
+  let label = $derived(pane.title?.trim() || pane.toolName)
+
+  function handleStripPointerDown(e: PointerEvent): void {
+    if (e.button !== 0 || e.altKey) return
+    const target = e.target as HTMLElement
+    if (target.closest('.strip-action')) return
+
+    e.preventDefault()
+    onFocus()
+
+    dragStartX = e.clientX
+    dragStartY = e.clientY
+    dragActive = false
+    startPaneDrag(tabId, pane.id, worktreePath)
+
+    window.addEventListener('pointermove', handleDragMove)
+    window.addEventListener('pointerup', handleDragEnd)
+  }
+
+  function handleDragMove(e: PointerEvent): void {
+    const dx = e.clientX - dragStartX
+    const dy = e.clientY - dragStartY
+    if (!dragActive && Math.sqrt(dx * dx + dy * dy) > DRAG_THRESHOLD) {
+      dragActive = true
+      activateDrag()
+    }
+  }
+
+  function handleDragEnd(): void {
+    window.removeEventListener('pointermove', handleDragMove)
+    window.removeEventListener('pointerup', handleDragEnd)
+
+    if (dragActive) {
+      const dt = dragState.dropTarget
+      if (dragState.detachToTabBar) {
+        detachPaneToTab(worktreePath, tabId, pane.id)
+      } else if (dt) {
+        movePaneToTarget(worktreePath, tabId, pane.id, dt.tabId, dt.paneId, dt.zone)
+      }
+    }
+
+    dragActive = false
+    clearDrag()
+  }
+
+  function handleDetachClick(e: MouseEvent): void {
+    e.stopPropagation()
+    detachPaneToTab(worktreePath, tabId, pane.id)
+  }
+
+  function handleCloseClick(e: MouseEvent): void {
+    e.stopPropagation()
+    closePane(worktreePath, tabId, pane.id)
+  }
+
+  $effect(() => {
+    return () => {
+      window.removeEventListener('pointermove', handleDragMove)
+      window.removeEventListener('pointerup', handleDragEnd)
+    }
+  })
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="pane-tab-strip" class:focused onclick={onFocus} onpointerdown={handleStripPointerDown}>
+  <span class="pane-label" title={label}>{label}</span>
+  <div class="pane-actions">
+    <button
+      type="button"
+      class="strip-action"
+      onclick={handleDetachClick}
+      title="Detach pane to tab"
+      aria-label="Detach pane to tab"
+    >
+      <ExternalLink size={12} />
+    </button>
+    <button
+      type="button"
+      class="strip-action"
+      onclick={handleCloseClick}
+      title="Close pane"
+      aria-label="Close pane"
+    >
+      <X size={12} />
+    </button>
+  </div>
+</div>
+
+<style>
+  .pane-tab-strip {
+    height: 28px;
+    min-height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 0 6px 0 10px;
+    background: var(--c-bg-glass-light);
+    border-bottom: 1px solid var(--c-border-subtle);
+    user-select: none;
+  }
+
+  .pane-tab-strip.focused {
+    background: var(--c-active);
+  }
+
+  .pane-label {
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 11px;
+    color: var(--c-text-secondary);
+  }
+
+  .pane-tab-strip.focused .pane-label {
+    color: var(--c-text);
+  }
+
+  .pane-actions {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    flex-shrink: 0;
+  }
+
+  .strip-action {
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--c-text-muted);
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .strip-action:hover {
+    background: var(--c-hover-strong);
+    color: var(--c-text);
+  }
+</style>

--- a/src/renderer/src/components/terminal/PaneTabStrip.svelte
+++ b/src/renderer/src/components/terminal/PaneTabStrip.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
   import { ExternalLink, X } from '@lucide/svelte'
   import type { PaneSession } from '../../lib/stores/splitTree'
-  import { closePane, detachPaneToTab, movePaneToTarget } from '../../lib/stores/tabs.svelte'
-  import {
-    dragState,
-    startPaneDrag,
-    activateDrag,
-    clearDrag,
-  } from '../../lib/stores/dragState.svelte'
+  import { closePane, detachPaneToTab } from '../../lib/stores/tabs.svelte'
+  import { startPaneDrag, activateDrag, clearDrag } from '../../lib/stores/dragState.svelte'
+  import { resolvePaneDrop } from '../../lib/stores/paneDrag'
 
   let {
     pane,
@@ -37,7 +33,6 @@
     if (target.closest('.strip-action')) return
 
     e.preventDefault()
-    onFocus()
 
     dragStartX = e.clientX
     dragStartY = e.clientY
@@ -62,12 +57,7 @@
     window.removeEventListener('pointerup', handleDragEnd)
 
     if (dragActive) {
-      const dt = dragState.dropTarget
-      if (dragState.detachToTabBar) {
-        detachPaneToTab(worktreePath, tabId, pane.id)
-      } else if (dt) {
-        movePaneToTarget(worktreePath, tabId, pane.id, dt.tabId, dt.paneId, dt.zone)
-      }
+      resolvePaneDrop(worktreePath, tabId, pane.id)
     }
 
     dragActive = false

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -1,12 +1,6 @@
 <script lang="ts">
   import type { PaneSession } from '../../lib/stores/splitTree'
-  import {
-    restartPane,
-    updatePaneTitle,
-    isAiToolId,
-    movePaneToTarget,
-    detachPaneToTab,
-  } from '../../lib/stores/tabs.svelte'
+  import { restartPane, updatePaneTitle, isAiToolId } from '../../lib/stores/tabs.svelte'
   import {
     dragState,
     setDropTarget,
@@ -15,6 +9,7 @@
     clearDrag,
     type DropZone,
   } from '../../lib/stores/dragState.svelte'
+  import { resolvePaneDrop } from '../../lib/stores/paneDrag'
   import TerminalInstance from '../../lib/terminal/TerminalInstance.svelte'
   import BrowserPane from '../browser/BrowserPane.svelte'
   import EditorPane from '../editor/EditorPane.svelte'
@@ -148,12 +143,7 @@
     window.removeEventListener('pointerup', handlePaneDragEnd)
 
     if (paneDragActive) {
-      const dt = dragState.dropTarget
-      if (dragState.detachToTabBar) {
-        detachPaneToTab(worktreePath, tabId, pane.id)
-      } else if (dt) {
-        movePaneToTarget(worktreePath, tabId, pane.id, dt.tabId, dt.paneId, dt.zone)
-      }
+      resolvePaneDrop(worktreePath, tabId, pane.id)
     }
 
     paneDragActive = false

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -165,13 +165,7 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
-  class="pane-wrapper"
-  class:focused
-  class:drag-source={isDragSource}
-  onclick={onFocus}
-  bind:this={wrapperEl}
->
+<div class="pane-wrapper" class:drag-source={isDragSource} onclick={onFocus} bind:this={wrapperEl}>
   {#if isMultiPane}
     <PaneTabStrip {pane} {tabId} {worktreePath} {focused} {onFocus} />
   {/if}

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -21,6 +21,7 @@
   import DiffPane from '../diff/DiffPane.svelte'
   import NotesPane from '../notes/NotesPane.svelte'
   import DrawingPane from '../drawing/DrawingPane.svelte'
+  import PaneTabStrip from './PaneTabStrip.svelte'
   import ExitBanner from './ExitBanner.svelte'
   import DetachedOverlay from './DetachedOverlay.svelte'
   import WpmIndicator from './WpmIndicator.svelte'
@@ -181,56 +182,62 @@
   onclick={onFocus}
   bind:this={wrapperEl}
 >
-  {#if pane.paneType === 'browser'}
-    <BrowserPane
-      browserId={pane.sessionId}
-      {worktreePath}
-      {active}
-      {focused}
-      initialUrl={pane.url}
-      onTitleChange={(title) => updatePaneTitle(pane.sessionId, title)}
-      {onFocus}
-    />
-  {:else if pane.paneType === 'editor'}
-    <EditorPane filePath={pane.filePath!} {active} />
-  {:else if pane.paneType === 'diff'}
-    <DiffPane {worktreePath} {active} />
-  {:else if pane.paneType === 'notes'}
-    <NotesPane paneSessionId={pane.sessionId} />
-  {:else if pane.paneType === 'drawing'}
-    <DrawingPane />
-  {:else}
-    <div class="pane-content">
-      {#key pane.sessionId}
-        <TerminalInstance
-          sessionId={pane.sessionId}
-          wsUrl={pane.wsUrl}
-          active={active && focused}
-          visible={active}
-          isAiTool={isAiToolId(pane.toolId)}
-          onTitleChange={(title) => updatePaneTitle(pane.sessionId, title)}
-        />
-      {/key}
-      {#if wpmEnabled}
-        <WpmIndicator sessionId={pane.sessionId} />
-      {/if}
-      {#if keystrokeVisualizerEnabled}
-        <KeystrokeVisualizer sessionId={pane.sessionId} />
-      {/if}
-      {#if !pane.isRunning && pane.detached && pane.tmuxSessionName}
-        <DetachedOverlay
-          tmuxSessionName={pane.tmuxSessionName}
-          onReattach={() => reattachTmuxPane(worktreePath, tabId, pane.id)}
-          onKill={() => killTmuxPane(worktreePath, tabId, pane.id)}
-        />
-      {:else if !pane.isRunning}
-        <ExitBanner
-          exitCode={pane.exitCode}
-          onRestart={() => restartPane(worktreePath, tabId, pane.id)}
-        />
-      {/if}
-    </div>
+  {#if isMultiPane}
+    <PaneTabStrip {pane} {tabId} {worktreePath} {focused} {onFocus} />
   {/if}
+
+  <div class="pane-body">
+    {#if pane.paneType === 'browser'}
+      <BrowserPane
+        browserId={pane.sessionId}
+        {worktreePath}
+        {active}
+        {focused}
+        initialUrl={pane.url}
+        onTitleChange={(title) => updatePaneTitle(pane.sessionId, title)}
+        {onFocus}
+      />
+    {:else if pane.paneType === 'editor'}
+      <EditorPane filePath={pane.filePath!} {active} />
+    {:else if pane.paneType === 'diff'}
+      <DiffPane {worktreePath} {active} />
+    {:else if pane.paneType === 'notes'}
+      <NotesPane paneSessionId={pane.sessionId} />
+    {:else if pane.paneType === 'drawing'}
+      <DrawingPane />
+    {:else}
+      <div class="pane-content">
+        {#key pane.sessionId}
+          <TerminalInstance
+            sessionId={pane.sessionId}
+            wsUrl={pane.wsUrl}
+            active={active && focused}
+            visible={active}
+            isAiTool={isAiToolId(pane.toolId)}
+            onTitleChange={(title) => updatePaneTitle(pane.sessionId, title)}
+          />
+        {/key}
+        {#if wpmEnabled}
+          <WpmIndicator sessionId={pane.sessionId} />
+        {/if}
+        {#if keystrokeVisualizerEnabled}
+          <KeystrokeVisualizer sessionId={pane.sessionId} />
+        {/if}
+        {#if !pane.isRunning && pane.detached && pane.tmuxSessionName}
+          <DetachedOverlay
+            tmuxSessionName={pane.tmuxSessionName}
+            onReattach={() => reattachTmuxPane(worktreePath, tabId, pane.id)}
+            onKill={() => killTmuxPane(worktreePath, tabId, pane.id)}
+          />
+        {:else if !pane.isRunning}
+          <ExitBanner
+            exitCode={pane.exitCode}
+            onRestart={() => restartPane(worktreePath, tabId, pane.id)}
+          />
+        {/if}
+      </div>
+    {/if}
+  </div>
 
   {#if hoveredZone}
     <div class="drop-zone-overlay {hoveredZone}"></div>
@@ -240,14 +247,18 @@
 <style>
   .pane-wrapper {
     position: relative;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
     overflow: hidden;
   }
 
-  .pane-wrapper.focused {
-    outline: 1px solid var(--c-border);
-    outline-offset: -1px;
+  .pane-body {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
   }
 
   .pane-wrapper.drag-source {

--- a/src/renderer/src/components/terminal/PaneWrapper.svelte
+++ b/src/renderer/src/components/terminal/PaneWrapper.svelte
@@ -211,7 +211,8 @@
           <TerminalInstance
             sessionId={pane.sessionId}
             wsUrl={pane.wsUrl}
-            active={active && focused}
+            {active}
+            focused={active && focused}
             visible={active}
             isAiTool={isAiToolId(pane.toolId)}
             onTitleChange={(title) => updatePaneTitle(pane.sessionId, title)}

--- a/src/renderer/src/lib/onboarding/steps.ts
+++ b/src/renderer/src/lib/onboarding/steps.ts
@@ -154,6 +154,14 @@ export const onboardingSteps: OnboardingStep[] = [
     introducedIn: '0.12.0',
     category: 'feature',
   },
+  {
+    id: 'pane-tab-strip-controls',
+    title: 'Pane tab strip controls',
+    description:
+      'Split panes now show a tab strip with quick actions: drag the strip to move the pane, use Detach to turn it into its own tab, or use Close to close just that pane.',
+    introducedIn: '0.12.0',
+    category: 'feature',
+  },
 ]
 
 export function getFirstLaunchSteps(): OnboardingStep[] {

--- a/src/renderer/src/lib/stores/paneDrag.ts
+++ b/src/renderer/src/lib/stores/paneDrag.ts
@@ -1,0 +1,11 @@
+import { dragState } from './dragState.svelte'
+import { detachPaneToTab, movePaneToTarget } from './tabs.svelte'
+
+export function resolvePaneDrop(worktreePath: string, tabId: string, paneId: string): void {
+  const dt = dragState.dropTarget
+  if (dragState.detachToTabBar) {
+    detachPaneToTab(worktreePath, tabId, paneId)
+  } else if (dt) {
+    movePaneToTarget(worktreePath, tabId, paneId, dt.tabId, dt.paneId, dt.zone)
+  }
+}

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -1178,18 +1178,23 @@ export async function splitFocusedPane(
   scheduleSave(worktreePath)
 }
 
-export async function closeFocusedPane(worktreePath: string): Promise<void> {
+export async function closePane(
+  worktreePath: string,
+  tabId: string,
+  paneId: string,
+): Promise<void> {
   const tabs = tabsByWorktree[worktreePath]
   if (!tabs) return
 
-  const tabId = activeTabId[worktreePath]
   const tab = tabs.find((t) => t.id === tabId)
   if (!tab) return
 
-  // Check if focused pane has active process before closing
-  const focusedPane = findLeaf(tab.rootSplit, tab.focusedPaneId)
-  if (focusedPane && focusedPane.isRunning) {
-    const description = await getActiveProcessDescription([focusedPane])
+  const pane = findLeaf(tab.rootSplit, paneId)
+  if (!pane) return
+
+  // Check if this pane has active process before closing
+  if (pane.isRunning) {
+    const description = await getActiveProcessDescription([pane])
     if (description) {
       const confirmed = await confirm({
         title: 'Close pane?',
@@ -1201,7 +1206,7 @@ export async function closeFocusedPane(worktreePath: string): Promise<void> {
     }
   }
 
-  const result = treeRemovePane(tab.rootSplit, tab.focusedPaneId)
+  const result = treeRemovePane(tab.rootSplit, paneId)
   if (!result) return
   disposeEphemeralPaneState(result.removed)
 
@@ -1221,8 +1226,6 @@ export async function closeFocusedPane(worktreePath: string): Promise<void> {
 
   if (!result.tree) {
     // Last pane — close the tab entirely
-    // Remove from closed tabs push since closeTab will handle it
-    // But we already cleaned up the session, so we handle it manually
     if (!closedTabs[worktreePath]) closedTabs[worktreePath] = []
     closedTabs[worktreePath].push({
       toolId: tab.toolId,
@@ -1252,6 +1255,17 @@ export async function closeFocusedPane(worktreePath: string): Promise<void> {
     reconcileTabIdentity(tab)
   }
   scheduleSave(worktreePath)
+}
+
+export async function closeFocusedPane(worktreePath: string): Promise<void> {
+  const tabs = tabsByWorktree[worktreePath]
+  if (!tabs) return
+
+  const tabId = activeTabId[worktreePath]
+  const tab = tabs.find((t) => t.id === tabId)
+  if (!tab) return
+
+  await closePane(worktreePath, tab.id, tab.focusedPaneId)
 }
 
 export function navigatePaneFocus(

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -23,6 +23,7 @@
     sessionId,
     wsUrl,
     active = true,
+    focused = true,
     visible = true,
     isAiTool = false,
     onTitleChange,
@@ -30,6 +31,7 @@
     sessionId: string
     wsUrl: string
     active?: boolean
+    focused?: boolean
     visible?: boolean
     isAiTool?: boolean
     onTitleChange?: (title: string) => void
@@ -80,7 +82,7 @@
   // Focus terminal when tab becomes active (deferred to next frame so the
   // container has left display:none and the browser has finished layout)
   $effect(() => {
-    if (active && termRef) {
+    if (focused && termRef) {
       const term = termRef
       requestAnimationFrame(() => term.focus())
     }


### PR DESCRIPTION
## What

Adds pane tab strip on terminals view, which are split in the same tab. It also prevents disposing of an active WebGL addon in the shared pane.

## Why

There was no clear UI indicator to close, move, or check the title of the terminals which are in the split view pane. There was also a bug which was causing the wrong terminal resize/refit when changing focus.

## How to test

1. Create 2 tabs.
2. Make a split screen with them by dragging one tab into the other.
3. Check new UI - Tab strip
4. Drag by holding the tab strip to manage the split pane
5. Change focus of the currently used terminal - it shouldn't change the size (width) of the terminal
6. Use the action button
  7. First one is "Move to separate tab" - this should move the terminal to a separate tab
  8. Last one is "Close" - this should close the tab


## Screenshots / recordings

<img width="1486" height="937" alt="image" src="https://github.com/user-attachments/assets/c060d831-ac6d-40bc-99bf-52b97481f6af" />

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [x] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly
- [x] Feature docs in `docs/` updated (behavior, config, errors, security — if any changed)
