### PR TITLE
fix(mobile): patch dependabot alerts via npm overrides

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3515,9 +3515,9 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -7811,9 +7811,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7830,7 +7830,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9646,12 +9646,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -72,6 +72,11 @@
     "@types/react": "~19.2.2",
     "typescript": "~5.9.2"
   },
+  "overrides": {
+    "@xmldom/xmldom": "^0.8.13",
+    "postcss": "^8.5.10",
+    "uuid": "^14.0.0"
+  },
   "private": true,
   "volta": {
     "node": "22.20.0"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -75,7 +75,9 @@
   "overrides": {
     "@xmldom/xmldom": "^0.8.13",
     "postcss": "^8.5.10",
-    "uuid": "^14.0.0"
+    "xcode": {
+      "uuid": "^14.0.0"
+    }
   },
   "private": true,
   "volta": {


### PR DESCRIPTION
## What
Adds `npm overrides` to `mobile/package.json` to force patched versions of three transitive dependencies flagged by Dependabot:

| Package | From | To | Severity | Alerts |
|---|---|---|---|---|
| @xmldom/xmldom | 0.8.12 | ^0.8.13 | High (×4) | #9, #12, #13, #15 |
| postcss | 8.4.49 | ^8.5.10 | Moderate | #17 |
| uuid (under `xcode`) | 7.0.3 | ^14.0.0 | Moderate | #16 |

The `uuid` override is scoped to the `xcode` subtree (its only consumer) so the major bump can't leak into other dependencies.

## Why
Six open Dependabot alerts on `mobile/package-lock.json` (4 High, 2 Moderate). All are transitive — none of these packages are direct dependencies of the mobile app — so a regular bump isn't possible; overrides are the standard fix for transitive vulnerabilities.

After install, `npm audit` reports 0 vulnerabilities and `npm ls` confirms all three are `overridden` in the dep tree.

## Test plan
- [x] `cd mobile && npm install` succeeds
- [x] `npm ls @xmldom/xmldom uuid postcss` shows overridden patched versions
- [x] `npm audit` clean
- [ ] EAS iOS prebuild succeeds (validates `xcode` still works with `uuid@14`)