### PR TITLE
chore: add opencode skills for code review workflow

### DIFF
--- a/.opencode/skills/create-issue/SKILL.md
+++ b/.opencode/skills/create-issue/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: create-issue
+description: Create a GitHub issue (bug report or feature request) following project templates
+---
+
+Create a GitHub issue for this repository following our issue templates.
+
+Ask me:
+
+1. Is this a **bug report** or a **feature request**?
+
+For a **bug report**, ask:
+
+- Description: what happened?
+- Steps to reproduce (numbered list)
+- Expected behavior
+- Platform: macOS, Windows, or Linux
+- App version (optional)
+
+For a **feature request**, ask:
+
+- Problem or use case: what workflow problem does this solve?
+- Proposed solution: how should it work?
+- Who benefits: all users, most users, some users, or niche/power users?
+- Should this be opt-in (off by default) or default on?
+
+After gathering all answers, create the issue with `gh issue create`:
+
+- Bug title format: `bug: <short description>`
+- Feature title format: `feat: <short description>`
+- Body: format as markdown matching the template sections
+- Labels: `bug` for bugs, `enhancement` for features
+
+Show me the issue URL when done.

--- a/.opencode/skills/create-pr/SKILL.md
+++ b/.opencode/skills/create-pr/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: create-pr
+description: Create a pull request with conventional commit title, auto-detected base branch, and filled-in PR template
+---
+
+Create a pull request for the current branch following our PR template and conventional commit standards.
+
+## Steps
+
+1. Detect the base branch:
+   - `hotfix/*` or `hotfix-*` branches target `main`
+   - Everything else targets `next` by default
+   - If the current branch looks like it chains off another feature branch (not `main` or `next`), ask me which base to use
+2. Run `git log` and `git diff` against the detected base branch to understand all changes.
+3. Generate a PR title using conventional commits (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `build:`). The title MUST be under 72 characters total (including prefix). Lowercase after prefix. If the summary is too long, shorten it aggressively — prefer brevity over completeness. Count the characters before proposing. Move details to the PR body instead.
+4. Fill in the PR body:
+   - **What**: summarize the change in 1-2 sentences
+   - **Why**: explain the problem or user need this solves (link issues with #N if applicable)
+   - **How to test**: write concrete steps a reviewer can follow
+   - **Screenshots / recordings**: include section only if there are UI changes
+   - **Checklist**: include all items, check the ones that apply to this PR
+5. Ask me to confirm or adjust the title and body before creating.
+6. Create the PR with `gh pr create --base <detected-base> --title "..." --body "..."`.
+7. Assign me as assignee with `gh pr edit --add-assignee @me`.
+
+Show me the PR URL when done.

--- a/.opencode/skills/fix-pr-review/SKILL.md
+++ b/.opencode/skills/fix-pr-review/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: fix-pr-review
+description: Fix unresolved PR review comments, reply, and resolve threads
+---
+
+# Fix PR review comments
+
+Address all unresolved review threads on a pull request: fix code, reply to each comment, resolve threads, commit.
+
+**PR number (optional):** `$ARGUMENTS`
+
+## Step 1: Identify the PR, repo, and ensure correct branch
+
+Get repo owner and name:
+
+```bash
+gh repo view --json owner,name -q '"\(.owner.login)/\(.name)"'
+```
+
+Split into OWNER and REPO variables for GraphQL queries.
+
+**If `$ARGUMENTS` is empty** — use the PR associated with the current branch:
+
+```bash
+gh pr view --json number,url -q '.number'
+```
+
+**If `$ARGUMENTS` contains a PR number** — fetch that PR's head branch and switch to it if not already on it:
+
+```bash
+PR_BRANCH=$(gh pr view $ARGUMENTS --json headRefName -q '.headRefName')
+CURRENT_BRANCH=$(git branch --show-current)
+```
+
+If `PR_BRANCH != CURRENT_BRANCH`, checkout the PR branch:
+
+```bash
+git checkout "$PR_BRANCH"
+```
+
+If the branch doesn't exist locally yet:
+
+```bash
+gh pr checkout $ARGUMENTS
+```
+
+## Step 2: Fetch unresolved review threads
+
+Single GraphQL query (substitute OWNER, REPO, PR_NUMBER):
+
+```bash
+gh api graphql -f query='
+query {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(last: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          startLine
+          comments(first: 10) {
+            nodes {
+              id
+              databaseId
+              body
+              author { login }
+              path
+              line
+              startLine
+              originalLine
+              diffHunk
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Filter: keep only threads where `isResolved == false`. Skip `isOutdated == true` threads (code moved, comment no longer applies). If zero unresolved threads remain, report "No unresolved review threads" and stop.
+
+## Step 3: Fix each thread
+
+For each unresolved, non-outdated thread:
+
+1. Read the first comment's `body` to understand what the reviewer wants.
+2. Read subsequent comments in the thread for follow-up context.
+3. Note `path` and `line` (and `startLine` if multi-line).
+4. Read the file at the relevant lines using the Read tool with enough surrounding context.
+5. Determine the fix. If the request is ambiguous or requires a design decision, **skip it** and add to the "needs manual attention" list.
+6. Apply the fix using the Edit tool.
+7. Compose a short, specific reply (1-2 sentences) describing what was changed. Example: "Added sender validation guard matching the pattern from `setMouseIgnore`." Do NOT write generic replies like "Fixed as suggested."
+
+## Step 4: Reply and resolve each thread
+
+For each fixed thread, run both mutations. Use the PR number and `databaseId` of the first comment in the thread for REST reply, or use GraphQL:
+
+**Reply via GraphQL:**
+
+```bash
+gh api graphql -f query='
+mutation {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: "THREAD_ID",
+    body: "REPLY_TEXT"
+  }) {
+    comment { id }
+  }
+}'
+```
+
+**Resolve the thread:**
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {
+    threadId: "THREAD_ID"
+  }) {
+    thread { isResolved }
+  }
+}'
+```
+
+For praise/acknowledgment comments (no code change needed), reply with a brief "Thanks!" and resolve.
+
+**Batch optimization:** if multiple threads can be resolved at once, combine mutations:
+
+```bash
+gh api graphql -f query='
+mutation {
+  a: resolveReviewThread(input: {threadId: "ID1"}) { thread { isResolved } }
+  b: resolveReviewThread(input: {threadId: "ID2"}) { thread { isResolved } }
+}'
+```
+
+## Step 5: Commit and report
+
+Stage only the files modified during this process. Create a single commit:
+
+```
+fix: address PR review feedback
+```
+
+Include a body listing each file and what was changed.
+
+Print summary:
+
+- Threads resolved (count and brief descriptions)
+- Threads skipped as needing manual attention (with reasons)
+- Files modified
+- Remind user to `git push` to update the PR
+
+## Rules
+
+- Do NOT resolve a thread unless you actually fixed the issue or it requires no code change (praise/ack).
+- If a comment is ambiguous, architectural, or you disagree with the approach, skip it and list in report.
+- Escape double quotes, newlines, and backslashes when injecting reply text into GraphQL queries.
+- Use `rg` instead of `grep` and `fd` instead of `find`.
+- Do NOT auto-push. Remind the user to push.

