### PR TITLE
fix(terminal): prevent buffer corruption on tab switch

### DIFF
--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -336,7 +336,16 @@
             dims.rows >= 3 &&
             (dims.cols !== t.cols || dims.rows !== t.rows)
           ) {
+            const buffer = t.buffer.active
+            const isAtBottom = buffer.viewportY >= buffer.baseY
+            const savedY = buffer.viewportY
             fit.fit()
+            if (!isAtBottom) {
+              const currentY = t.buffer.active.viewportY
+              if (currentY !== savedY) {
+                t.scrollLines(savedY - currentY)
+              }
+            }
           }
         }
         t.refresh(0, t.rows - 1)

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -39,6 +39,7 @@
 
   let containerEl: HTMLDivElement
   let termRef: Terminal | null = null
+  let fitAddonRef: FitAddon | null = null
   let wsRef: WebSocket | null = null
   let webglAddonRef: WebglAddon | null = null
   let webglAttached = $state(false)
@@ -59,7 +60,6 @@
 
   const MAX_RECONNECT_ATTEMPTS = 30
   const MAX_RECONNECT_DELAY = 8000
-  const MAX_PENDING_CHARS = 2 * 1024 * 1024 // ~2 MB for ASCII
 
   function attachWebgl(term: Terminal): void {
     if (webglAddonRef) return
@@ -248,11 +248,11 @@
       const chunk = typeof e.data === 'string' ? e.data : String(e.data)
       receivedChars += chunk.length
       pendingData += chunk
-      if (pendingData.length > MAX_PENDING_CHARS) {
-        pendingData = pendingData.slice(-MAX_PENDING_CHARS)
-      }
-      // Only schedule writes when the pane is visible
-      if (visible && !writeScheduled) {
+      // Always write through to xterm regardless of visibility. Gating on
+      // `visible` let pendingData accumulate while hidden and replay after
+      // show; with a bounded cap the head got truncated and deltas were
+      // applied to a stale buffer (overlapping / row-shifted TUI output).
+      if (!writeScheduled) {
         writeScheduled = true
         writeRafId = requestAnimationFrame(() => {
           writeRafId = null
@@ -315,13 +315,35 @@
     if (!termRef) return
     const term = termRef
     if (visible) {
-      // Becoming visible: ensure WS is connected and flush buffered output
+      // Becoming visible: ensure WS is connected and flush any in-flight batch.
       connectWs(term)
       flushPendingData(term)
-    } else {
-      // Becoming hidden: cancel pending RAF writes but keep WS connected
-      // so background output is still buffered via receivedChars/pendingData
-      cancelPendingWrite()
+      // The container was `display:none` while hidden, so the xterm renderer
+      // and ResizeObserver saw no meaningful dimensions. Now that layout is
+      // back, refit if needed, force a full repaint to drop any stale canvas
+      // state, and re-assert PTY size in case the window was resized while
+      // this tab was hidden. Deferred a frame so the browser has finished
+      // laying out the now-visible container.
+      requestAnimationFrame(() => {
+        if (disposed || !containerEl || !termRef) return
+        const t = termRef
+        const fit = fitAddonRef
+        if (fit && containerEl.clientWidth && containerEl.clientHeight) {
+          const dims = fit.proposeDimensions()
+          if (
+            dims &&
+            dims.cols >= 10 &&
+            dims.rows >= 3 &&
+            (dims.cols !== t.cols || dims.rows !== t.rows)
+          ) {
+            fit.fit()
+          }
+        }
+        t.refresh(0, t.rows - 1)
+        if (t.cols > 0 && t.rows > 0) {
+          window.api.resizePty(sessionId, t.cols, t.rows)
+        }
+      })
     }
   })
 
@@ -350,6 +372,7 @@
       })
 
       const fitAddon = new FitAddon()
+      fitAddonRef = fitAddon
       const ligaturesAddon = new LigaturesAddon()
       const progressAddon = new ProgressAddon()
       term.open(containerEl)
@@ -539,6 +562,7 @@
       if (dataDisposable) dataDisposable.dispose()
       const term = termRef
       termRef = null
+      fitAddonRef = null
       if (resizeDebounceTimer !== null) clearTimeout(resizeDebounceTimer)
       if (resizeObserver) resizeObserver.disconnect()
       if (webglAddonRef) {


### PR DESCRIPTION
## What

Write PTY output through to xterm regardless of tab visibility, and resync the renderer + PTY dimensions when a hidden tab becomes visible.

## Why

Hidden tabs queued PTY output in a 2 MB `pendingData` string instead of applying it to xterm. When a long-running TUI (e.g. lazygit) exceeded the cap, the head was silently truncated — on show, xterm replayed incremental cursor-positioning deltas onto a stale buffer, producing overlapping / row-shifted text. Window resize masked the bug because TUIs full-redraw on SIGWINCH.

`ResizeObserver` on a `display:none` container also never saw a size change, so a window resize while a tab was hidden left xterm's cols/rows out of sync with the new viewport on show.

## How to test

1. `npm run dev`
2. Open two terminal tabs. In tab A run `lazygit`.
3. Switch to tab B, idle for ~1 minute (or run a command that emits a lot of output).
4. Switch back to tab A — LazyGit renders cleanly, no row shift or text overlap, no window resize needed.
5. Rapidly switch tabs 10+ times — stays clean.
6. Repeat with `vim`, `htop`, `claude`.
7. Resize the window while tab A is hidden, then switch back — content should match the new window size.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [x] Non-core feature is behind a feature flag (off by default) — N/A, bug fix
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows \`feature:action\` naming and uses \`invoke\`/\`handle\` — N/A
- [x] Renderer code does not import Node.js modules directly
- [ ] Feature docs in \`docs/\` updated — N/A, no user-visible behavior change