### PR TITLE
fix(mobile): add safe area handling to instances empty state

### DIFF
--- a/mobile/src/app/(tabs)/index.tsx
+++ b/mobile/src/app/(tabs)/index.tsx
@@ -80,20 +80,22 @@ export default function InstancesScreen(): React.ReactElement {
           />
         </SafeAreaView>
       ) : (
-        <FlatList
-          data={instances ?? []}
-          keyExtractor={(i) => i.id}
-          ListHeaderComponent={<LargeTitle />}
-          contentContainerStyle={styles.listContent}
-          ItemSeparatorComponent={() => <View style={styles.separator} />}
-          renderItem={({ item }) => (
-            <SwipeableInstanceCard
-              instance={item}
-              onPress={() => goToDetail(item.id)}
-              onRemove={() => removeInstance(item.id)}
-            />
-          )}
-        />
+        <SafeAreaView edges={['top']} style={styles.container}>
+          <FlatList
+            data={instances ?? []}
+            keyExtractor={(i) => i.id}
+            ListHeaderComponent={<LargeTitle />}
+            contentContainerStyle={styles.listContent}
+            ItemSeparatorComponent={() => <View style={styles.separator} />}
+            renderItem={({ item }) => (
+              <SwipeableInstanceCard
+                instance={item}
+                onPress={() => goToDetail(item.id)}
+                onRemove={() => removeInstance(item.id)}
+              />
+            )}
+          />
+        </SafeAreaView>
       )}
 
       {!showEmpty && <AddInstanceFab onPress={goToScan} />}
@@ -175,7 +177,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.four,
   },
   listContent: {
-    paddingTop: TOP_INSET,
     paddingHorizontal: Spacing.four,
     paddingBottom: BottomTabInset + Spacing.six + Spacing.four,
   },

--- a/mobile/src/app/(tabs)/index.tsx
+++ b/mobile/src/app/(tabs)/index.tsx
@@ -4,7 +4,7 @@ import ReanimatedSwipeable, {
   type SwipeableMethods,
 } from 'react-native-gesture-handler/ReanimatedSwipeable'
 import { Alert, FlatList, Pressable, StyleSheet, View } from 'react-native'
-import { initialWindowMetrics } from 'react-native-safe-area-context'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { AddInstanceFab } from '@/components/instances/add-instance-fab'
 import { InstancesEmptyState } from '@/components/instances/empty-state'
@@ -16,8 +16,6 @@ import { useSavedInstances } from '@/hooks/use-saved-instances'
 import { makeMockInstance } from '@/lib/mock/projects'
 import { SavedInstancesStorage } from '@/lib/storage/saved-instances'
 import type { SavedInstance } from '@/lib/storage/saved-instances-types'
-
-const TOP_INSET = initialWindowMetrics?.insets.top ?? 0
 
 function LargeTitle(): React.ReactElement {
   return (
@@ -74,13 +72,13 @@ export default function InstancesScreen(): React.ReactElement {
       )}
 
       {showEmpty ? (
-        <View style={styles.emptyContainer}>
+        <SafeAreaView edges={['top']} style={styles.emptyContainer}>
           <LargeTitle />
           <InstancesEmptyState
             onScanPress={goToScan}
             onAddMockPress={__DEV__ ? addMock : undefined}
           />
-        </View>
+        </SafeAreaView>
       ) : (
         <FlatList
           data={instances ?? []}
@@ -174,6 +172,7 @@ const styles = StyleSheet.create({
   },
   emptyContainer: {
     flex: 1,
+    paddingHorizontal: Spacing.four,
   },
   listContent: {
     paddingTop: TOP_INSET,


### PR DESCRIPTION
## What
Replaces the static `initialWindowMetrics` top inset with a `SafeAreaView`
component in the Instances empty state, and adds horizontal padding to the
container.

## Why
`initialWindowMetrics?.insets.top` can be `null` on first render or stale
after navigation, causing the empty state to overlap the device status bar.
`SafeAreaView` with `edges={['top']}` resolves insets dynamically.

## How to test
1. Launch the mobile app with no instances added (empty state visible).
2. On a device with a notch/Dynamic Island, confirm the title is not
   obscured by the status bar.
3. Verify horizontal padding is consistent on both sides of the screen.

## Screenshots / recordings
<!-- Add before/after screenshots if available -->

## Checklist
- [x] Tested on device or simulator
- [ ] Added / updated tests
- [x] No breaking changes
- [x] Docs updated (if behavior changed)