### PR TITLE
fix(browser): restore autofill click + reload prompt under Electron 41

### DIFF
--- a/docs/integrations/browser.md
+++ b/docs/integrations/browser.md
@@ -49,6 +49,16 @@ The browser webview intercepts Cmd/Ctrl keyboard shortcuts to prevent them from 
 - **Cmd+R**: Reloads the page within the webview (handled locally, not forwarded).
 - **App shortcuts** (Cmd+W, Cmd+T, Cmd+K, Cmd+B, Cmd+D, Cmd+L, Cmd+O, Cmd+1-9, Cmd+Shift+I, Cmd+Shift+N, Cmd+comma): The webview consumes the event, refocuses the main renderer, and re-dispatches the keystroke so the app handles it.
 
+### Beforeunload prompt
+
+When the page sets a `beforeunload` handler that returns a non-empty value (editors, forms with unsaved input) and the user reloads or navigates away, Electron emits `will-prevent-unload` on the webview's `WebContents`. Without a listener Electron silently cancels the reload, so Cmd+R appears dead. `BrowserManager.setup()` registers a listener that shows a native system modal:
+
+- **Title / message:** `Leave site?`
+- **Detail:** `Changes you made may not be saved.`
+- **Buttons:** `Leave` (allows the unload) / `Stay` (cancels). `Stay` is the default for both Enter and Esc, matching Chrome and matching the password-reveal confirmation elsewhere in the repo.
+
+The page's `event.returnValue` text is intentionally not surfaced — Chrome, Firefox, and Safari have ignored per-site custom messages since ~2017 as a phishing mitigation, and Electron has no built-in browser-style prompt for this event. Note that in `will-prevent-unload`, calling `event.preventDefault()` means **allow the unload** (inverted from the DOM convention) — picking _Leave_ in the modal is what triggers `preventDefault()`.
+
 ### DevTools
 
 1. User opens DevTools via the toolbar button, context menu "Inspect Element", or keyboard shortcut.
@@ -88,6 +98,8 @@ Users can add custom viewport presets stored in the `viewports.custom` preferenc
    - Locates the nearest username field within the same form (by type `email`/`text` or name attributes containing `user`/`email`/`login`, or `autocomplete="username"`).
    - Sets values on both fields and dispatches `input` and `change` events with `bubbles: true` so frameworks detect the change.
 5. The isolated world prevents page scripts from intercepting the injected values.
+
+The autofill click in the picker, the capture-on-submit signal, and the password-field detection all reach the renderer over `console.log` markers (`__CANOPY_FILL__:<id>`, `__CANOPY_CREDS_READY__`, `__CANOPY_PW_FIELD_FOUND__`) consumed by the webview's `console-message` event. The renderer reads the payload defensively because Electron 35+ may deliver the message string directly on the event, nested inside the event (`e.message.message`), or on `e.detail.message`. If a future Electron upgrade reshapes the event again, that handler is the place to update.
 
 ### Screenshot capture
 
