### PR TITLE
feat(mobile): add paste button to terminal

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -17,6 +17,7 @@
         "@xterm/xterm": "^6.0.0",
         "expo": "~55.0.15",
         "expo-camera": "~55.0.15",
+        "expo-clipboard": "~55.0.13",
         "expo-constants": "~55.0.14",
         "expo-dev-client": "~55.0.27",
         "expo-device": "~55.0.15",
@@ -4930,6 +4931,17 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-55.0.13.tgz",
+      "integrity": "sha512-PrOmmuVsGW4bAkNQmGKtxMXj3invsfN+jfIKmQxHwE/dn7ODqwFWviUTa+PMUjP3XZmYCDLyu/i0GLeu7HF9Ew==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -38,6 +38,7 @@
     "@xterm/xterm": "^6.0.0",
     "expo": "~55.0.15",
     "expo-camera": "~55.0.15",
+    "expo-clipboard": "~55.0.13",
     "expo-constants": "~55.0.14",
     "expo-dev-client": "~55.0.27",
     "expo-device": "~55.0.15",

--- a/mobile/src/app/terminal.tsx
+++ b/mobile/src/app/terminal.tsx
@@ -1,3 +1,4 @@
+import * as Clipboard from 'expo-clipboard'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { SymbolView } from 'expo-symbols'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -23,6 +24,7 @@ import {
 } from '@/hooks/use-remote-state'
 import { useSavedInstance } from '@/hooks/use-saved-instances'
 import { useTheme } from '@/hooks/use-theme'
+import { wrapAsBracketedPaste } from '@/lib/pty/paste'
 
 export default function TerminalScreen(): React.ReactElement {
   const { instanceId, worktreePath: encodedPath } = useLocalSearchParams<{
@@ -205,6 +207,32 @@ export default function TerminalScreen(): React.ReactElement {
     }
   }, [])
 