--- a/.opencode/skills/self-review/SKILL.md
+++ b/.opencode/skills/self-review/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: self-review
+description: Code review current changes using project review standards before creating a PR
+---
+
+# Self-review
+
+1. Check for uncommitted changes (`git diff` and `git diff --staged`). If none, diff against base branch (`main` for `hotfix/*`, otherwise `next`).
+2. Read `.github/prompts/code-review.md` for review criteria.
+3. Read each changed file. Apply the review categories. Skip "What NOT to review".
+4. Report issues: file path, line, category, problem, fix.
+5. Summary: one line per category with issue count.

--- a/.opencode/skills/verify/SKILL.md
+++ b/.opencode/skills/verify/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: verify
+description: Run lint, typecheck, and svelte-check to validate the codebase
+---
+
+Run the following commands in sequence. Stop and report on the first failure:
+
+1. `npm run lint` — ESLint check
+2. `npm run typecheck` — TypeScript check (node + svelte)
+
+Report a summary of any errors found. If all pass, confirm the codebase is clean.


### PR DESCRIPTION
## What
Add five OpenCode skills that automate the agent code review workflow: creating issues, creating PRs, fixing PR review comments, self-review before PR, and running lint/typecheck.

## Why
Agents need a standardized way to create GitHub issues and PRs, self-review changes before submission, and validate the codebase. These skills make the workflow consistent and automatic.

## How to test
1. Trigger each skill via conversation (e.g., "create an issue", "create a PR", "self-review", "verify")
2. Confirm the skill executes the corresponding `gh` commands correctly
3. For self-review, verify it diffs against `next` and reports issues per `.github/prompts/code-review.md`

## Checklist
- [x] `chore` — build/tooling changes
- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code refactoring
- [ ] `test` — adding or updating tests
- [ ] `build` — build system or dependency changes
- [ ] `perf` — performance improvements