@@ -135,6 +147,7 @@ When a browser tab is closed, the renderer calls `teardownBrowserWebview(browser
 | Blocked permission     | Nothing (silently denied)                              | Page requested camera, microphone, geolocation, or other permissions |
 | DevTools view creation | DevTools button has no effect                          | `WebContents` for the webview guest could not be found               |
 | Favicon fetch failure  | Tab shows no favicon                                   | CORS error, network error, or invalid favicon URL                    |
+| Beforeunload prompt    | Native `Leave site? / Stay` modal (Stay default)       | Page set a `beforeunload` handler and the user reloaded or navigated |
 
 ## Security and privacy
 

--- a/src/main/browser/BrowserManager.ts
+++ b/src/main/browser/BrowserManager.ts
@@ -1,4 +1,4 @@
-import { webContents, WebContentsView, Menu, session, type BrowserWindow } from 'electron'
+import { webContents, WebContentsView, Menu, dialog, session, type BrowserWindow } from 'electron'
 import type { WebContents } from 'electron'
 import { join } from 'path'
 import { writeFileSync } from 'fs'
@@ -125,6 +125,28 @@ export class BrowserManager {
         // Invalid URL, ignore
       }
       return { action: 'deny' }
+    })
+
+    // Mirror Chrome's beforeunload behavior. Electron has no built-in
+    // beforeunload prompt: without a listener, the reload is silently
+    // cancelled; with `preventDefault()` it proceeds without any prompt
+    // and the user loses unsaved work. We show the same generic dialog
+    // every modern browser shows — the page's `event.returnValue` text
+    // has been ignored by Chrome / Firefox / Safari since ~2017 as a
+    // phishing mitigation, so a custom per-site message isn't possible.
+    // In this event, `preventDefault()` means "allow the unload"
+    // (inverted from the DOM convention).
+    wc.on('will-prevent-unload', (event) => {
+      const choice = dialog.showMessageBoxSync(win, {
+        type: 'question',
+        buttons: ['Leave', 'Stay'],
+        defaultId: 0,
+        cancelId: 1,
+        title: 'Reload site?',
+        message: 'Leave site?',
+        detail: 'Changes you made may not be saved.',
+      })
+      if (choice === 0) event.preventDefault()
     })
 
     // Only allow http(s) navigation

--- a/src/main/browser/BrowserManager.ts
+++ b/src/main/browser/BrowserManager.ts
@@ -136,13 +136,18 @@ export class BrowserManager {
     // phishing mitigation, so a custom per-site message isn't possible.
     // In this event, `preventDefault()` means "allow the unload"
     // (inverted from the DOM convention).
+    // Default to Stay so an accidental Enter after Cmd+R doesn't discard
+    // the user's work — same as Chrome's beforeunload prompt and the
+    // password-reveal confirmation elsewhere in this repo. The event
+    // fires for reloads and navigations alike (Electron doesn't
+    // distinguish), so title and message stay identical.
     wc.on('will-prevent-unload', (event) => {
       const choice = dialog.showMessageBoxSync(win, {
         type: 'question',
         buttons: ['Leave', 'Stay'],
-        defaultId: 0,
+        defaultId: 1,
         cancelId: 1,
-        title: 'Reload site?',
+        title: 'Leave site?',
         message: 'Leave site?',
         detail: 'Changes you made may not be saved.',
       })

--- a/src/renderer/src/components/browser/BrowserPane.svelte
+++ b/src/renderer/src/components/browser/BrowserPane.svelte
@@ -959,8 +959,26 @@
     const onWebviewFocus = (): void => onFocus?.()
 
     const onConsoleMessage = (e: Event): void => {
-      const msg = (e as CustomEvent & { message: string }).message
-      if (typeof msg !== 'string') return
+      // Electron 35+ changed `console-message` so the message can be delivered
+      // either directly on the event (e.message: string), nested in a details
+      // object (e.message: { message: string, level, lineNumber, … }), or in
+      // CustomEvent.detail. Cover all three so `__CANOPY_*` IPC channels keep
+      // working across upgrades.
+      const evt = e as Event & {
+        message?: unknown
+        detail?: { message?: unknown }
+      }
+      let msg: string | undefined
+      if (typeof evt.message === 'string') {
+        msg = evt.message
+      } else if (evt.message && typeof evt.message === 'object') {
+        const nested = (evt.message as { message?: unknown }).message
+        if (typeof nested === 'string') msg = nested
+      }
+      if (msg === undefined && evt.detail && typeof evt.detail.message === 'string') {
+        msg = evt.detail.message
+      }
+      if (msg === undefined) return
       match(msg)
         .with('__CANOPY_CREDS_READY__', () => {
           w.executeJavaScript(


### PR DESCRIPTION
## What

Two related regressions that surfaced after the upgrade to Electron 41:
clicking a saved credential in the browser pane's autofill picker, and pressing **Cmd/Ctrl+R** (or the toolbar reload) on pages with a `beforeunload` handler. Closes #189.

## Why

- Electron 35 reshaped the `<webview>` `console-message` event. The renderer's single listener for `__CANOPY_*` IPC channels (`__CANOPY_FILL__`, `__CANOPY_CREDS_READY__`, `__CANOPY_NAV__`, `__CANOPY_PW_FIELD_FOUND__`) silently rejected the new payload, breaking autofill click, capture-on-submit, mouse back/forward, and password-field detection.
- Electron has no built-in `beforeunload` prompt. Without a `will-prevent-unload` listener, every reload on a page that returns from `beforeunload` was silently cancelled — Cmd+R looked dead. We now show the same generic dialog Chrome / Firefox / Safari show ("Leave site? Changes you made may not be saved."). Per-site custom text is intentionally not surfaced — every modern browser has ignored it since ~2017 as a phishing mitigation.

## How to test

### Autofill click

1. In Settings → Saved Logins, add a credential for any site (or capture one via the in-page banner on the next login).
2. Open the browser pane (`Cmd/Ctrl+T` → browser tab) and navigate to that site's login page.
3. Click the small key icon that appears next to the password field. Confirm the dropdown lists the saved accounts.
4. Click an account. **Expected:** username and password fields fill in immediately and the dropdown closes.

### Capture on submit (same console-message channel)

1. Log in to a new site with credentials Canopy doesn't have. The "Save password?" prompt should appear after submit.

### Mouse back / forward (same channel)

1. Navigate forward a couple of pages in the browser pane.
2. Press the mouse's back / forward buttons (or trackpad equivalents) — webview should navigate.

### Reload prompt

1. Open the browser pane, navigate to a page that runs `window.addEventListener('beforeunload', e => e.returnValue = '')` (e.g. an editing UI like Google Docs while typing, or a form with `<input>` changes that pages register).
2. Press **Cmd/Ctrl+R** or click the reload button in the toolbar.
3. **Expected:** native dialog "Leave site? Changes you made may not be saved." with **Leave** / **Stay** buttons.
   - **Leave** → page reloads.
   - **Stay** → page stays, no reload.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run svelte-check` passes
- [x] `npm run build` passes
- [x] Tested manually on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