+  // Read the system clipboard, sanitize, wrap in bracketed-paste markers
+  // and ship to the active PTY in one shot. No trailing CR — the user
+  // reviews the pasted prompt and presses Enter themselves.
+  const handlePaste = useCallback(async () => {
+    const api = apiRef.current
+    const sid = sessionIdRef.current
+    if (!api || !sid) return
+    let text = ''
+    try {
+      text = await Clipboard.getStringAsync()
+    } catch {
+      return
+    }
+    if (!text) return
+    try {
+      await api.pty.write(sid, wrapAsBracketedPaste(text))
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (/ActionRejected|rejected/i.test(msg)) {
+        setStreamError('Approve terminal input on desktop to continue')
+      }
+    }
+  }, [])
+
+  const pasteDisabled = !api || !sessionId
+
   const handleTabSelect = useCallback(
     (tabId: string) => {
       setLocalTabId(tabId)
@@ -319,6 +347,34 @@ export default function TerminalScreen(): React.ReactElement {
           onLongPress={api ? handleTabLongPress : undefined}
           onNewTab={api ? () => setPickerVisible(true) : undefined}
         />
+        <View style={[styles.actionBar, { borderTopColor: theme.backgroundElement }]}>
+          <Pressable
+            onPress={handlePaste}
+            disabled={pasteDisabled}
+            style={({ pressed }) => [
+              styles.actionButton,
+              { backgroundColor: theme.backgroundElement },
+              pressed && styles.pressed,
+              pasteDisabled && styles.actionButtonDisabled,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Paste from clipboard"
+          >
+            <SymbolView
+              name={{
+                ios: 'doc.on.clipboard',
+                android: 'content_paste',
+                web: 'content_paste',
+              }}
+              size={14}
+              weight="semibold"
+              tintColor={theme.textSecondary}
+            />
+            <ThemedText type="small" themeColor="textSecondary">
+              Paste
+            </ThemedText>
+          </Pressable>
+        </View>
         {streamError ? (
           <View style={styles.banner}>
             <ThemedText type="small" themeColor="textSecondary">
@@ -438,6 +494,25 @@ const styles = StyleSheet.create({
   },
   pressed: {
     opacity: 0.6,
+  },
+  actionBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.two,
+    paddingHorizontal: Spacing.three,
+    paddingVertical: Spacing.two,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.two,
+    paddingHorizontal: Spacing.three,
+    paddingVertical: Spacing.two,
+    borderRadius: Spacing.three,
+  },
+  actionButtonDisabled: {
+    opacity: 0.4,
   },
   banner: {
     paddingHorizontal: Spacing.four,

--- a/mobile/src/app/terminal.tsx
+++ b/mobile/src/app/terminal.tsx
@@ -179,22 +179,33 @@ export default function TerminalScreen(): React.ReactElement {
     }
   }, [api, sessionId, scheduleFlush])
 
+  // Translate a thrown api.pty.write error into a user-facing banner.
+  // Keyboard strokes, paste, and any future write path (drag-and-drop,
+  // shortcut macros) funnel through here so the brittle regex-against-
+  // error-message check lives in exactly one place.
+  const handleWriteError = useCallback((err: unknown): void => {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (/ActionRejected|rejected/i.test(msg)) {
+      setStreamError('Approve terminal input on desktop to continue')
+    }
+  }, [])
+
   // Stable forever — read api/sessionId from refs so switching tabs doesn't
   // invalidate these callbacks and rebuild the xterm via terminal-view's
   // internal useEffect.
-  const onInput = useCallback(async (data: string) => {
-    const api = apiRef.current
-    const sid = sessionIdRef.current
-    if (!api || !sid) return
-    try {
-      await api.pty.write(sid, data)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      if (/ActionRejected|rejected/i.test(msg)) {
-        setStreamError('Approve terminal input on desktop to continue')
+  const onInput = useCallback(
+    async (data: string) => {
+      const api = apiRef.current
+      const sid = sessionIdRef.current
+      if (!api || !sid) return
+      try {
+        await api.pty.write(sid, data)
+      } catch (err) {
+        handleWriteError(err)
       }
-    }
-  }, [])
+    },
+    [handleWriteError],
+  )
 
   const onResize = useCallback(async (cols: number, rows: number) => {
     const api = apiRef.current
@@ -217,19 +228,21 @@ export default function TerminalScreen(): React.ReactElement {
     let text = ''
     try {
       text = await Clipboard.getStringAsync()
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setStreamError(`Could not read clipboard: ${msg}`)
       return
     }
-    if (!text) return
+    if (!text) {
+      setStreamError('Clipboard is empty')
+      return
+    }
     try {
       await api.pty.write(sid, wrapAsBracketedPaste(text))
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      if (/ActionRejected|rejected/i.test(msg)) {
-        setStreamError('Approve terminal input on desktop to continue')
-      }
+      handleWriteError(err)
     }
-  }, [])
+  }, [handleWriteError])
 
   const pasteDisabled = !api || !sessionId
 

--- a/mobile/src/lib/pty/paste.ts
+++ b/mobile/src/lib/pty/paste.ts
@@ -1,0 +1,37 @@
+// eslint-disable-next-line no-control-regex
+const BRACKETED_PASTE_END = /\x1b\[201~/g
+
+/**
+ * Strip C0 control characters (keep \n 0x0A and \t 0x09) and ANSI CSI
+ * sequences. Used before piping arbitrary text into a PTY so stray control
+ * bytes can't hijack the terminal.
+ */
+export function sanitizePtyInput(text: string): string {
+  let result = ''
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i)
+    if (code === 0x1b && text[i + 1] === '[') {
+      let j = i + 2
+      while (j < text.length && !/[a-zA-Z]/.test(text[j])) j++
+      i = j
+      continue
+    }
+    if (code < 0x20 && code !== 0x0a && code !== 0x09) continue
+    if (code === 0x7f) continue
+    result += text[i]
+  }
+  return result
+}
+
+/**
+ * Wrap text in bracketed-paste markers so the CLI on the other end of the
+ * PTY treats multi-chunk arrivals as one paste instead of firing its
+ * line-at-a-time / timing-based input handlers on the fragments.
+ *
+ * Any stray `\x1b[201~` inside the content is stripped first — it would
+ * otherwise terminate the paste early.
+ */
+export function wrapAsBracketedPaste(text: string): string {
+  const sanitised = sanitizePtyInput(text).replace(BRACKETED_PASTE_END, '')
+  return `\x1b[200~${sanitised}\x1b[201~`
+}

--- a/mobile/src/lib/pty/paste.ts
+++ b/mobile/src/lib/pty/paste.ts
@@ -1,3 +1,9 @@
+// KEEP IN SYNC with `src/renderer/src/lib/pty/paste.ts`. Mobile is a
+// separate Expo workspace and can't import from the renderer, so the
+// sanitizer + bracketed-paste wrapper is duplicated here. Any fix to
+// one file (e.g. widening the CSI final-byte set in sanitizePtyInput)
+// must be applied to the other.
+
 // eslint-disable-next-line no-control-regex
 const BRACKETED_PASTE_END = /\x1b\[201~/g
 

--- a/src/renderer/src/lib/pty/paste.ts
+++ b/src/renderer/src/lib/pty/paste.ts
@@ -1,3 +1,9 @@
+// KEEP IN SYNC with `mobile/src/lib/pty/paste.ts`. The mobile Expo
+// workspace can't import from the renderer, so the sanitizer +
+// bracketed-paste wrapper is duplicated there. Any fix to one file
+// (e.g. widening the CSI final-byte set in sanitizePtyInput) must be
+// applied to the other.
+
 // eslint-disable-next-line no-control-regex
 const BRACKETED_PASTE_END = /\x1b\[201~/g
 


### PR DESCRIPTION
## What

Add a Paste button to the mobile terminal screen. Tapping reads the OS clipboard via `expo-clipboard`, sanitizes C0/CSI control bytes, wraps the text in bracketed-paste markers (`\x1b[200~...\x1b[201~`) and writes to the active PTY via the existing `pty.write` RPC. No trailing `\r` — the user reviews and presses Enter.

## Why

Mobile had no way to paste text into a PTY session — users pasting commands or task context on the go had to retype everything. Mirrors the bracketed-paste approach the desktop task picker, branch create form, and diff pane already use.

## How to test

1. `cd mobile && npm install` (pulls in `expo-clipboard`).
2. Rebuild dev client: `npm run build:sim` (native module, OTA won't pick it up).
3. Open a terminal tab with an active session.
4. Copy multi-line text from Notes/Safari. Tap Paste → all lines land as a single paste on the prompt; cursor does NOT auto-execute. Press Enter to submit.
5. Copy text containing literal `\x1b[201~` → paste does not terminate early.
6. Close all tabs in the worktree → Paste button disabled.
7. With action-guard rejecting terminal input on desktop, Paste → banner shows "Approve terminal input on desktop to continue".
8. Paste with keyboard closed (main requirement) works; with keyboard open, bar stays visible above terminal.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly
- [ ] Feature docs in `docs/` updated (behavior, config, errors, security — if any changed)