### PR TITLE
fix(notch): restore mouse passthrough during peek notification

### DIFF
--- a/src/renderer/src/components/notch/NotchOverlay.svelte
+++ b/src/renderer/src/components/notch/NotchOverlay.svelte
@@ -44,7 +44,6 @@
 
       if (s.peekSessionIds && s.peekSessionIds.length > 0 && !isHovered) {
         for (const id of s.peekSessionIds) peekSessionIds.add(id)
-        window.notchApi.setMouseIgnore(false)
 
         if (peekTimer) clearTimeout(peekTimer)
         peekTimer = setTimeout(() => {
@@ -118,7 +117,7 @@
         peekLocked = false
         peekSessionIds.clear()
       }
-      if (!isPeeking) window.notchApi.setMouseIgnore(true)
+      window.notchApi.setMouseIgnore(true)
       collapseTimer = null
     }, 300)
   }


### PR DESCRIPTION
## What

Removes the unconditional `setIgnoreMouseEvents(false)` call that fired on every peek notification, and drops the `isPeeking` guard that prevented passthrough from being restored on mouseleave.

## Why

On macOS, `setIgnoreMouseEvents(false)` makes the **entire** window rect (560×650px) capture mouse events — including fully transparent areas. This blocked all user input across the notch overlay for up to 4 seconds on every agent status notification peek.

The fix relies on the fact that `{ forward: true }` already forwards `mousemove`/`mouseenter`/`mouseleave` to the renderer while events are ignored. Hover detection therefore works without flipping `setIgnoreMouseEvents` to false — that only needs to happen when the cursor is actually over the island (handled by `handleMouseEnter`).

## How to test

1. Open the app with an active agent session so the notch shows.
2. Trigger a peek-worthy event (agent completes, hits an error, or requests permission).
3. While the notification peeks (4 s window): click anywhere **below** the notification in the transparent overlay area — the click should reach the window behind it normally.
4. Move cursor over the notification island while it's peeking — it should expand and be interactive.
5. Click a notification row while hovering → session focuses correctly.
6. Move cursor off the island while peek is still active → clicks in the transparent area pass through immediately.

## Screenshots / recordings

UI-only behaviour change (no visual difference in the notification itself).

## Checklist

- [x] Tested manually on macOS
- [ ] Tested on Windows
- [x] No new dependencies
- [x] Follows existing code patterns