### PR TITLE
refactor(ui): app-wide reskin to unify design language

### DIFF
--- a/docs/core/welcome-dashboard.md
+++ b/docs/core/welcome-dashboard.md
@@ -1,0 +1,93 @@
+# Welcome dashboard
+
+> Picker shown when no project is open, listing recent workspaces and offering ways to open a new one.
+
+**Status:** Stable
+**Introduced:** v0.13.0 (current redesign)
+**Platforms:** All
+
+## Overview
+
+The welcome dashboard is the empty-state surface rendered by `MainLayout` when no projects are attached and no tabs are open. It serves two roles: a fast picker for returning users (filter + keyboard navigation over recent workspaces) and a clear entry point for new users or after detaching the last project (dedicated empty state with an auto-focused Open Folder action).
+
+Recent workspaces are sourced from the workspace database. The first three git repos are refreshed in the background after mount so branch, dirty status, ahead/behind, and worktree count reflect current disk state without blocking the initial render.
+
+## Behavior
+
+### Populated state
+
+Rendered when one or more workspaces are present in the database.
+
+1. Top row shows a small "CANOPY" wordmark and shortcut hints (`⌘O` / `Ctrl O` open, `/` filter when filter is shown).
+2. Filter input appears only when more than 4 recents exist, mirroring the search affordance from app preferences. Matches against workspace name, path, and cached branch (case-insensitive substring).
+3. The "Recent" section header shows a count: `N` total, or `N / total` while filtering.
+4. Each row shows: name, branch, dirty marker (`*`), ahead/behind indicators (`↑`/`↓`), absolute path (mono, truncated with full path in `title` tooltip), and either worktree count or relative-time stamp.
+5. Footer holds Open Folder and Open from Path actions plus a keyboard hint row.
+
+### Empty state
+
+Rendered when no workspaces exist (fresh install or after detaching the last project).
+
+1. Large Canopy wordmark and one-line tagline.
+2. Primary `Open Folder` button auto-focused on mount, with `⌘O` / `Ctrl O` kbd hint embedded in the button.
+3. Secondary `Open from Path…` text-button below.
+
+### Keyboard navigation
+
+The dashboard uses a roving-tabindex listbox pattern. On mount with recents, the first row is focused so the user can start navigating immediately.
+
+| Key                     | Action                                                                                 |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `↑` / `↓`               | Move selection (focus follows when on a row).                                          |
+| `PageUp` / `PageDown`   | Jump 5 rows.                                                                           |
+| `Home` / `End`          | Jump to first / last (only when on a row, not while typing in filter).                 |
+| `Enter`                 | Open the selected workspace (works from both filter and row).                          |
+| `/`                     | Focus and select the filter input (only when filter is shown).                         |
+| Any printable character | When focused on a row and filter is empty, switches focus to filter and starts typing. |
+| `Esc`                   | Clears the filter when non-empty; otherwise moves focus from filter back to the list.  |
+| `⌘⌫` / `Ctrl+Backspace` | Remove the selected workspace from recents (with confirm dialog).                      |
+
+Navigation keys are scoped to the filter input and row buttons, so `Enter` on Open Folder / Open from Path activates those buttons normally instead of opening a workspace.
+
+### Recent-workspace context menu
+
+Right-clicking a row opens a small context menu with three actions:
+
+- **Show in Finder / Show in File Manager** — platform-resolved label via `fileManagerLabel()`; calls `window.api.showInFolder(path)`.
+- **Copy Path** — writes the absolute path to the clipboard.
+- **Remove from Recent** — confirmation-dialog-gated removal via `window.api.removeWorkspace(id)`.
+
+`Escape` closes the menu.
+
+### Background git refresh
+
+After the initial DB query, the first 3 git workspaces are refreshed sequentially via `window.api.refreshWorkspaceGitStatus(id, path)`. Failures (path moved/deleted) are swallowed silently — the dashboard still renders the cached row. The refresh loop checks a `disposed` flag so it stops cleanly if the dashboard unmounts (project attached) before it finishes.
+
+### Returning to the dashboard
+
+`MainLayout` renders the dashboard only when `projects.length === 0 && allTabs.length === 0`. When the user detaches the last project (`detachProject` in `workspace.svelte.ts`), every owned tab key is removed from `tabsByWorktree` — including stale or symlink-normalized keys under the repo root — and a `killAllTabs()` safety net runs if any entries remain. This guarantees `allTabs` is empty so the dashboard re-mounts.
+
+## Configuration
+
+No user-facing preferences. Recent count is hard-coded to 20 entries on initial load; the filter affordance is hard-gated to `workspaces.length > 4`.
+
+## Error states
+
+- `listWorkspaces` failure: dashboard shows the empty state (it relies on the resolved array being empty rather than a thrown error path; the IPC handler returns `[]` on failure).
+- `refreshWorkspaceGitStatus` failure for a recent row: silently caught — the row keeps its cached values.
+- `removeWorkspace` IPC failure: the row is still removed from the local list because the call is awaited only for the side-effect; subsequent reloads will reconcile.
+
+## Security / Privacy
+
+Recent paths are stored locally in the workspace SQLite database and never transmitted. `Copy Path` writes to the system clipboard only on explicit user click. The `prompt()` dialog used by Open from Path does not validate filesystem access; downstream `openWorkspace()` is responsible for handling missing or unreadable directories.
+
+## Source files
+
+- `src/renderer/src/components/dashboard/WelcomeDashboard.svelte` — orchestration: data fetch, keyboard handler, context menu state.
+- `src/renderer/src/components/dashboard/_partials/WelcomeEmpty.svelte` — empty state hero.
+- `src/renderer/src/components/dashboard/_partials/WelcomeRecents.svelte` — populated state (header, filter input, list, footer).
+- `src/renderer/src/components/dashboard/_partials/RecentRow.svelte` — single row markup with branch/path/metadata.
+- `src/renderer/src/components/dashboard/_partials/WelcomeContextMenu.svelte` — right-click menu.
+- `src/renderer/src/components/layout/MainLayout.svelte` — mount site (`projects.length === 0 && allTabs.length === 0`).
+- `src/renderer/src/lib/stores/workspace.svelte.ts` — `detachProject` cleanup that ensures the dashboard re-mounts after the last project is removed.
+- `src/preload/index.ts` — IPC surface used: `listWorkspaces`, `refreshWorkspaceGitStatus`, `removeWorkspace`, `openFolder`, `showInFolder`.

--- a/docs/features/file-editor.md
+++ b/docs/features/file-editor.md
@@ -157,16 +157,22 @@ A pane with zero files after a merge/detach is not restored.
 
 ## IPC surface
 
-| Handler                        | Purpose                                                                    |
-| ------------------------------ | -------------------------------------------------------------------------- |
-| `fs:readFile`                  | Bounded read (up to 10 MB hard cap), binary detection, truncation flag.    |
-| `fs:writeFile`                 | Writes UTF-8, optionally gated by `expectedMtimeMs` to detect stale saves. |
-| `fs:stat`                      | Returns `{ mtimeMs, size, canWrite }`.                                     |
-| `dialog:confirmUnsavedChanges` | Native 3-way dialog (Save / Don't Save / Cancel) used by `closeTab`.       |
+| Handler                        | Purpose                                                                               |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| `fs:readFile`                  | Bounded read (up to 10 MB hard cap), binary detection, truncation flag.               |
+| `fs:writeFile`                 | Writes UTF-8, optionally gated by `expectedMtimeMs` to detect stale saves.            |
+| `fs:stat`                      | Returns `{ mtimeMs, size, canWrite }`.                                                |
+| `fs:createFile`                | Creates an empty file (`wx` flag), creating parent dirs as needed. Used by file tree. |
+| `fs:mkdir`                     | Recursively creates a directory. Used by file tree.                                   |
+| `dialog:confirmUnsavedChanges` | Native 3-way dialog (Save / Don't Save / Cancel) used by `closeTab`.                  |
 
-All three validate `filePath` through `validatePathAccess(senderId, path)`
-which resolves symlinks and rejects anything outside the renderer's
-workspace roots.
+Read/write/stat handlers validate `filePath` through `validatePathAccess`,
+which calls `fs.realpath` on the target and rejects anything outside the
+renderer's workspace roots. Create handlers (`fs:createFile`, `fs:mkdir`)
+use `validateCreationPath`, which walks up to the closest existing ancestor,
+runs `validatePathAccess` against it, and rejects tails that escape via
+`..` or absolute references — needed because the target itself does not
+yet exist and `realpath` would fail with `ENOENT`.
 
 ## Keyboard shortcuts
 

--- a/docs/features/settings-export.md
+++ b/docs/features/settings-export.md
@@ -130,7 +130,7 @@ All errors surface to the renderer as thrown `Error`s from the IPC handlers, cau
 
 ## Configuration
 
-Backup & Restore has no user-configurable options. The Export and Import actions live in the Settings sidebar footer (icon-buttons next to the version label).
+Backup & Restore has no user-configurable options. The Export and Import actions live in the Settings sidebar footer, next to the **Backup** label.
 
 ## Source files
 

--- a/docs/features/settings-export.md
+++ b/docs/features/settings-export.md
@@ -17,7 +17,7 @@ Export is a merge-friendly operation: import upserts rows by natural key (`key` 
 
 ### Export
 
-1. User opens Preferences → General → Backup & Restore → **Export Settings…**
+1. User opens Settings and clicks the **Export** icon in the sidebar footer.
 2. A confirmation dialog warns that the file will contain plaintext API keys and tokens. The user either confirms or cancels.
 3. On confirm, the main process presents a native Save dialog (`dialog.showSaveDialog`) pre-filled with `canopy-settings-YYYY-MM-DD.json`.
 4. `SettingsExportService.buildExport()` reads every exportable preference (decrypting encrypted keys with `safeStorage`), every agent profile (with decrypted `apiKey`), every credential (with decrypted password), and every `is_custom = 1` tool definition.
@@ -26,7 +26,7 @@ Export is a merge-friendly operation: import upserts rows by natural key (`key` 
 
 ### Import
 
-1. User opens Preferences → General → Backup & Restore → **Import Settings…**
+1. User opens Settings and clicks the **Import** icon in the sidebar footer.
 2. A confirmation dialog warns that existing matching entries will be overwritten. The user either confirms or cancels.
 3. On confirm, the main process presents a native Open dialog filtered to `.json` files.
 4. The file is read, `JSON.parse`'d, and handed to `SettingsExportService.applyImport()`.
@@ -130,7 +130,7 @@ All errors surface to the renderer as thrown `Error`s from the IPC handlers, cau
 
 ## Configuration
 
-Backup & Restore has no user-configurable options. The Export and Import actions live under Preferences → General → Backup & Restore.
+Backup & Restore has no user-configurable options. The Export and Import actions live in the Settings sidebar footer (icon-buttons next to the version label).
 
 ## Source files
 
@@ -140,4 +140,4 @@ Backup & Restore has no user-configurable options. The Export and Import actions
 - Store helpers: `src/main/db/PreferencesStore.ts` (`getAllDecrypted`, `setMany`, `NON_EXPORTABLE_KEYS`), `src/main/profiles/ProfileStore.ts` (`listInternal`, `upsertForImport`), `src/main/db/CredentialStore.ts` (`listInternalDecrypted`, `upsertForImport`), `src/main/tools/ToolRegistry.ts` (`listCustom`, `upsertCustomForImport`)
 - IPC handlers: `src/main/ipc/handlers.ts` (`settings:export`, `settings:import`)
 - Preload bridge: `src/preload/index.ts` (`exportSettings`, `importSettings`)
-- UI: `src/renderer/src/components/preferences/GeneralPrefs.svelte` (Backup & Restore section)
+- UI: `src/renderer/src/components/preferences/PreferencesModal.svelte` (sidebar-footer Import/Export buttons)

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1786,8 +1786,38 @@ export function registerIpcHandlers(
     },
   )
 
+  // Validate a path that does not yet exist (for create operations). Walks up
+  // to the closest existing ancestor, validates IT through validatePathAccess
+  // (so realpath/symlink/workspace checks still apply), then re-attaches the
+  // not-yet-existing tail. Rejects any path whose tail would escape the
+  // ancestor via `..` or absolute references.
+  async function validateCreationPath(wcId: number, targetPath: string): Promise<string> {
+    const absolute = path.isAbsolute(targetPath) ? targetPath : path.resolve(targetPath)
+    const normalized = path.normalize(absolute)
+    let ancestor = normalized
+    const tail: string[] = []
+    while (true) {
+      try {
+        await fs.promises.access(ancestor)
+        break
+      } catch {
+        const parent = path.dirname(ancestor)
+        if (parent === ancestor) throw new Error('Access denied: no existing ancestor')
+        tail.unshift(path.basename(ancestor))
+        ancestor = parent
+      }
+    }
+    const resolvedAncestor = await validatePathAccess(wcId, ancestor)
+    const finalPath = path.join(resolvedAncestor, ...tail)
+    const rel = path.relative(resolvedAncestor, finalPath)
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new Error('Access denied: path escapes workspace')
+    }
+    return finalPath
+  }
+
   ipcMain.handle('fs:createFile', async (event, payload: { filePath: string }): Promise<void> => {
-    const resolved = await validatePathAccess(event.sender.id, payload.filePath)
+    const resolved = await validateCreationPath(event.sender.id, payload.filePath)
     // Ensure the parent dir exists (handles nested paths typed in the prompt
     // like "subdir/newfile.ts" — creates "subdir" if missing).
     await fs.promises.mkdir(path.dirname(resolved), { recursive: true })
@@ -1798,7 +1828,7 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('fs:mkdir', async (event, payload: { dirPath: string }): Promise<void> => {
-    const resolved = await validatePathAccess(event.sender.id, payload.dirPath)
+    const resolved = await validateCreationPath(event.sender.id, payload.dirPath)
     await fs.promises.mkdir(resolved, { recursive: true })
   })
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1786,6 +1786,22 @@ export function registerIpcHandlers(
     },
   )
 
+  ipcMain.handle('fs:createFile', async (event, payload: { filePath: string }): Promise<void> => {
+    const resolved = await validatePathAccess(event.sender.id, payload.filePath)
+    // Ensure the parent dir exists (handles nested paths typed in the prompt
+    // like "subdir/newfile.ts" — creates "subdir" if missing).
+    await fs.promises.mkdir(path.dirname(resolved), { recursive: true })
+    // wx flag: error if file already exists. Avoids silently clobbering
+    // anything the user typed by accident.
+    const handle = await fs.promises.open(resolved, 'wx')
+    await handle.close()
+  })
+
+  ipcMain.handle('fs:mkdir', async (event, payload: { dirPath: string }): Promise<void> => {
+    const resolved = await validatePathAccess(event.sender.id, payload.dirPath)
+    await fs.promises.mkdir(resolved, { recursive: true })
+  })
+
   ipcMain.handle(
     'dialog:confirmUnsavedChanges',
     async (event, payload: { filePaths: string[] }): Promise<'save' | 'discard' | 'cancel'> => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -557,6 +557,8 @@ interface CanopyAPI {
     content: string,
     expectedMtimeMs?: number,
   ) => Promise<FileWriteResult>
+  createFile: (filePath: string) => Promise<void>
+  mkdir: (dirPath: string) => Promise<void>
   statFile: (filePath: string) => Promise<FileStatResult>
   quickOpenListFiles: (worktreePath: string, force?: boolean) => Promise<string[]>
   quickOpenInvalidateCache: (worktreePath: string) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -692,6 +692,8 @@ const api = {
     ipcRenderer.invoke('fs:readFile', { filePath, maxBytes }),
   writeFile: (filePath: string, content: string, expectedMtimeMs?: number) =>
     ipcRenderer.invoke('fs:writeFile', { filePath, content, expectedMtimeMs }),
+  createFile: (filePath: string) => ipcRenderer.invoke('fs:createFile', { filePath }),
+  mkdir: (dirPath: string) => ipcRenderer.invoke('fs:mkdir', { dirPath }),
   statFile: (filePath: string) => ipcRenderer.invoke('fs:stat', { filePath }),
   quickOpenListFiles: (worktreePath: string, force?: boolean) =>
     ipcRenderer.invoke('quickOpen:listFiles', { worktreePath, force }) as Promise<string[]>,

--- a/src/renderer-shared/styles/tokens.css
+++ b/src/renderer-shared/styles/tokens.css
@@ -460,13 +460,15 @@
   transition-timing-function: var(--ease-std);
 }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-user-select: none;
-  user-select: none;
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    -webkit-user-select: none;
+    user-select: none;
+  }
 }
 
 input,

--- a/src/renderer-shared/styles/tokens.css
+++ b/src/renderer-shared/styles/tokens.css
@@ -422,16 +422,21 @@
 
 /* Preferences modal sizing. */
 @utility w-prefs {
-  width: 880px;
+  width: 920px;
 }
 @utility max-w-prefs {
   max-width: 92vw;
 }
 @utility h-prefs {
-  height: 640px;
+  height: 680px;
 }
 @utility max-h-prefs {
   max-height: 88vh;
+}
+
+/* Hover background for prefs setting rows — softer than bg-hover. */
+@utility bg-row-hover {
+  background: color-mix(in srgb, var(--color-text) 4%, transparent);
 }
 
 /* macOS traffic-light buttons reserve ~78px on each side of the titlebar.

--- a/src/renderer/src/components/agents/AgentInspector.svelte
+++ b/src/renderer/src/components/agents/AgentInspector.svelte
@@ -38,6 +38,15 @@
       .otherwise(() => 'dim'),
   )
 
+  let statusDotTone = $derived(
+    match(statusClass)
+      .with('permission', () => 'bg-warning-text animate-badge-pulse motion-reduce:animate-none')
+      .with('error', () => 'bg-danger-text')
+      .with('active', () => 'bg-accent-text animate-badge-pulse motion-reduce:animate-none')
+      .with('idle', () => 'bg-success')
+      .otherwise(() => 'bg-text-faint'),
+  )
+
   function relativeTime(ts: number): string {
     const diff = Date.now() - ts
     const seconds = Math.floor(diff / 1000)
@@ -89,35 +98,38 @@
     return `${hours}h ${minutes % 60}m`
   }
 
-  const sectionLabelCls = 'text-2xs font-semibold tracking-[0.5px] uppercase text-text-faint m-0'
-  const infoGridCls = 'grid grid-cols-[auto_1fr] gap-x-3 gap-y-[3px] text-sm'
-  const infoKeyCls = 'text-text-muted'
+  const sectionLabelCls =
+    'text-2xs font-semibold tracking-caps-looser uppercase text-text-faint leading-tight m-0'
+  const infoGridCls = 'grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm'
+  const infoKeyCls = 'text-text-faint'
   const infoValCls = 'text-text-secondary'
 </script>
 
-<div class="flex flex-col gap-3 p-3" data-status={statusClass}>
-  <h3 class="text-2xs font-semibold tracking-[1px] uppercase text-text-faint m-0">
+<div class="flex flex-col gap-4 p-3" data-status={statusClass}>
+  <h3
+    class="text-2xs font-semibold tracking-caps-looser uppercase text-text-faint leading-tight m-0"
+  >
     {inspectorTitle}
   </h3>
 
   <!-- Status -->
-  <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-border-subtle">
-    <span class="status-dot w-2 h-2 rounded-full flex-shrink-0 bg-text-faint"></span>
+  <div class="flex items-center gap-2 h-7 px-2.5 rounded-md bg-border-subtle">
+    <span class="size-2 rounded-full flex-shrink-0 {statusDotTone}" aria-hidden="true"></span>
     <span class="text-sm text-text">{statusText}</span>
   </div>
 
   <!-- Context Bar -->
   {#if state.contextPercent != null}
-    <div class="flex flex-col gap-1">
+    <div class="flex flex-col gap-1.5">
       <div class="flex justify-between items-baseline">
         <span class={sectionLabelCls}>Context</span>
-        <span class="text-xs text-text-secondary"
+        <span class="text-2xs font-mono tabular-nums text-text-secondary"
           >{Math.round(state.contextPercent)}% of {formatContextSize(state.contextSize)}</span
         >
       </div>
-      <div class="h-1 rounded-xs bg-active overflow-hidden">
+      <div class="h-1.5 rounded-sm bg-border-subtle overflow-hidden">
         <div
-          class="h-full rounded-xs transition-[width] duration-slow {contextBarClass}"
+          class="h-full rounded-sm transition-[width] duration-slow {contextBarClass}"
           style="width: {Math.min(state.contextPercent, 100)}%"
         ></div>
       </div>
@@ -175,12 +187,19 @@
   <!-- Tasks -->
   {#if visibleTasks.length > 0}
     <div class="flex flex-col gap-1.5">
-      <h4 class={sectionLabelCls}>Tasks ({taskCounts.done}/{taskCounts.total})</h4>
-      <div class="flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
+      <div class="flex items-baseline justify-between">
+        <h4 class={sectionLabelCls}>Tasks</h4>
+        <span class="text-2xs font-mono tabular-nums text-text-faint"
+          >{taskCounts.done}/{taskCounts.total}</span
+        >
+      </div>
+      <div class="flex flex-col max-h-[200px] overflow-y-auto -mx-1">
         {#each visibleTasks as task (task.id)}
-          <div class="flex items-center gap-1.5 py-0.5">
+          <div
+            class="flex items-center gap-2 h-6 px-1 rounded-sm transition-colors duration-fast hover:bg-hover"
+          >
             {#if task.status === 'completed'}
-              <span class="text-2xs w-3 flex-shrink-0 text-center text-success">✓</span>
+              <span class="text-2xs w-3 flex-shrink-0 text-center text-success-text">✓</span>
             {:else if task.status === 'in_progress'}
               <span class="text-2xs w-3 flex-shrink-0 text-center text-accent-text">▶</span>
             {:else}
@@ -200,16 +219,24 @@
   <!-- Agents -->
   {#if state.activeSubagents.length > 0}
     <div class="flex flex-col gap-1.5">
-      <h4 class={sectionLabelCls}>Agents ({state.activeSubagents.length})</h4>
-      <div class="flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
+      <div class="flex items-baseline justify-between">
+        <h4 class={sectionLabelCls}>Agents</h4>
+        <span class="text-2xs font-mono tabular-nums text-text-faint"
+          >{state.activeSubagents.length}</span
+        >
+      </div>
+      <div class="flex flex-col max-h-[200px] overflow-y-auto -mx-1">
         {#each state.activeSubagents as agent (agent.agentId)}
-          <div class="flex items-center gap-1.5 py-0.5">
-            <span class="w-1.5 h-1.5 rounded-full bg-focus-ring flex-shrink-0"></span>
+          <div
+            class="flex items-center gap-2 h-6 px-1 rounded-sm transition-colors duration-fast hover:bg-hover"
+          >
+            <span class="size-1.5 rounded-full bg-focus-ring flex-shrink-0"></span>
             <span
               class="text-sm text-text-secondary overflow-hidden text-ellipsis whitespace-nowrap flex-1"
               >{agent.agentType}</span
             >
-            <span class="text-2xs text-text-faint flex-shrink-0">({agent.agentId.slice(0, 8)})</span
+            <span class="text-2xs font-mono text-text-faint flex-shrink-0"
+              >{agent.agentId.slice(0, 8)}</span
             >
           </div>
         {/each}
@@ -221,14 +248,17 @@
   {#if reversedNotifications.length > 0}
     <div class="flex flex-col gap-1.5">
       <h4 class={sectionLabelCls}>Notifications</h4>
-      <div class="flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
+      <div class="flex flex-col max-h-[200px] overflow-y-auto -mx-1">
         {#each reversedNotifications as notif (notif.timestamp)}
-          <div class="flex items-baseline justify-between gap-2 py-0.5">
+          <div
+            class="flex items-baseline justify-between gap-2 px-1 py-1 rounded-sm transition-colors duration-fast hover:bg-hover"
+          >
             <span
               class="text-xs text-text-secondary overflow-hidden text-ellipsis whitespace-nowrap flex-1"
               >{notif.message || notif.title}</span
             >
-            <span class="text-2xs text-text-faint flex-shrink-0"
+            <span
+              class="inline-flex items-center h-4 px-1 rounded-sm bg-border-subtle text-text-faint text-2xs font-mono tabular-nums leading-none flex-shrink-0"
               >{relativeTime(notif.timestamp)}</span
             >
           </div>

--- a/src/renderer/src/components/dashboard/WelcomeDashboard.svelte
+++ b/src/renderer/src/components/dashboard/WelcomeDashboard.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount, tick } from 'svelte'
   import { openWorkspace } from '../../lib/stores/workspace.svelte'
   import { confirm, prompt } from '../../lib/stores/dialogs.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
   import WelcomeEmpty from './_partials/WelcomeEmpty.svelte'
   import WelcomeContextMenu from './_partials/WelcomeContextMenu.svelte'
   import WelcomeRecents from './_partials/WelcomeRecents.svelte'
@@ -50,7 +51,13 @@
   })
 
   onMount(async () => {
-    workspaces = await window.api.listWorkspaces(20)
+    try {
+      workspaces = await window.api.listWorkspaces(20)
+    } catch (err) {
+      addToast(
+        `Failed to load recent workspaces: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
 
     await tick()
     if (workspaces.length === 0) {

--- a/src/renderer/src/components/dashboard/WelcomeDashboard.svelte
+++ b/src/renderer/src/components/dashboard/WelcomeDashboard.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte'
+  import { onDestroy, onMount, tick } from 'svelte'
   import { openWorkspace } from '../../lib/stores/workspace.svelte'
   import { confirm, prompt } from '../../lib/stores/dialogs.svelte'
-  import { fileManagerLabel } from '../../lib/platform'
+  import WelcomeEmpty from './_partials/WelcomeEmpty.svelte'
+  import WelcomeContextMenu from './_partials/WelcomeContextMenu.svelte'
+  import WelcomeRecents from './_partials/WelcomeRecents.svelte'
 
   interface WorkspaceRow {
     id: string
@@ -17,52 +19,46 @@
   }
 
   const isMac = navigator.userAgent.includes('Mac')
+  const modKey = isMac ? '⌘' : 'Ctrl'
+
   let workspaces = $state<WorkspaceRow[]>([])
+  let filter = $state('')
+  let selectedIndex = $state(0)
   let contextMenu = $state<{ x: number; y: number; workspace: WorkspaceRow } | null>(null)
   let disposed = false
 
-  function relativeTime(dateStr: string | null): string {
-    if (!dateStr) return ''
-    const diff = Date.now() - Date.parse(dateStr)
-    const seconds = Math.floor(diff / 1000)
-    if (seconds < 60) return 'just now'
-    const minutes = Math.floor(seconds / 60)
-    if (minutes < 60) return `${minutes}m ago`
-    const hours = Math.floor(minutes / 60)
-    if (hours < 24) return `${hours}h ago`
-    const days = Math.floor(hours / 24)
-    if (days === 1) return 'yesterday'
-    if (days < 30) return `${days}d ago`
-    const months = Math.floor(days / 30)
-    return `${months}mo ago`
-  }
+  let filterInputEl: HTMLInputElement | undefined = $state()
+  let openFolderBtnEl: HTMLButtonElement | undefined = $state()
+  let listEl: HTMLDivElement | undefined = $state()
 
-  function parseAheadBehind(raw: string | null): { ahead: number; behind: number } | null {
-    if (!raw) return null
-    try {
-      const parsed = JSON.parse(raw)
-      if (parsed && typeof parsed.ahead === 'number') return parsed
-      // Legacy format: "ahead/behind"
-      const parts = raw.split('/')
-      if (parts.length === 2) {
-        return { ahead: parseInt(parts[0]), behind: parseInt(parts[1]) }
-      }
-    } catch {
-      // Legacy "ahead/behind" string format
-      const parts = raw.split('/')
-      if (parts.length === 2) {
-        const ahead = parseInt(parts[0])
-        const behind = parseInt(parts[1])
-        if (!isNaN(ahead) && !isNaN(behind)) return { ahead, behind }
-      }
-    }
-    return null
-  }
+  const filteredWorkspaces = $derived.by(() => {
+    const q = filter.trim().toLowerCase()
+    if (!q) return workspaces
+    return workspaces.filter(
+      (w) =>
+        w.name.toLowerCase().includes(q) ||
+        w.path.toLowerCase().includes(q) ||
+        (w.cached_branch?.toLowerCase().includes(q) ?? false),
+    )
+  })
+
+  const showFilter = $derived(workspaces.length > 4)
+
+  $effect(() => {
+    void filteredWorkspaces
+    if (selectedIndex >= filteredWorkspaces.length) selectedIndex = 0
+  })
 
   onMount(async () => {
-    workspaces = await window.api.listWorkspaces(10)
+    workspaces = await window.api.listWorkspaces(20)
 
-    // Refresh a few recent repos sequentially so the welcome screen stays cheap to render.
+    await tick()
+    if (workspaces.length === 0) {
+      openFolderBtnEl?.focus()
+    } else {
+      focusRow(0)
+    }
+
     for (const ws of workspaces.slice(0, 3)) {
       if (disposed) break
       if (ws.is_git_repo) {
@@ -70,12 +66,10 @@
           const fresh = await window.api.refreshWorkspaceGitStatus(ws.id, ws.path)
           if (fresh && !disposed) {
             const idx = workspaces.findIndex((w) => w.id === fresh.id)
-            if (idx !== -1) {
-              workspaces[idx] = fresh
-            }
+            if (idx !== -1) workspaces[idx] = fresh
           }
         } catch {
-          // Path may no longer exist — ignore
+          // path may no longer exist — ignore
         }
       }
     }
@@ -124,10 +118,7 @@
     closeContextMenu()
   }
 
-  async function ctxRemove(): Promise<void> {
-    if (!contextMenu) return
-    const ws = contextMenu.workspace
-    closeContextMenu()
+  async function removeWorkspace(ws: WorkspaceRow): Promise<void> {
     const ok = await confirm({
       title: 'Remove from Recent?',
       message: `Remove "${ws.name}" from your recent workspaces?`,
@@ -140,109 +131,153 @@
     workspaces = workspaces.filter((w) => w.id !== ws.id)
   }
 
+  async function ctxRemove(): Promise<void> {
+    if (!contextMenu) return
+    const ws = contextMenu.workspace
+    closeContextMenu()
+    await removeWorkspace(ws)
+  }
+
+  function focusRow(idx: number): void {
+    listEl?.querySelectorAll<HTMLElement>('[data-row]')[idx]?.focus()
+  }
+
+  function selectAt(idx: number, refocus: boolean): void {
+    const len = filteredWorkspaces.length
+    if (len === 0) return
+    selectedIndex = Math.max(0, Math.min(len - 1, idx))
+    if (refocus) focusRow(selectedIndex)
+  }
+
+  const NAV_DELTA: Record<string, number> = {
+    ArrowDown: 1,
+    ArrowUp: -1,
+    PageDown: 5,
+    PageUp: -5,
+  }
+
   function handleKeydown(e: KeyboardEvent): void {
     if (contextMenu && e.key === 'Escape') {
       e.preventDefault()
       closeContextMenu()
+      return
+    }
+
+    const t = e.target
+    const onFilter = t === filterInputEl
+    const onRow = t instanceof HTMLElement && t.hasAttribute('data-row')
+    const inOtherInput =
+      t instanceof HTMLElement &&
+      !onFilter &&
+      (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)
+    if (inOtherInput) return
+
+    if (e.key === 'Escape') {
+      if (filter !== '') {
+        e.preventDefault()
+        filter = ''
+        return
+      }
+      if (onFilter) {
+        e.preventDefault()
+        focusRow(selectedIndex)
+        return
+      }
+    }
+
+    if (e.key === '/' && !onFilter && showFilter) {
+      e.preventDefault()
+      filterInputEl?.focus()
+      filterInputEl?.select()
+      return
+    }
+
+    // Quick-search: printable key on a row jumps to filter (only when filter is empty).
+    const printable =
+      e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey && /\S/.test(e.key)
+    if (onRow && showFilter && filter === '' && printable) {
+      e.preventDefault()
+      filter = e.key
+      filterInputEl?.focus()
+      void tick().then(() => {
+        if (filterInputEl) {
+          filterInputEl.selectionStart = filterInputEl.selectionEnd = filter.length
+        }
+      })
+      return
+    }
+
+    // Navigation keys are scoped to filter/row so Enter on action buttons activates them.
+    if (!onFilter && !onRow) return
+    if (filteredWorkspaces.length === 0) return
+
+    const delta = NAV_DELTA[e.key]
+    if (delta !== undefined) {
+      e.preventDefault()
+      selectAt(selectedIndex + delta, !onFilter)
+      return
+    }
+    if (e.key === 'Home' && !onFilter) {
+      e.preventDefault()
+      selectAt(0, true)
+      return
+    }
+    if (e.key === 'End' && !onFilter) {
+      e.preventDefault()
+      selectAt(filteredWorkspaces.length - 1, true)
+      return
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleOpen(filteredWorkspaces[selectedIndex])
+      return
+    }
+    if (e.key === 'Backspace' && (e.metaKey || e.ctrlKey) && !onFilter) {
+      e.preventDefault()
+      const ws = filteredWorkspaces[selectedIndex]
+      if (ws) void removeWorkspace(ws)
     }
   }
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<!-- svelte-ignore a11y_no_static_element_interactions -->
 {#if contextMenu}
-  <div class="fixed inset-0 z-overlay" onclick={closeContextMenu}>
-    <div
-      class="fixed min-w-45 bg-bg-overlay border border-border rounded-xl shadow-ctx p-1 z-popover"
-      style="left: {contextMenu.x}px; top: {contextMenu.y}px"
-      onclick={(e) => e.stopPropagation()}
-    >
-      <button
-        class="block w-full px-3 py-1.5 border-0 rounded-md bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-active"
-        onclick={ctxRevealInFileManager}>{fileManagerLabel()}</button
-      >
-      <button
-        class="block w-full px-3 py-1.5 border-0 rounded-md bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-active"
-        onclick={ctxCopyPath}>Copy Path</button
-      >
-      <div class="h-px mx-2 my-1 bg-active"></div>
-      <button
-        class="block w-full px-3 py-1.5 border-0 rounded-md bg-transparent text-danger-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-active"
-        onclick={ctxRemove}>Remove from Recent</button
-      >
-    </div>
-  </div>
+  <WelcomeContextMenu
+    x={contextMenu.x}
+    y={contextMenu.y}
+    onClose={closeContextMenu}
+    onReveal={ctxRevealInFileManager}
+    onCopyPath={ctxCopyPath}
+    onRemove={ctxRemove}
+  />
 {/if}
 
-<div class="flex items-start justify-center h-full overflow-y-auto py-15 px-5">
-  <div class="w-full max-w-130">
-    <h1 class="text-3xl font-bold text-text-faint tracking-caps text-center m-0 mb-10">Canopy</h1>
-
-    {#if workspaces.length > 0}
-      <h2 class="text-xs font-semibold tracking-caps-tight uppercase text-text-faint m-0 mb-2">
-        Recent
-      </h2>
-      <div class="flex flex-col gap-0.5 mb-6">
-        {#each workspaces as ws (ws.id)}
-          <button
-            class="block w-full px-3 py-2.5 border-0 rounded-lg bg-transparent text-inherit font-inherit text-inherit text-left cursor-pointer transition-colors duration-fast outline-none hover:bg-hover focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-1"
-            onclick={() => handleOpen(ws)}
-            oncontextmenu={(e) => handleContextMenu(e, ws)}
-          >
-            <div class="flex items-baseline justify-between gap-3">
-              <span
-                class="text-md font-semibold text-text whitespace-nowrap overflow-hidden text-ellipsis"
-                >{ws.name}</span
-              >
-              <span class="flex items-baseline gap-1.5 flex-shrink-0 text-sm">
-                {#if ws.cached_branch}
-                  <span class="text-text-muted">{ws.cached_branch}</span>
-                {/if}
-                {#if ws.cached_dirty === 1}
-                  <span class="text-warning-text font-bold">*</span>
-                {/if}
-                {#if parseAheadBehind(ws.cached_ahead_behind)}
-                  {@const ab = parseAheadBehind(ws.cached_ahead_behind)!}
-                  {#if ab.ahead > 0}
-                    <span class="text-success text-xs">{ab.ahead}&#x2191;</span>
-                  {/if}
-                  {#if ab.behind > 0}
-                    <span class="text-warning-text text-xs">{ab.behind}&#x2193;</span>
-                  {/if}
-                {/if}
-              </span>
-            </div>
-            <div class="flex items-baseline justify-between gap-3 mt-0.5">
-              <span
-                class="text-xs font-mono text-text-faint whitespace-nowrap overflow-hidden text-ellipsis"
-                >{ws.path}</span
-              >
-              <span class="flex items-baseline gap-2 flex-shrink-0 text-xs text-text-faint">
-                {#if ws.is_git_repo && ws.cached_worktree_count && ws.cached_worktree_count > 1}
-                  <span>{ws.cached_worktree_count} worktrees</span>
-                {/if}
-                {#if ws.last_opened}
-                  <span>{relativeTime(ws.last_opened)}</span>
-                {/if}
-              </span>
-            </div>
-          </button>
-        {/each}
-      </div>
+<div class="flex items-start justify-center h-full overflow-y-auto py-12 px-5">
+  <div class="w-full max-w-160 flex flex-col gap-6">
+    {#if workspaces.length === 0}
+      <WelcomeEmpty
+        {modKey}
+        onOpenFolder={handleOpenFolder}
+        onOpenFromPath={handleOpenFromPath}
+        bind:openFolderBtnEl
+      />
+    {:else}
+      <WelcomeRecents
+        {workspaces}
+        {filteredWorkspaces}
+        bind:filter
+        {showFilter}
+        {selectedIndex}
+        {modKey}
+        onOpen={handleOpen}
+        onSelect={(i) => (selectedIndex = i)}
+        onContextMenu={handleContextMenu}
+        onOpenFolder={handleOpenFolder}
+        onOpenFromPath={handleOpenFromPath}
+        bind:filterInputEl
+        bind:listEl
+      />
     {/if}
-
-    <div class="flex items-center gap-2">
-      <button
-        class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 outline-none bg-hover text-text-secondary transition-colors duration-fast hover:bg-hover-strong focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-1"
-        onclick={handleOpenFolder}>Open Folder</button
-      >
-      <button
-        class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 outline-none bg-hover text-text-secondary transition-colors duration-fast hover:bg-hover-strong focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-1"
-        onclick={handleOpenFromPath}>Open from Path...</button
-      >
-      <span class="text-xs text-text-faint ml-1">{isMac ? 'Cmd' : 'Ctrl'}+O</span>
-    </div>
   </div>
 </div>

--- a/src/renderer/src/components/dashboard/_partials/RecentRow.svelte
+++ b/src/renderer/src/components/dashboard/_partials/RecentRow.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  interface WorkspaceRow {
+    id: string
+    path: string
+    name: string
+    is_git_repo: number
+    last_opened: string | null
+    cached_branch: string | null
+    cached_dirty: number | null
+    cached_ahead_behind: string | null
+    cached_worktree_count: number | null
+  }
+
+  interface Props {
+    ws: WorkspaceRow
+    selected: boolean
+    onopen: () => void
+    onfocus: () => void
+    onmouseenter: () => void
+    oncontextmenu: (e: MouseEvent) => void
+  }
+
+  let { ws, selected, onopen, onfocus, onmouseenter, oncontextmenu }: Props = $props()
+
+  function relativeTime(dateStr: string | null): string {
+    if (!dateStr) return ''
+    const diff = Date.now() - Date.parse(dateStr)
+    const seconds = Math.floor(diff / 1000)
+    if (seconds < 60) return 'just now'
+    const minutes = Math.floor(seconds / 60)
+    if (minutes < 60) return `${minutes}m ago`
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return `${hours}h ago`
+    const days = Math.floor(hours / 24)
+    if (days === 1) return 'yesterday'
+    if (days < 30) return `${days}d ago`
+    const months = Math.floor(days / 30)
+    return `${months}mo ago`
+  }
+
+  function parseAheadBehind(raw: string | null): { ahead: number; behind: number } | null {
+    if (!raw) return null
+    try {
+      const parsed = JSON.parse(raw)
+      if (parsed && typeof parsed.ahead === 'number') return parsed
+      const parts = raw.split('/')
+      if (parts.length === 2) {
+        return { ahead: parseInt(parts[0], 10), behind: parseInt(parts[1], 10) }
+      }
+    } catch {
+      const parts = raw.split('/')
+      if (parts.length === 2) {
+        const ahead = parseInt(parts[0], 10)
+        const behind = parseInt(parts[1], 10)
+        if (!isNaN(ahead) && !isNaN(behind)) return { ahead, behind }
+      }
+    }
+    return null
+  }
+
+  const ab = $derived(parseAheadBehind(ws.cached_ahead_behind))
+</script>
+
+<button
+  data-row
+  role="option"
+  tabindex={selected ? 0 : -1}
+  aria-selected={selected}
+  aria-label={`Open ${ws.name}`}
+  class="block w-full px-3 py-2 border-0 border-t border-border-subtle first:border-t-0 rounded-none bg-transparent text-inherit font-inherit text-left cursor-pointer transition-colors duration-fast outline-none hover:bg-hover focus:bg-hover focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:-outline-offset-2 aria-selected:bg-hover"
+  onclick={onopen}
+  {onfocus}
+  {onmouseenter}
+  {oncontextmenu}
+>
+  <div class="flex items-baseline justify-between gap-3">
+    <span
+      class="text-md font-medium text-text whitespace-nowrap overflow-hidden text-ellipsis"
+      title={ws.name}
+    >
+      {ws.name}
+    </span>
+    <span class="flex items-baseline gap-1.5 flex-shrink-0 text-xs tabular-nums">
+      {#if ws.cached_branch}
+        <span class="text-text-muted font-mono">{ws.cached_branch}</span>
+      {/if}
+      {#if ws.cached_dirty === 1}
+        <span class="text-warning-text font-bold" title="Uncommitted changes">*</span>
+      {/if}
+      {#if ab && ab.ahead > 0}
+        <span class="text-success-text text-2xs">{ab.ahead}↑</span>
+      {/if}
+      {#if ab && ab.behind > 0}
+        <span class="text-warning-text text-2xs">{ab.behind}↓</span>
+      {/if}
+    </span>
+  </div>
+  <div class="flex items-baseline justify-between gap-3 mt-0.5">
+    <span
+      class="text-xs font-mono text-text-faint whitespace-nowrap overflow-hidden text-ellipsis"
+      title={ws.path}
+    >
+      {ws.path}
+    </span>
+    <span class="flex items-baseline gap-2 flex-shrink-0 text-2xs text-text-faint">
+      {#if ws.is_git_repo && ws.cached_worktree_count && ws.cached_worktree_count > 1}
+        <span>{ws.cached_worktree_count} worktrees</span>
+        <span aria-hidden="true">·</span>
+      {/if}
+      {#if ws.last_opened}
+        <span>{relativeTime(ws.last_opened)}</span>
+      {/if}
+    </span>
+  </div>
+</button>

--- a/src/renderer/src/components/dashboard/_partials/WelcomeContextMenu.svelte
+++ b/src/renderer/src/components/dashboard/_partials/WelcomeContextMenu.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { fileManagerLabel } from '../../../lib/platform'
+
+  interface Props {
+    x: number
+    y: number
+    onClose: () => void
+    onReveal: () => void
+    onCopyPath: () => void
+    onRemove: () => void
+  }
+
+  let { x, y, onClose, onReveal, onCopyPath, onRemove }: Props = $props()
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="fixed inset-0 z-overlay" onclick={onClose}>
+  <div
+    class="fixed min-w-45 bg-bg-overlay border border-border rounded-md shadow-ctx p-1 z-popover"
+    style="left: {x}px; top: {y}px"
+    onclick={(e) => e.stopPropagation()}
+  >
+    <button
+      class="block w-full px-3 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
+      onclick={onReveal}>{fileManagerLabel()}</button
+    >
+    <button
+      class="block w-full px-3 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
+      onclick={onCopyPath}>Copy Path</button
+    >
+    <div class="h-px mx-2 my-1 bg-border-subtle"></div>
+    <button
+      class="block w-full px-3 py-1.5 border-0 rounded-sm bg-transparent text-danger-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
+      onclick={onRemove}>Remove from Recent</button
+    >
+  </div>
+</div>

--- a/src/renderer/src/components/dashboard/_partials/WelcomeContextMenu.svelte
+++ b/src/renderer/src/components/dashboard/_partials/WelcomeContextMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount, tick } from 'svelte'
   import { fileManagerLabel } from '../../../lib/platform'
 
   interface Props {
@@ -11,27 +12,91 @@
   }
 
   let { x, y, onClose, onReveal, onCopyPath, onRemove }: Props = $props()
+
+  let menuEl: HTMLDivElement | undefined = $state()
+  const previouslyFocused = (
+    typeof document !== 'undefined' ? document.activeElement : null
+  ) as HTMLElement | null
+
+  onMount(() => {
+    void tick().then(() => {
+      const first = menuEl?.querySelector<HTMLElement>('[role="menuitem"]')
+      first?.focus()
+    })
+    return () => {
+      previouslyFocused?.focus?.()
+    }
+  })
+
+  function items(): HTMLElement[] {
+    return Array.from(menuEl?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [])
+  }
+
+  function focusByOffset(offset: number): void {
+    const list = items()
+    if (list.length === 0) return
+    const current = document.activeElement as HTMLElement | null
+    const idx = current ? list.indexOf(current) : -1
+    const next = (idx + offset + list.length) % list.length
+    list[next]?.focus()
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onClose()
+      return
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      focusByOffset(1)
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      focusByOffset(-1)
+      return
+    }
+    if (e.key === 'Home') {
+      e.preventDefault()
+      items()[0]?.focus()
+      return
+    }
+    if (e.key === 'End') {
+      e.preventDefault()
+      const list = items()
+      list[list.length - 1]?.focus()
+    }
+  }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="fixed inset-0 z-overlay" onclick={onClose}>
   <div
+    bind:this={menuEl}
+    role="menu"
+    aria-label="Workspace actions"
+    tabindex="-1"
     class="fixed min-w-45 bg-bg-overlay border border-border rounded-md shadow-ctx p-1 z-popover"
     style="left: {x}px; top: {y}px"
     onclick={(e) => e.stopPropagation()}
+    onkeydown={handleKeydown}
   >
     <button
-      class="block w-full px-3 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
+      role="menuitem"
+      class="block w-full px-3 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover focus-visible:bg-hover focus-visible:outline-none"
       onclick={onReveal}>{fileManagerLabel()}</button
     >
     <button
-      class="block w-full px-3 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
+      role="menuitem"
+      class="block w-full px-3 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover focus-visible:bg-hover focus-visible:outline-none"
       onclick={onCopyPath}>Copy Path</button
     >
-    <div class="h-px mx-2 my-1 bg-border-subtle"></div>
+    <div class="h-px mx-2 my-1 bg-border-subtle" role="separator"></div>
     <button
-      class="block w-full px-3 py-1.5 border-0 rounded-sm bg-transparent text-danger-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
+      role="menuitem"
+      class="block w-full px-3 py-1.5 border-0 rounded-sm bg-transparent text-danger-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover focus-visible:bg-hover focus-visible:outline-none"
       onclick={onRemove}>Remove from Recent</button
     >
   </div>

--- a/src/renderer/src/components/dashboard/_partials/WelcomeEmpty.svelte
+++ b/src/renderer/src/components/dashboard/_partials/WelcomeEmpty.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { FolderOpen } from '@lucide/svelte'
+
+  interface Props {
+    modKey: string
+    onOpenFolder: () => void
+    onOpenFromPath: () => void
+    openFolderBtnEl?: HTMLButtonElement
+  }
+
+  let { modKey, onOpenFolder, onOpenFromPath, openFolderBtnEl = $bindable() }: Props = $props()
+</script>
+
+<div class="flex flex-col items-center text-center gap-6 mt-16">
+  <div class="flex flex-col items-center gap-1.5">
+    <h1 class="text-3xl font-semibold tracking-caps uppercase text-text m-0 leading-tight">
+      Canopy
+    </h1>
+    <p class="text-sm text-text-muted m-0">developer terminal workstation</p>
+  </div>
+
+  <div class="flex flex-col items-center gap-2 mt-4">
+    <button
+      bind:this={openFolderBtnEl}
+      type="button"
+      class="inline-flex items-center gap-2 px-4 h-9 rounded-md text-md font-medium font-inherit cursor-pointer border-0 outline-none bg-accent-bg text-accent-text transition-colors duration-fast hover:bg-accent-bg-hover focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-2"
+      onclick={onOpenFolder}
+    >
+      <FolderOpen size={14} />
+      Open Folder
+      <kbd class="text-2xs text-accent-text/70 font-sans ml-1.5 select-none">
+        {modKey}O
+      </kbd>
+    </button>
+    <button
+      type="button"
+      class="px-3 h-7 rounded-md text-sm font-inherit cursor-pointer border-0 outline-none bg-transparent text-text-secondary transition-colors duration-fast hover:bg-hover focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-2"
+      onclick={onOpenFromPath}
+    >
+      Open from Path…
+    </button>
+  </div>
+</div>

--- a/src/renderer/src/components/dashboard/_partials/WelcomeRecents.svelte
+++ b/src/renderer/src/components/dashboard/_partials/WelcomeRecents.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import { Search, FolderOpen, FolderPlus } from '@lucide/svelte'
+  import RecentRow from './RecentRow.svelte'
+
+  interface WorkspaceRow {
+    id: string
+    path: string
+    name: string
+    is_git_repo: number
+    last_opened: string | null
+    cached_branch: string | null
+    cached_dirty: number | null
+    cached_ahead_behind: string | null
+    cached_worktree_count: number | null
+  }
+
+  interface Props {
+    workspaces: WorkspaceRow[]
+    filteredWorkspaces: WorkspaceRow[]
+    filter: string
+    showFilter: boolean
+    selectedIndex: number
+    modKey: string
+    onOpen: (ws: WorkspaceRow) => void
+    onSelect: (i: number) => void
+    onContextMenu: (e: MouseEvent, ws: WorkspaceRow) => void
+    onOpenFolder: () => void
+    onOpenFromPath: () => void
+    filterInputEl?: HTMLInputElement
+    listEl?: HTMLDivElement
+  }
+
+  let {
+    workspaces,
+    filteredWorkspaces,
+    filter = $bindable(),
+    showFilter,
+    selectedIndex,
+    modKey,
+    onOpen,
+    onSelect,
+    onContextMenu,
+    onOpenFolder,
+    onOpenFromPath,
+    filterInputEl = $bindable(),
+    listEl = $bindable(),
+  }: Props = $props()
+</script>
+
+<div class="flex items-center justify-between h-7">
+  <span class="text-xs font-semibold tracking-caps uppercase text-text-faint select-none">
+    Canopy
+  </span>
+  <span class="flex items-center gap-3 text-2xs text-text-faint select-none">
+    <span class="inline-flex items-center gap-1">
+      <kbd class="font-sans">{modKey}O</kbd>
+      <span>open</span>
+    </span>
+    {#if showFilter}
+      <span class="inline-flex items-center gap-1">
+        <kbd class="font-sans">/</kbd>
+        <span>filter</span>
+      </span>
+    {/if}
+  </span>
+</div>
+
+{#if showFilter}
+  <div
+    class="relative flex items-center h-8 rounded-md bg-bg-input border border-transparent focus-within:border-focus-ring transition-colors duration-fast"
+  >
+    <Search size={13} class="absolute left-2.5 text-text-faint pointer-events-none shrink-0" />
+    <input
+      bind:this={filterInputEl}
+      type="text"
+      placeholder="Filter recents…"
+      aria-label="Filter recents"
+      spellcheck="false"
+      autocomplete="off"
+      bind:value={filter}
+      class="w-full h-full pl-7 pr-3 bg-transparent border-0 outline-none text-md text-text placeholder:text-text-faint font-inherit"
+    />
+  </div>
+{/if}
+
+<section class="flex flex-col gap-2">
+  <div class="flex items-baseline justify-between">
+    <h2
+      class="text-2xs font-semibold uppercase tracking-caps-looser text-text-faint m-0 leading-tight"
+    >
+      Recent
+    </h2>
+    <span class="text-2xs text-text-faint tabular-nums">
+      {filteredWorkspaces.length}{filter ? ` / ${workspaces.length}` : ''}
+    </span>
+  </div>
+
+  {#if filteredWorkspaces.length === 0}
+    <p class="text-sm text-text-muted py-8 text-center m-0">
+      No matches for <span class="font-mono text-text">{filter}</span>
+    </p>
+  {:else}
+    <div bind:this={listEl} role="listbox" aria-label="Recent workspaces" class="flex flex-col">
+      {#each filteredWorkspaces as ws, i (ws.id)}
+        <RecentRow
+          {ws}
+          selected={i === selectedIndex}
+          onopen={() => onOpen(ws)}
+          onfocus={() => onSelect(i)}
+          onmouseenter={() => onSelect(i)}
+          oncontextmenu={(e) => onContextMenu(e, ws)}
+        />
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<div class="flex items-center gap-2 pt-2 border-t border-border-subtle">
+  <button
+    type="button"
+    class="inline-flex items-center gap-2 px-3 h-8 rounded-md text-md font-inherit cursor-pointer border-0 outline-none bg-hover text-text-secondary transition-colors duration-fast hover:bg-hover-strong hover:text-text focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-2"
+    onclick={onOpenFolder}
+  >
+    <FolderOpen size={13} />
+    Open Folder
+  </button>
+  <button
+    type="button"
+    class="inline-flex items-center gap-2 px-3 h-8 rounded-md text-md font-inherit cursor-pointer border-0 outline-none bg-hover text-text-secondary transition-colors duration-fast hover:bg-hover-strong hover:text-text focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-2"
+    onclick={onOpenFromPath}
+  >
+    <FolderPlus size={13} />
+    Open from Path…
+  </button>
+  <span class="text-2xs text-text-faint ml-auto select-none flex items-center gap-3">
+    <span class="inline-flex items-center gap-1">
+      <kbd class="font-sans">↑↓</kbd>
+      <span>navigate</span>
+    </span>
+    <span class="inline-flex items-center gap-1">
+      <kbd class="font-sans">↵</kbd>
+      <span>open</span>
+    </span>
+    <span class="inline-flex items-center gap-1">
+      <kbd class="font-sans">{modKey}⌫</kbd>
+      <span>remove</span>
+    </span>
+  </span>
+</div>

--- a/src/renderer/src/components/dialogs/InputDialog.svelte
+++ b/src/renderer/src/components/dialogs/InputDialog.svelte
@@ -94,53 +94,55 @@
 >
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
-    class="w-105 bg-bg-overlay border border-border rounded-2xl shadow-modal p-5"
+    class="w-105 bg-bg-overlay border border-border rounded-2xl shadow-modal px-6 py-5 flex flex-col gap-4"
     role="dialog"
     aria-modal="true"
     aria-labelledby="input-dialog-title"
     onmousedown={(e) => e.stopPropagation()}
   >
-    <h3 id="input-dialog-title" class="m-0 mb-3 text-base font-semibold text-text">{title}</h3>
+    <h3 id="input-dialog-title" class="m-0 text-base font-semibold text-text">{title}</h3>
 
-    {#if multiline}
-      <textarea
-        bind:this={textareaEl}
-        bind:value
-        class="w-full border border-border rounded-md bg-bg-input text-text text-md font-inherit px-2.5 py-1.5 outline-none transition-colors duration-fast box-border resize-y min-h-20 focus:border-focus-ring placeholder:text-text-faint"
-        {placeholder}
-        rows="4"
-        spellcheck="false"
-      ></textarea>
-    {:else}
-      <input
-        bind:this={inputEl}
-        bind:value
-        class="w-full border border-border rounded-md bg-bg-input text-text text-md font-inherit px-2.5 py-1.5 outline-none transition-colors duration-fast box-border focus:border-focus-ring placeholder:text-text-faint"
-        type="text"
-        {placeholder}
-        spellcheck="false"
-        autocomplete="off"
-      />
-    {/if}
+    <div class="flex flex-col gap-2">
+      {#if multiline}
+        <textarea
+          bind:this={textareaEl}
+          bind:value
+          class="w-full border border-border rounded-md bg-bg-input text-text text-md font-inherit px-3 py-2 outline-none transition-colors duration-fast box-border resize-y min-h-20 focus:border-focus-ring placeholder:text-text-faint"
+          {placeholder}
+          rows="4"
+          spellcheck="false"
+        ></textarea>
+      {:else}
+        <input
+          bind:this={inputEl}
+          bind:value
+          class="w-full h-9 border border-border rounded-md bg-bg-input text-text text-md font-inherit px-3 outline-none transition-colors duration-fast box-border focus:border-focus-ring placeholder:text-text-faint"
+          type="text"
+          {placeholder}
+          spellcheck="false"
+          autocomplete="off"
+        />
+      {/if}
 
-    {#if error}
-      <p class="mt-1.5 mb-0 text-sm text-danger-text">{error}</p>
-    {/if}
+      {#if error}
+        <p class="m-0 text-sm text-danger-text">{error}</p>
+      {/if}
 
-    {#if checkbox}
-      <label
-        class="flex items-center gap-1.5 mt-2.5 text-sm text-text-secondary cursor-pointer select-none"
-      >
-        <CustomCheckbox {checked} onchange={(v) => (checked = v)} />
-        <span>{checkbox.label}</span>
-      </label>
-    {/if}
+      {#if checkbox}
+        <label
+          class="flex items-center gap-1.5 mt-1 text-sm text-text-secondary cursor-pointer select-none"
+        >
+          <CustomCheckbox {checked} onchange={(v) => (checked = v)} />
+          <span>{checkbox.label}</span>
+        </label>
+      {/if}
 
-    {#if multiline}
-      <p class="mt-1.5 mb-0 text-xs text-text-faint">{isMac ? 'Cmd' : 'Ctrl'}+Enter to submit</p>
-    {/if}
+      {#if multiline}
+        <p class="m-0 text-xs text-text-faint">{isMac ? 'Cmd' : 'Ctrl'}+Enter to submit</p>
+      {/if}
+    </div>
 
-    <div class="flex items-center gap-2 mt-4">
+    <div class="flex items-center gap-2">
       {#if onGenerate}
         <button
           class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 outline-none transition-colors duration-fast bg-generate-bg text-generate enabled:hover:bg-generate-bg-hover disabled:opacity-40 disabled:cursor-default focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-1"

--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -158,28 +158,33 @@
 </script>
 
 <div class="flex flex-col h-full">
-  <div class="flex items-center justify-between px-3 py-2 flex-shrink-0">
-    <span class="text-xs font-semibold text-text-secondary uppercase tracking-caps-looser"
-      >Changes</span
+  <div class="flex items-center justify-between px-3 pt-3 pb-1 flex-shrink-0">
+    <h3
+      class="text-2xs font-semibold tracking-caps-looser uppercase text-text-faint leading-tight m-0"
     >
+      Changes
+    </h3>
     <button
-      class="bg-transparent border-0 text-text-muted cursor-pointer px-1 py-0.5 rounded-md flex items-center justify-center enabled:hover:text-text enabled:hover:bg-hover disabled:opacity-50 disabled:cursor-default"
+      class="inline-flex items-center justify-center size-5 -my-1 rounded-sm border-0 bg-transparent text-text-faint cursor-pointer transition-colors duration-fast enabled:hover:text-text enabled:hover:bg-hover disabled:opacity-40 disabled:cursor-default"
       onclick={refresh}
       title="Refresh"
+      aria-label="Refresh"
       disabled={loading}
     >
-      <RotateCw size={13} class={loading ? 'animate-spin-slow motion-reduce:animate-none' : ''} />
+      <RotateCw size={12} class={loading ? 'animate-spin-slow motion-reduce:animate-none' : ''} />
     </button>
   </div>
 
   {#if totalFiles > 0}
     <div class="flex items-center gap-2 px-3 pt-0.5 pb-2 flex-shrink-0 overflow-hidden">
-      <span class="text-xs text-text-muted whitespace-nowrap flex-shrink-0">
+      <span class="text-xs text-text-faint whitespace-nowrap flex-shrink-0">
         {totalFiles} file{totalFiles !== 1 ? 's' : ''} changed,
-        <span class="text-diff-add-fg">+{totalAdditions}</span>
-        <span class="text-diff-delete-fg">&minus;{totalDeletions}</span>
+        <span class="text-diff-add-fg font-mono">+{totalAdditions}</span>
+        <span class="text-diff-delete-fg font-mono">&minus;{totalDeletions}</span>
       </span>
-      <span class="flex items-stretch h-1.5 rounded-xs overflow-hidden flex-1 min-w-5">
+      <span
+        class="flex items-stretch h-1.5 rounded-sm overflow-hidden flex-1 min-w-5 bg-border-subtle"
+      >
         {#if totalAdditions > 0}
           <span class="block h-full bg-diff-add-fg" style="width: {summaryBarAddWidth}px"></span>
         {/if}
@@ -191,21 +196,28 @@
   {/if}
 
   <div class="px-3 pb-2 flex flex-col gap-1.5 flex-shrink-0">
-    <input
-      class="bg-bg border border-border-subtle rounded-md text-text text-xs px-2 py-1 w-full outline-none font-mono box-border focus:border-accent placeholder:text-text-faint"
-      type="text"
-      placeholder="Filter files..."
-      bind:value={filterQuery}
-    />
+    <div
+      class="relative flex items-center h-7 rounded-md bg-bg-input border border-transparent focus-within:border-focus-ring transition-colors duration-fast"
+    >
+      <input
+        class="w-full h-full px-2.5 bg-transparent border-0 outline-none text-xs text-text font-mono placeholder:text-text-faint"
+        type="text"
+        placeholder="Filter files…"
+        spellcheck="false"
+        autocomplete="off"
+        bind:value={filterQuery}
+      />
+    </div>
     <div class="flex gap-1">
       {#each [['all', 'All', 'Show all files'], ['added', 'A', 'Filter added files'], ['modified', 'M', 'Filter modified files'], ['deleted', 'D', 'Filter deleted files']] as [val, label, aria] (val)}
         <button
-          class="bg-transparent border border-border-subtle text-text-muted cursor-pointer text-2xs font-semibold px-2 py-0.5 rounded-sm font-mono"
-          class:bg-accent={statusFilter === val}
-          class:text-bg={statusFilter === val}
-          class:border-accent={statusFilter === val}
+          class="inline-flex items-center justify-center h-5 px-2 rounded-sm border-0 cursor-pointer text-2xs font-semibold font-mono tracking-caps-tight leading-none transition-colors duration-fast"
+          class:bg-accent-bg={statusFilter === val}
+          class:text-accent-text={statusFilter === val}
+          class:bg-border-subtle={statusFilter !== val}
+          class:text-text-faint={statusFilter !== val}
           class:hover:text-text={statusFilter !== val}
-          class:hover:bg-active={statusFilter !== val}
+          class:hover:bg-hover={statusFilter !== val}
           aria-label={aria}
           aria-pressed={statusFilter === val}
           onclick={() =>
@@ -248,7 +260,7 @@
             )}">{statusIcon(file.status)}</span
           >
           <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
-            <span class="text-text-muted">{dirname(file.path)}</span><span class="text-text"
+            <span class="text-text-faint">{dirname(file.path)}</span><span class="text-text"
               >{basename(file.path)}</span
             >
           </span>
@@ -278,7 +290,7 @@
     </ul>
   {:else if !loading}
     <div class="flex items-center justify-center h-full p-4">
-      <span class="text-sm text-text-muted">
+      <span class="text-sm text-text-faint">
         {#if filterQuery || statusFilter !== 'all'}
           No matching files
         {:else}

--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -86,10 +86,8 @@
   let totalDeletions = $derived(allFiles.reduce((sum, f) => sum + f.deletions, 0))
   let totalChanges = $derived(totalAdditions + totalDeletions)
 
-  let summaryBarAddWidth = $derived(
-    totalChanges > 0 ? Math.round((totalAdditions / totalChanges) * 60) : 0,
-  )
-  let summaryBarDelWidth = $derived(totalChanges > 0 ? 60 - summaryBarAddWidth : 0)
+  let summaryBarAddPct = $derived(totalChanges > 0 ? (totalAdditions / totalChanges) * 100 : 0)
+  let summaryBarDelPct = $derived(totalChanges > 0 ? 100 - summaryBarAddPct : 0)
 
   // Expose file count to parent via bindable prop
   $effect(() => {
@@ -186,10 +184,10 @@
         class="flex items-stretch h-1.5 rounded-sm overflow-hidden flex-1 min-w-5 bg-border-subtle"
       >
         {#if totalAdditions > 0}
-          <span class="block h-full bg-diff-add-fg" style="width: {summaryBarAddWidth}px"></span>
+          <span class="block h-full bg-diff-add-fg" style="width: {summaryBarAddPct}%"></span>
         {/if}
         {#if totalDeletions > 0}
-          <span class="block h-full bg-diff-delete-fg" style="width: {summaryBarDelWidth}px"></span>
+          <span class="block h-full bg-diff-delete-fg" style="width: {summaryBarDelPct}%"></span>
         {/if}
       </span>
     </div>

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -476,7 +476,7 @@
             onpointerleave={() => (hoveredFilePath = null)}
           >
             <div
-              class="file-header flex items-center gap-2 px-4 py-2 bg-bg-elevated border-b border-border-subtle sticky top-0 z-10 cursor-pointer select-none hover:bg-file-header-hover"
+              class="file-header flex items-center gap-2 h-9 px-4 bg-bg-elevated border-b border-border-subtle sticky top-0 z-10 cursor-pointer select-none hover:bg-file-header-hover"
               role="button"
               tabindex="0"
               aria-expanded={!collapsedFiles.has(file.path)}

--- a/src/renderer/src/components/editor/EditorPane.svelte
+++ b/src/renderer/src/components/editor/EditorPane.svelte
@@ -598,7 +598,7 @@
           title={dirty ? 'Save (Cmd/Ctrl+S)' : 'No changes'}
           aria-label="Save file"
         >
-          <Save size={13} />
+          <Save size={12} />
         </button>
       {/if}
       <button
@@ -607,7 +607,7 @@
         title="Refresh"
         aria-label="Refresh file"
       >
-        <RotateCw size={13} />
+        <RotateCw size={12} />
       </button>
       <button
         class="toolbar-btn"
@@ -615,7 +615,7 @@
         title="Show in Folder"
         aria-label="Show in Folder"
       >
-        <FolderOpen size={13} />
+        <FolderOpen size={12} />
       </button>
     </div>
   </div>
@@ -753,38 +753,35 @@
   .sub-tabs {
     display: flex;
     align-items: stretch;
-    gap: 1px;
-    background: var(--color-bg-glass-heavy);
+    background: transparent;
     border-bottom: 1px solid var(--color-border-subtle);
     overflow-x: auto;
-    min-height: 30px;
+    height: 32px;
     flex-shrink: 0;
     user-select: none;
   }
 
   .sub-tab {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 4px 8px 4px 12px;
+    gap: 4px;
+    padding: 0 12px;
     max-width: 240px;
     background: transparent;
     border: none;
-    border-right: 1px solid var(--color-border-subtle);
-    color: var(--color-text-muted);
+    color: var(--color-text-faint);
     font-size: 12px;
     cursor: pointer;
     white-space: nowrap;
     position: relative;
+    transition: color var(--duration-fast) var(--ease-std);
   }
 
   .sub-tab:hover {
-    background: var(--color-hover);
-    color: var(--color-text);
+    color: var(--color-text-secondary);
   }
 
   .sub-tab.active {
-    background: var(--color-bg);
     color: var(--color-text);
   }
 
@@ -793,7 +790,7 @@
     position: absolute;
     left: 0;
     right: 0;
-    bottom: -1px;
+    bottom: 0;
     height: 2px;
     background: var(--color-accent);
   }
@@ -817,14 +814,17 @@
     width: 16px;
     height: 16px;
     border-radius: 3px;
-    color: var(--color-text-muted);
-    opacity: 0.6;
+    color: var(--color-text-faint);
+    background: transparent;
     cursor: pointer;
+    transition:
+      color var(--duration-fast) var(--ease-std),
+      background var(--duration-fast) var(--ease-std);
   }
 
   .sub-tab-close:hover {
-    background: var(--color-hover-strong);
-    opacity: 1;
+    background: var(--color-hover);
+    color: var(--color-text);
   }
 
   .sub-tab.dragging {
@@ -850,10 +850,10 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 4px 10px;
+    padding: 0 12px;
     height: 32px;
     min-height: 32px;
-    background: var(--color-bg-glass-heavy);
+    background: transparent;
     border-bottom: 1px solid var(--color-border-subtle);
     user-select: none;
   }
@@ -881,40 +881,59 @@
 
   .file-path {
     font-size: 11px;
-    color: var(--color-text-muted);
+    color: var(--color-text-faint);
+    font-family: var(--font-mono);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .file-size {
+    display: inline-flex;
+    align-items: center;
+    height: 16px;
+    padding: 0 6px;
+    border-radius: 3px;
+    background: var(--color-border-subtle);
+    color: var(--color-text-secondary);
     font-size: 10px;
-    color: var(--color-text-faint);
+    font-family: var(--font-mono);
+    font-weight: 600;
+    line-height: 1;
     white-space: nowrap;
+    flex-shrink: 0;
   }
 
   .toolbar-actions {
     display: flex;
-    gap: 2px;
+    gap: 4px;
     flex-shrink: 0;
   }
 
   .toolbar-btn {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
     background: none;
     border: none;
-    border-radius: 4px;
-    color: var(--color-text-muted);
+    border-radius: 3px;
+    color: var(--color-text-faint);
     cursor: pointer;
+    transition:
+      color var(--duration-fast) var(--ease-std),
+      background var(--duration-fast) var(--ease-std);
   }
 
   .toolbar-btn:hover {
-    background: var(--color-active);
-    color: var(--color-text);
+    background: var(--color-hover);
+    color: var(--color-text-secondary);
+  }
+
+  .toolbar-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
   }
 
   .content-area {
@@ -1049,12 +1068,12 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 3px 10px;
-    min-height: 24px;
+    padding: 0 12px;
+    height: 24px;
     background: var(--color-bg-glass-heavy);
     border-top: 1px solid var(--color-border-subtle);
     font-size: 11px;
-    color: var(--color-text-muted);
+    color: var(--color-text-faint);
     user-select: none;
     flex-shrink: 0;
   }
@@ -1068,14 +1087,16 @@
   }
 
   .status-badge {
-    padding: 1px 6px;
+    display: inline-flex;
+    align-items: center;
+    height: 18px;
+    padding: 0 6px;
     font-size: 10px;
-    font-weight: 500;
-    line-height: 1.4;
+    font-weight: 600;
+    line-height: 1;
     border-radius: 3px;
     background: var(--color-accent-bg);
     color: var(--color-accent-text);
-    border: 1px solid var(--color-accent-muted);
     white-space: nowrap;
   }
 
@@ -1090,24 +1111,29 @@
   }
 
   .status-btn {
-    padding: 1px 6px;
+    display: inline-flex;
+    align-items: center;
+    height: 18px;
+    padding: 0 6px;
     font-size: 11px;
     background: none;
-    border: 1px solid transparent;
+    border: 0;
     border-radius: 3px;
-    color: var(--color-text-muted);
+    color: var(--color-text-faint);
     cursor: pointer;
-    line-height: 1.4;
+    line-height: 1;
+    transition:
+      color var(--duration-fast) var(--ease-std),
+      background var(--duration-fast) var(--ease-std);
   }
 
   .status-btn:hover {
     background: var(--color-hover);
-    color: var(--color-text);
+    color: var(--color-text-secondary);
   }
 
   .status-btn.active {
-    background: var(--color-active);
-    color: var(--color-text);
-    border-color: var(--color-border);
+    background: var(--color-border-subtle);
+    color: var(--color-text-secondary);
   }
 </style>

--- a/src/renderer/src/components/editor/cm/theme.ts
+++ b/src/renderer/src/components/editor/cm/theme.ts
@@ -38,6 +38,13 @@ const canopyTheme = EditorView.theme({
     padding: '0 8px 0 6px',
     minWidth: '2.5em',
   },
+  '.cm-foldGutter .cm-gutterElement': {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: '0',
+    paddingBottom: '0',
+  },
   '.cm-tooltip': {
     backgroundColor: 'var(--color-bg-elevated)',
     color: 'var(--color-text)',

--- a/src/renderer/src/components/layout/RightPanel.svelte
+++ b/src/renderer/src/components/layout/RightPanel.svelte
@@ -25,48 +25,42 @@
   class="min-w-50 max-w-125 h-full bg-bg border-l border-border-subtle flex flex-col flex-shrink-0"
   style:width="{width}px"
 >
-  <div class="flex items-center justify-center px-3 py-2 flex-shrink-0">
-    <div class="flex gap-1 w-full bg-bg-input rounded-lg p-0.5" role="tablist">
-      <button
-        class="flex-1 flex items-center justify-center gap-1 h-6 text-xs font-medium cursor-pointer border-0 font-inherit rounded-md transition-colors duration-base motion-reduce:transition-none"
-        class:bg-active={workspaceState.rightPanelTab === 'session'}
-        class:bg-transparent={workspaceState.rightPanelTab !== 'session'}
-        class:text-text={workspaceState.rightPanelTab === 'session'}
-        class:text-text-secondary={workspaceState.rightPanelTab !== 'session'}
-        class:hover:bg-hover={workspaceState.rightPanelTab !== 'session'}
-        class:hover:text-text={workspaceState.rightPanelTab !== 'session'}
-        role="tab"
-        aria-selected={workspaceState.rightPanelTab === 'session'}
-        onclick={() => (workspaceState.rightPanelTab = 'session')}
-      >
-        Session
-      </button>
-      <button
-        class="flex-1 flex items-center justify-center gap-1 h-6 text-xs font-medium cursor-pointer border-0 font-inherit rounded-md transition-colors duration-base motion-reduce:transition-none"
-        class:bg-active={workspaceState.rightPanelTab === 'changes'}
-        class:bg-transparent={workspaceState.rightPanelTab !== 'changes'}
-        class:text-text={workspaceState.rightPanelTab === 'changes'}
-        class:text-text-secondary={workspaceState.rightPanelTab !== 'changes'}
-        class:hover:bg-hover={workspaceState.rightPanelTab !== 'changes'}
-        class:hover:text-text={workspaceState.rightPanelTab !== 'changes'}
-        role="tab"
-        aria-selected={workspaceState.rightPanelTab === 'changes'}
-        onclick={() => (workspaceState.rightPanelTab = 'changes')}
-      >
-        Changes
-        {#if workspaceState.changesCount > 0}
-          <span
-            class="text-2xs font-semibold min-w-3.5 h-3.5 rounded-3xl inline-flex items-center justify-center px-1 leading-none"
-            class:bg-border={workspaceState.rightPanelTab === 'changes'}
-            class:text-text={workspaceState.rightPanelTab === 'changes'}
-            class:bg-active={workspaceState.rightPanelTab !== 'changes'}
-            class:text-text-secondary={workspaceState.rightPanelTab !== 'changes'}
-          >
-            {workspaceState.changesCount}
-          </span>
-        {/if}
-      </button>
-    </div>
+  <div class="flex items-stretch px-3 border-b border-border-subtle flex-shrink-0" role="tablist">
+    <button
+      class="relative flex-1 inline-flex items-center justify-center gap-1.5 h-9 text-xs font-medium font-inherit border-0 bg-transparent cursor-pointer transition-colors duration-fast"
+      class:text-text={workspaceState.rightPanelTab === 'session'}
+      class:text-text-faint={workspaceState.rightPanelTab !== 'session'}
+      class:hover:text-text-secondary={workspaceState.rightPanelTab !== 'session'}
+      role="tab"
+      aria-selected={workspaceState.rightPanelTab === 'session'}
+      onclick={() => (workspaceState.rightPanelTab = 'session')}
+    >
+      Session
+      {#if workspaceState.rightPanelTab === 'session'}
+        <span class="absolute inset-x-0 -bottom-px h-0.5 bg-accent" aria-hidden="true"></span>
+      {/if}
+    </button>
+    <button
+      class="relative flex-1 inline-flex items-center justify-center gap-1.5 h-9 text-xs font-medium font-inherit border-0 bg-transparent cursor-pointer transition-colors duration-fast"
+      class:text-text={workspaceState.rightPanelTab === 'changes'}
+      class:text-text-faint={workspaceState.rightPanelTab !== 'changes'}
+      class:hover:text-text-secondary={workspaceState.rightPanelTab !== 'changes'}
+      role="tab"
+      aria-selected={workspaceState.rightPanelTab === 'changes'}
+      onclick={() => (workspaceState.rightPanelTab = 'changes')}
+    >
+      Changes
+      {#if workspaceState.changesCount > 0}
+        <span
+          class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-sm bg-border-subtle text-text-secondary text-2xs font-semibold tracking-caps-tight tabular-nums leading-none"
+        >
+          {workspaceState.changesCount}
+        </span>
+      {/if}
+      {#if workspaceState.rightPanelTab === 'changes'}
+        <span class="absolute inset-x-0 -bottom-px h-0.5 bg-accent" aria-hidden="true"></span>
+      {/if}
+    </button>
   </div>
 
   <div
@@ -77,7 +71,7 @@
       <AgentInspector state={agentState} />
     {:else}
       <div class="flex items-center justify-center h-full p-4">
-        <span class="text-sm text-text-muted">No active agent session</span>
+        <span class="text-sm text-text-faint">No active agent session</span>
       </div>
     {/if}
   </div>
@@ -90,7 +84,7 @@
       <ChangesPanel {worktreePath} bind:fileCount={changesFileCount} />
     {:else}
       <div class="flex items-center justify-center h-full p-4">
-        <span class="text-sm text-text-muted">No changes yet</span>
+        <span class="text-sm text-text-faint">No changes yet</span>
       </div>
     {/if}
   </div>

--- a/src/renderer/src/components/layout/StatusBar.svelte
+++ b/src/renderer/src/components/layout/StatusBar.svelte
@@ -318,7 +318,7 @@
             onclick={openPerfHudSettings}
           >
             <Cpu size={11} class="flex-shrink-0 text-text-faint" />
-            <span class="text-2xs font-mono" style="transform: translateY(1px)"
+            <span class="text-2xs font-mono mt-px"
               >{perfHudState.metrics.cpu}% · {perfHudState.metrics.memMb} MB</span
             >
           </button>

--- a/src/renderer/src/components/layout/StatusBar.svelte
+++ b/src/renderer/src/components/layout/StatusBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { match } from 'ts-pattern'
+  import { Settings, GitBranch, Folder, Bell, ArrowDownToLine, Eye, Cpu } from '@lucide/svelte'
   import { workspaceState, projects, toggleRightPanel } from '../../lib/stores/workspace.svelte'
   import { agentSessions, type AgentSessionState } from '../../lib/agents/agentState.svelte'
   import { getAllTabs, activeTabId, focusSessionByPtyId } from '../../lib/stores/tabs.svelte'
@@ -8,7 +9,6 @@
   import { prefs } from '../../lib/stores/preferences.svelte'
   import { perfHudState, enablePerfHud, disablePerfHud } from '../../lib/stores/perfHud.svelte'
   import { showPreferences } from '../../lib/stores/dialogs.svelte'
-  import { Settings } from '@lucide/svelte'
 
   const AI_TOOL_IDS = new Set(['claude', 'codex', 'opencode', 'gemini'])
 
@@ -187,12 +187,13 @@
 
 {#if projects.length > 0}
   <footer
-    class="flex items-center justify-between gap-3 w-full h-status-bar px-2 bg-bg-glass border-t border-border-subtle font-sans text-xs font-medium text-text-secondary select-none flex-shrink-0 app-no-drag"
+    class="flex items-center justify-between gap-4 w-full h-status-bar px-3 pb-px bg-bg-glass border-t border-border-subtle font-sans text-xs font-medium text-text-faint select-none flex-shrink-0 app-no-drag"
   >
-    <div class="flex items-center gap-3 min-w-0">
+    <!-- LEFT: focused-pane info -->
+    <div class="flex items-center gap-2 min-w-0">
       {#if focusedPaneKind === 'agent' && activeAgent}
         <span
-          class="flex items-center gap-1 leading-none whitespace-nowrap font-medium"
+          class="inline-flex items-center h-5 px-1.5 whitespace-nowrap font-medium"
           class:text-text-secondary={activeAgent.status.type !== 'thinking' &&
             activeAgent.status.type !== 'toolCalling' &&
             activeAgent.status.type !== 'compacting' &&
@@ -208,14 +209,14 @@
         </span>
 
         {#if activeAgent.model}
-          <span class="flex items-center gap-1 leading-none whitespace-nowrap text-text-muted"
+          <span class="inline-flex items-center h-5 whitespace-nowrap text-text-faint"
             >{activeAgent.model}</span
           >
         {/if}
 
         {#if activeAgent.contextPercent != null}
           <span
-            class="flex items-center gap-1 leading-none whitespace-nowrap font-mono text-xs tabular-nums"
+            class="inline-flex items-center h-5 whitespace-nowrap font-mono tabular-nums"
             style="color: {contextColor(activeAgent.contextPercent)}"
             title="Context window usage"
           >
@@ -225,7 +226,7 @@
 
         {#if activeAgent.costUsd != null}
           <span
-            class="flex items-center gap-1 leading-none whitespace-nowrap font-mono text-xs"
+            class="inline-flex items-center h-5 whitespace-nowrap font-mono text-text-faint"
             title="Session cost"
           >
             {formatCost(activeAgent.costUsd)}
@@ -234,165 +235,166 @@
 
         {#if taskProgress}
           <span
-            class="flex items-center gap-1 leading-none whitespace-nowrap text-text-muted"
+            class="inline-flex items-center h-5 whitespace-nowrap text-text-faint tabular-nums"
             title="Task progress"
           >
             {taskProgress.done}/{taskProgress.total} tasks
           </span>
         {/if}
       {:else if focusedPaneKind === 'shell'}
-        <span class="flex items-center gap-1 leading-none text-text-muted">Shell</span>
+        <span class="inline-flex items-center h-5 text-text-faint">Shell</span>
       {:else if focusedPaneKind === 'notes'}
-        <span class="flex items-center gap-1 leading-none text-text-muted">Notes</span>
+        <span class="inline-flex items-center h-5 text-text-faint">Notes</span>
       {:else if focusedPaneKind === 'drawing'}
-        <span class="flex items-center gap-1 leading-none text-text-muted">Drawing</span>
+        <span class="inline-flex items-center h-5 text-text-faint">Drawing</span>
       {/if}
     </div>
 
-    <div class="flex items-center gap-3 min-w-0">
-      {#if workspaceState.isGitRepo && workspaceState.branch}
-        <button
-          class="flex items-center gap-1 leading-none whitespace-nowrap border-0 bg-transparent text-inherit font-inherit px-1 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text"
-          aria-label="Branch: {workspaceState.branch}{workspaceState.isDirty
-            ? ', uncommitted changes'
-            : ''}"
-          title="Branch: {workspaceState.branch}"
-        >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-            <path
-              d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 2.122a2.25 2.25 0 1 0-1 0v1.836A2.252 2.252 0 0 0 2 9.5a2.25 2.25 0 1 0 3.163.132l2.382-2.382A1.75 1.75 0 0 1 8.783 6.75h1.467a2.25 2.25 0 1 0 0-1.5H8.783a3.25 3.25 0 0 0-2.299.952L4.5 8.186V5.372ZM4.25 12a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Zm8.25-6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z"
-            />
-          </svg>
-          <span class="overflow-hidden text-ellipsis max-w-40 font-mono text-xs"
-            >{workspaceState.branch}</span
-          >
-          {#if workspaceState.isDirty}
-            <span
-              class="w-1.5 h-1.5 rounded-full bg-warning-text flex-shrink-0"
-              title="Uncommitted changes"
-              aria-hidden="true"
-            ></span>
-          {/if}
-        </button>
-
-        {#if workspaceState.aheadBehind && (workspaceState.aheadBehind.ahead > 0 || workspaceState.aheadBehind.behind > 0)}
-          {@const ahead = workspaceState.aheadBehind.ahead}
-          {@const behind = workspaceState.aheadBehind.behind}
+    <!-- RIGHT: three sub-groups separated by hairline dividers -->
+    <div class="flex items-center min-w-0">
+      <!-- Sub-group A: git -->
+      <div class="flex items-center gap-2">
+        {#if workspaceState.isGitRepo && workspaceState.branch}
           <button
-            class="flex items-center gap-1 leading-none whitespace-nowrap border-0 bg-transparent text-inherit font-mono text-xs px-1 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text"
-            aria-label="{ahead > 0 ? `${ahead} ahead` : ''}{ahead > 0 && behind > 0
-              ? ', '
-              : ''}{behind > 0 ? `${behind} behind` : ''}"
-            title="{ahead > 0 ? `${ahead} ahead` : ''}{ahead > 0 && behind > 0 ? ', ' : ''}{behind >
-            0
-              ? `${behind} behind`
+            class="inline-flex items-center gap-1.5 h-5 px-1.5 rounded-sm border-0 bg-transparent font-inherit text-text-faint cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text-secondary"
+            aria-label="Branch: {workspaceState.branch}{workspaceState.isDirty
+              ? ', uncommitted changes'
               : ''}"
+            title="Branch: {workspaceState.branch}"
           >
-            {#if ahead > 0}<span aria-hidden="true">&#8593;{ahead}</span>{/if}
-            {#if behind > 0}<span aria-hidden="true">&#8595;{behind}</span>{/if}
+            <GitBranch size={12} class="flex-shrink-0" />
+            <span class="overflow-hidden text-ellipsis max-w-40 font-mono text-xs whitespace-nowrap"
+              >{workspaceState.branch}</span
+            >
+            {#if workspaceState.isDirty}
+              <span
+                class="size-1.5 rounded-full bg-warning-text flex-shrink-0"
+                title="Uncommitted changes"
+                aria-hidden="true"
+              ></span>
+            {/if}
+          </button>
+
+          {#if workspaceState.aheadBehind && (workspaceState.aheadBehind.ahead > 0 || workspaceState.aheadBehind.behind > 0)}
+            {@const ahead = workspaceState.aheadBehind.ahead}
+            {@const behind = workspaceState.aheadBehind.behind}
+            <button
+              class="inline-flex items-center gap-1 h-5 px-1.5 rounded-sm border-0 bg-border-subtle font-inherit text-text-secondary font-mono text-2xs font-semibold tabular-nums leading-none cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text"
+              aria-label="{ahead > 0 ? `${ahead} ahead` : ''}{ahead > 0 && behind > 0
+                ? ', '
+                : ''}{behind > 0 ? `${behind} behind` : ''}"
+              title="{ahead > 0 ? `${ahead} ahead` : ''}{ahead > 0 && behind > 0
+                ? ', '
+                : ''}{behind > 0 ? `${behind} behind` : ''}"
+            >
+              {#if ahead > 0}<span aria-hidden="true">↑{ahead}</span>{/if}
+              {#if behind > 0}<span aria-hidden="true">↓{behind}</span>{/if}
+            </button>
+          {/if}
+        {/if}
+
+        {#if worktreeCount > 1 && worktreeName}
+          <span
+            class="inline-flex items-center gap-1.5 h-5 px-1.5 whitespace-nowrap text-text-faint"
+            title="Worktree: {worktreeName}"
+          >
+            <Folder size={12} class="flex-shrink-0" />
+            <span class="overflow-hidden text-ellipsis max-w-35">{worktreeName}</span>
+          </span>
+        {/if}
+      </div>
+
+      {#if perfHudEnabled || agentCount > 0 || permissionSessionId || hasUpdate}
+        <span class="self-stretch w-px bg-border-subtle mx-3" aria-hidden="true"></span>
+      {/if}
+
+      <!-- Sub-group B: perf / agents / alerts -->
+      <div class="flex items-center gap-2">
+        {#if perfHudEnabled && perfHudState.metrics}
+          <button
+            class="inline-flex items-center gap-1.5 h-5 px-1.5 rounded-sm border-0 bg-border-subtle font-inherit text-text-secondary tabular-nums leading-none cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text"
+            aria-label="App CPU {perfHudState.metrics.cpu}%, RAM {perfHudState.metrics.memMb} MB"
+            title="App CPU / RAM — click to open settings"
+            onclick={openPerfHudSettings}
+          >
+            <Cpu size={11} class="flex-shrink-0 text-text-faint" />
+            <span class="text-2xs font-mono" style="transform: translateY(1px)"
+              >{perfHudState.metrics.cpu}% · {perfHudState.metrics.memMb} MB</span
+            >
           </button>
         {/if}
-      {/if}
 
-      {#if worktreeCount > 1 && worktreeName}
-        <span
-          class="flex items-center gap-1 leading-none whitespace-nowrap"
-          title="Worktree: {worktreeName}"
-        >
-          <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor">
-            <path
-              d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z"
-            />
-          </svg>
-          <span class="overflow-hidden text-ellipsis max-w-35">{worktreeName}</span>
-        </span>
-      {/if}
+        {#if agentCount > 0}
+          <button
+            class="inline-flex items-center gap-1.5 h-5 px-1.5 rounded-sm border-0 bg-transparent font-inherit text-text-faint cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text-secondary"
+            aria-label="{agentCount} agent{agentCount !== 1 ? 's' : ''}{globalWorstStatus !== 'none'
+              ? `, ${globalStatusLabel(globalWorstStatus)}`
+              : ''}"
+            title="{agentCount} agent{agentCount !== 1 ? 's' : ''}{globalWorstStatus !== 'none'
+              ? ` — ${globalStatusLabel(globalWorstStatus)}`
+              : ''}"
+            onclick={focusWorstAgent}
+          >
+            <span
+              class="size-2 rounded-full flex-shrink-0"
+              class:animate-badge-pulse={globalWorstStatus === 'waitingPermission' ||
+                globalWorstStatus === 'working'}
+              class:motion-reduce:animate-none={globalWorstStatus === 'waitingPermission' ||
+                globalWorstStatus === 'working'}
+              style="background: {statusDotColor(globalWorstStatus)}"
+            ></span>
+            <span
+              class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-sm bg-border-subtle text-text-secondary text-2xs font-semibold tabular-nums leading-none"
+              >{agentCount}</span
+            >
+          </button>
+        {/if}
 
-      {#if perfHudEnabled && perfHudState.metrics}
+        {#if permissionSessionId}
+          <button
+            class="inline-flex items-center h-5 px-1.5 rounded-sm border-0 bg-transparent font-inherit text-warning-text animate-badge-pulse motion-reduce:animate-none cursor-pointer transition-colors duration-fast hover:bg-hover"
+            aria-label="Agent waiting for permission"
+            title="Agent waiting for permission"
+            onclick={focusPermissionAgent}
+          >
+            <Bell size={13} class="flex-shrink-0" />
+          </button>
+        {/if}
+
+        {#if hasUpdate}
+          <button
+            class="inline-flex items-center h-5 px-1.5 rounded-sm border-0 bg-transparent font-inherit text-accent-text cursor-pointer transition-colors duration-fast hover:bg-hover"
+            aria-label="Install update v{updateState.version}"
+            title="Update v{updateState.version} ready to install"
+            onclick={installUpdate}
+          >
+            <ArrowDownToLine size={13} class="flex-shrink-0" />
+          </button>
+        {/if}
+      </div>
+
+      <span class="self-stretch w-px bg-border-subtle mx-3" aria-hidden="true"></span>
+
+      <!-- Sub-group C: app actions -->
+      <div class="flex items-center gap-1">
         <button
-          class="flex items-center gap-1 leading-none whitespace-nowrap border-0 bg-transparent text-text-muted font-inherit tabular-nums px-1 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text"
-          aria-label="App CPU {perfHudState.metrics.cpu}%, RAM {perfHudState.metrics.memMb} MB"
-          title="App CPU / RAM — click to open settings"
-          onclick={openPerfHudSettings}
+          class="inline-flex items-center justify-center size-5 rounded-sm border-0 bg-transparent font-inherit text-text-faint cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text-secondary"
+          aria-label="Toggle Inspector"
+          title="Toggle Inspector"
+          onclick={() => toggleRightPanel()}
         >
-          {perfHudState.metrics.cpu}% · {perfHudState.metrics.memMb} MB
+          <Eye size={13} />
         </button>
-      {/if}
 
-      {#if agentCount > 0}
         <button
-          class="flex items-center gap-1 leading-none whitespace-nowrap border-0 bg-transparent text-inherit font-inherit px-1 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text"
-          aria-label="{agentCount} agent{agentCount !== 1 ? 's' : ''}{globalWorstStatus !== 'none'
-            ? `, ${globalStatusLabel(globalWorstStatus)}`
-            : ''}"
-          title="{agentCount} agent{agentCount !== 1 ? 's' : ''}{globalWorstStatus !== 'none'
-            ? ` — ${globalStatusLabel(globalWorstStatus)}`
-            : ''}"
-          onclick={focusWorstAgent}
+          class="inline-flex items-center justify-center size-5 rounded-sm border-0 bg-transparent font-inherit text-text-faint cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text-secondary"
+          aria-label="Open Settings"
+          title="Open Settings"
+          onclick={() => showPreferences()}
         >
-          <span
-            class="w-2 h-2 rounded-full flex-shrink-0"
-            class:animate-badge-pulse={globalWorstStatus === 'waitingPermission' ||
-              globalWorstStatus === 'working'}
-            class:motion-reduce:animate-none={globalWorstStatus === 'waitingPermission' ||
-              globalWorstStatus === 'working'}
-            style="background: {statusDotColor(globalWorstStatus)}"
-          ></span>
-          <span class="overflow-hidden text-ellipsis max-w-35">{agentCount}</span>
+          <Settings size={13} />
         </button>
-      {/if}
-
-      {#if permissionSessionId}
-        <button
-          class="flex items-center gap-1 leading-none whitespace-nowrap border-0 bg-transparent font-inherit text-warning-text animate-badge-pulse motion-reduce:animate-none px-1 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:bg-hover"
-          aria-label="Agent waiting for permission"
-          title="Agent waiting for permission"
-          onclick={focusPermissionAgent}
-        >
-          <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
-            <path
-              d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2ZM8 1.918l-.797.161A4.002 4.002 0 0 0 4 6c0 .628-.134 2.197-.459 3.742-.16.767-.376 1.566-.663 2.258h10.244c-.287-.692-.502-1.49-.663-2.258C12.134 8.197 12 6.628 12 6a4.002 4.002 0 0 0-3.203-3.92L8 1.917ZM14.22 12c.223.447.481.801.78 1H1c.299-.199.557-.553.78-1C2.68 10.2 3 6.88 3 6c0-2.42 1.72-4.44 4.005-4.901a1 1 0 1 1 1.99 0A5.002 5.002 0 0 1 13 6c0 .88.32 4.2 1.22 6Z"
-            />
-          </svg>
-        </button>
-      {/if}
-
-      {#if hasUpdate}
-        <button
-          class="flex items-center gap-1 leading-none whitespace-nowrap border-0 bg-transparent font-inherit text-accent-text px-1 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:bg-hover"
-          aria-label="Install update v{updateState.version}"
-          title="Update v{updateState.version} ready to install"
-          onclick={installUpdate}
-        >
-          <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
-            <path
-              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 1.371 1.37V3.5a.25.25 0 0 1 .25-.25h.006a.25.25 0 0 1 .25.25v3.097l1.371-1.37a.25.25 0 0 1 .354.353l-1.793 1.793a.252.252 0 0 1-.166.073h-.027a.252.252 0 0 1-.166-.073L6.025 5.58a.25.25 0 0 1 .354-.353ZM5 10.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Z"
-            />
-          </svg>
-        </button>
-      {/if}
-
-      <button
-        class="flex items-center gap-1 leading-none whitespace-nowrap border-0 bg-transparent font-inherit text-text-muted px-1 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text"
-        aria-label="Toggle Inspector"
-        title="Toggle Inspector"
-        onclick={() => toggleRightPanel()}
-      >
-        <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
-          <path
-            d="M8 2c1.981 0 3.671.992 4.933 2.078 1.27 1.091 2.187 2.345 2.637 3.023a1.62 1.62 0 0 1 0 1.798c-.45.678-1.367 1.932-2.637 3.023C11.67 13.008 9.981 14 8 14c-1.981 0-3.671-.992-4.933-2.078C1.797 10.83.88 9.576.43 8.898a1.62 1.62 0 0 1 0-1.798c.45-.677 1.367-1.931 2.637-3.022C4.33 2.992 6.019 2 8 2ZM1.679 7.932a.12.12 0 0 0 0 .136c.411.622 1.241 1.75 2.366 2.717C5.176 11.758 6.527 12.5 8 12.5c1.473 0 2.825-.742 3.955-1.715 1.124-.967 1.954-2.096 2.366-2.717a.12.12 0 0 0 0-.136c-.412-.621-1.242-1.75-2.366-2.717C10.824 4.242 9.473 3.5 8 3.5c-1.473 0-2.824.742-3.955 1.715-1.124.967-1.954 2.096-2.366 2.717ZM8 10a2 2 0 1 1-.001-3.999A2 2 0 0 1 8 10Z"
-          />
-        </svg>
-      </button>
-
-      <button
-        class="flex items-center gap-1 leading-none whitespace-nowrap border-0 bg-transparent font-inherit text-text-muted px-1 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text"
-        aria-label="Open Settings"
-        title="Open Settings"
-        onclick={() => showPreferences()}
-      >
-        <Settings size={13} />
-      </button>
+      </div>
     </div>
   </footer>
 {/if}

--- a/src/renderer/src/components/palette/CommandPalette.svelte
+++ b/src/renderer/src/components/palette/CommandPalette.svelte
@@ -2,6 +2,15 @@
   import { onMount } from 'svelte'
   import { SvelteMap } from 'svelte/reactivity'
   import {
+    Search,
+    Wrench,
+    GitBranch,
+    GitCommitVertical,
+    PanelLeft,
+    Sliders,
+    Terminal,
+  } from 'lucide-svelte'
+  import {
     workspaceState,
     toggleSidebar,
     toggleRightPanel,
@@ -56,6 +65,15 @@
 
   const isMac = navigator.userAgent.includes('Mac')
   const mod = isMac ? 'Cmd' : 'Ctrl'
+
+  const CATEGORY_ICON: Record<string, typeof Search> = {
+    Tools: Wrench,
+    Git: GitCommitVertical,
+    Worktrees: GitBranch,
+    Tabs: PanelLeft,
+    App: Sliders,
+    Terminal,
+  }
 
   let allItems = $derived.by((): PaletteItem[] => {
     const items: PaletteItem[] = []
@@ -615,17 +633,18 @@
 >
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
-    class="w-[520px] max-h-[440px] flex flex-col bg-bg-overlay border border-border rounded-xl shadow-modal backdrop-blur-2xl overflow-hidden self-start"
+    class="w-[520px] max-h-[440px] flex flex-col bg-bg-overlay border border-border-subtle rounded-lg shadow-modal backdrop-blur-2xl overflow-hidden self-start"
     role="dialog"
     aria-modal="true"
     aria-label="Command palette"
     onclick={(e) => e.stopPropagation()}
   >
-    <div class="px-3.5 py-3 border-b border-active flex-shrink-0">
+    <div class="h-12 px-3 flex items-center gap-2 border-b border-border-subtle flex-shrink-0">
+      <Search size={14} class="text-text-faint flex-shrink-0" />
       <input
         bind:this={inputEl}
         bind:value={query}
-        class="w-full border-0 bg-transparent text-text text-lg font-inherit outline-none placeholder:text-text-faint"
+        class="w-full border-0 bg-transparent text-text text-md font-inherit outline-none placeholder:text-text-faint"
         type="text"
         placeholder={filterMode === 'app'
           ? 'Search app commands...'
@@ -639,24 +658,28 @@
 
     <div class="overflow-y-auto flex-1 py-1.5">
       {#if flatItems.length === 0}
-        <div class="px-3.5 py-5 text-center text-text-faint text-md">No results</div>
+        <div class="px-3 py-5 text-center text-text-faint text-md">No results</div>
       {:else}
         {#each groupedItems as group, gi (group.category)}
+          {@const Icon = CATEGORY_ICON[group.category] ?? Sliders}
           <div class="py-0.5">
             <div
-              class="text-2xs font-semibold tracking-[0.8px] text-text-muted px-3.5 pt-1.5 pb-1 uppercase"
+              class="flex items-center gap-1.5 text-2xs font-semibold tracking-caps-looser text-text-faint px-3 pt-2 pb-1 uppercase leading-tight"
             >
-              {group.category}
+              <Icon size={11} class="flex-shrink-0" />
+              <span>{group.category}</span>
             </div>
             {#each group.items as item, ii (item.id)}
               {@const isSelected = flatIndex(gi, ii) === selectedIndex}
+              {@const isShortDesc = !!item.description && item.description.length <= 24}
               <!-- svelte-ignore a11y_click_events_have_key_events -->
               <!-- svelte-ignore a11y_no_static_element_interactions -->
               <div
-                class="flex items-center gap-2.5 px-3.5 py-1.5 cursor-pointer text-md text-text transition-colors duration-fast"
-                class:!bg-active={isSelected}
-                class:!text-text-faint={item.disabled}
-                class:!cursor-default={item.disabled}
+                class="flex items-center gap-2 h-8 px-3 cursor-pointer text-md text-text transition-colors duration-fast"
+                class:bg-accent-bg={isSelected}
+                class:text-accent-text={isSelected}
+                class:opacity-50={item.disabled}
+                class:cursor-default={item.disabled}
                 data-palette-selected={isSelected}
                 onclick={() => {
                   if (!item.disabled) {
@@ -672,13 +695,32 @@
                   >{item.label}</span
                 >
                 {#if item.description}
-                  <span class="text-xs text-text-faint flex-shrink-0">{item.description}</span>
+                  {#if isShortDesc}
+                    <span
+                      class="inline-flex items-center h-5 px-1.5 rounded-sm text-2xs font-semibold tracking-caps-tight uppercase flex-shrink-0 {isSelected
+                        ? 'bg-accent-bg-hover text-accent-text'
+                        : 'bg-border-subtle text-text-faint'}"
+                    >
+                      {item.description}
+                    </span>
+                  {:else}
+                    <span
+                      class="text-xs flex-shrink-0 {isSelected
+                        ? 'text-accent-text'
+                        : 'text-text-faint'}"
+                    >
+                      {item.description}
+                    </span>
+                  {/if}
                 {/if}
                 {#if item.shortcut}
                   <span
-                    class="text-xs text-text-faint px-1.5 py-px rounded-md bg-hover flex-shrink-0"
-                    >{item.shortcut}</span
+                    class="inline-flex items-center h-5 px-1.5 rounded-sm text-2xs font-mono font-semibold flex-shrink-0 {isSelected
+                      ? 'bg-accent-bg-hover text-accent-text'
+                      : 'bg-border-subtle text-text-secondary'}"
                   >
+                    {item.shortcut}
+                  </span>
                 {/if}
               </div>
             {/each}

--- a/src/renderer/src/components/preferences/AgentProfilesPanel.svelte
+++ b/src/renderer/src/components/preferences/AgentProfilesPanel.svelte
@@ -194,7 +194,7 @@
         {#each agentProfiles as p (p.id)}
           {@const active = selectedId === p.id}
           <li
-            class="group/profilerow flex items-center rounded-md hover:bg-hover"
+            class="group/profilerow flex items-center rounded-md hover:bg-hover focus-within:bg-hover"
             class:bg-accent-bg={active}
           >
             <button
@@ -215,7 +215,7 @@
             </button>
             <button
               type="button"
-              class="invisible group-hover/profilerow:visible flex items-center justify-center size-6 mr-1 border-0 bg-transparent rounded-sm text-text-faint cursor-pointer shrink-0 hover:text-danger-text hover:bg-danger-bg"
+              class="opacity-0 group-hover/profilerow:opacity-100 group-focus-within/profilerow:opacity-100 focus-visible:opacity-100 flex items-center justify-center size-6 mr-1 border-0 bg-transparent rounded-sm text-text-faint cursor-pointer shrink-0 hover:text-danger-text hover:bg-danger-bg"
               title="Delete"
               onclick={() => handleDelete(p)}
               aria-label="Delete profile {p.name}"

--- a/src/renderer/src/components/preferences/AgentProfilesPanel.svelte
+++ b/src/renderer/src/components/preferences/AgentProfilesPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { tick, type Component } from 'svelte'
+  import { Plus, Trash2 } from '@lucide/svelte'
   import type { AgentType } from '../../../../main/agents/types'
   import type { AgentProfileMasked, ProfilePrefs } from '../../../../main/profiles/types'
   import { getProfilesByAgent, saveProfile, deleteProfile } from '../../lib/stores/profiles.svelte'
@@ -16,11 +17,9 @@
 
   let {
     agentType,
-    title,
     form: FormComponent,
   }: {
     agentType: AgentType
-    title: string
     form: Component<FormProps>
   } = $props()
 
@@ -170,87 +169,100 @@
   }
 </script>
 
-<div class="flex flex-col gap-4 h-full">
-  <h3 class="text-[15px] font-semibold text-text m-0">{title}</h3>
-  <p class="text-sm text-text-faint m-0 leading-snug">
-    Create multiple profiles to switch between providers (Anthropic, Ollama, GLM, etc.) without
-    re-entering settings. Click a profile in the sidebar to launch it.
-  </p>
+<div class="grid grid-cols-[180px_1fr] gap-5 h-full min-h-0">
+  <aside class="flex flex-col gap-2 border-r border-border-subtle pr-3 min-h-0">
+    <div class="flex items-center justify-between gap-2 pl-1">
+      <span class="text-2xs font-semibold uppercase tracking-caps-looser text-text-faint">
+        Profiles
+      </span>
+      <button
+        type="button"
+        class="flex items-center justify-center size-6 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-hover hover:text-text disabled:opacity-50 disabled:cursor-default"
+        onclick={handleNew}
+        disabled={saving}
+        aria-label="New profile"
+        title="New profile"
+      >
+        <Plus size={14} />
+      </button>
+    </div>
 
-  <div class="grid grid-cols-[200px_1fr] gap-4 flex-1 min-h-0">
-    <aside class="flex flex-col gap-2 border-r border-border pr-3 min-h-0">
-      <div class="flex items-center justify-between gap-2">
-        <span class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted"
-          >Profiles</span
-        >
-        <button
-          class="px-2.5 py-1 border border-dashed border-text-faint rounded-lg bg-transparent text-text-secondary text-sm font-inherit cursor-pointer enabled:hover:bg-hover enabled:hover:text-text disabled:opacity-50 disabled:cursor-not-allowed"
-          onclick={handleNew}
-          disabled={saving}>+ New</button
-        >
-      </div>
-      {#if agentProfiles.length === 0}
-        <div class="text-sm text-text-faint p-2">No profiles yet</div>
-      {:else}
-        <ul class="list-none m-0 p-0 flex flex-col gap-0.5 overflow-y-auto group/profilelist">
-          {#each agentProfiles as p (p.id)}
-            <li
-              class="flex items-center rounded-lg bg-transparent group/profilerow hover:bg-hover"
-              class:!bg-active={selectedId === p.id}
+    {#if agentProfiles.length === 0}
+      <div class="text-sm text-text-faint px-2 py-3">No profiles yet</div>
+    {:else}
+      <ul role="list" class="m-0 p-0 flex flex-col gap-1 overflow-y-auto">
+        {#each agentProfiles as p (p.id)}
+          {@const active = selectedId === p.id}
+          <li
+            class="group/profilerow flex items-center rounded-md hover:bg-hover"
+            class:bg-accent-bg={active}
+          >
+            <button
+              type="button"
+              class="flex-1 flex items-center gap-1.5 px-2 py-1 border-0 bg-transparent font-inherit text-md text-left cursor-pointer min-w-0"
+              class:text-text={!active}
+              class:text-accent-text={active}
+              onclick={() => selectProfile(p.id)}
+              title={p.name}
             >
-              <button
-                class="flex-1 flex items-center gap-1.5 px-2 py-1.5 border-0 bg-transparent text-text font-inherit text-md text-left cursor-pointer min-w-0"
-                onclick={() => selectProfile(p.id)}
-                title={p.name}
-              >
-                <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{p.name}</span>
-                {#if p.isDefault}
-                  <span
-                    class="text-2xs uppercase text-text-faint border border-border rounded-sm px-1"
-                    >default</span
-                  >
-                {/if}
-              </button>
-              <button
-                class="invisible group-hover/profilerow:visible border-0 bg-transparent text-text-faint text-sm cursor-pointer px-2 py-1.5 mr-1 rounded-sm flex-shrink-0 hover:text-danger-text hover:bg-danger-bg"
-                title="Delete"
-                onclick={() => handleDelete(p)}
-                aria-label="Delete profile {p.name}"
-              >
-                ✕
-              </button>
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </aside>
+              <span class="flex-1 truncate">{p.name}</span>
+              {#if p.isDefault}
+                <span
+                  class="text-2xs uppercase tracking-caps-tight text-text-faint border border-border-subtle rounded-sm px-1 shrink-0"
+                  >default</span
+                >
+              {/if}
+            </button>
+            <button
+              type="button"
+              class="invisible group-hover/profilerow:visible flex items-center justify-center size-6 mr-1 border-0 bg-transparent rounded-sm text-text-faint cursor-pointer shrink-0 hover:text-danger-text hover:bg-danger-bg"
+              title="Delete"
+              onclick={() => handleDelete(p)}
+              aria-label="Delete profile {p.name}"
+            >
+              <Trash2 size={12} />
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </aside>
 
-    <section class="flex flex-col gap-4 overflow-y-auto min-h-0">
-      {#if selected}
-        <div class="flex items-end gap-3 pb-3 border-b border-border">
-          <div class="flex flex-col gap-1 flex-1">
-            <label class="text-sm font-medium text-text-secondary" for="profile-name"
-              >Profile name</label
-            >
-            <input
-              id="profile-name"
-              class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-              type="text"
-              bind:this={nameInputEl}
-              value={draftName}
-              oninput={onNameInput}
-              spellcheck="false"
-            />
-          </div>
+  <section class="flex flex-col min-h-0">
+    {#if selected}
+      <div class="flex items-end gap-3 pb-4 mb-7 border-b border-border-subtle shrink-0">
+        <div class="flex flex-col gap-1 flex-1 min-w-0">
+          <label
+            class="text-2xs font-semibold uppercase tracking-caps-looser text-text-faint"
+            for="profile-name">Profile name</label
+          >
+          <input
+            id="profile-name"
+            class="px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring"
+            type="text"
+            name="profileName"
+            bind:this={nameInputEl}
+            value={draftName}
+            oninput={onNameInput}
+            spellcheck="false"
+          />
+        </div>
+        <div class="flex items-center gap-2 shrink-0">
+          {#if dirty}
+            <span class="text-xs text-warning-text">Unsaved changes</span>
+          {/if}
           <button
-            class="px-4 py-1.5 border-0 rounded-lg bg-accent-bg text-accent-text text-md font-inherit cursor-pointer enabled:hover:bg-accent-bg-hover disabled:opacity-50 disabled:cursor-not-allowed"
+            type="button"
+            class="px-3.5 py-1.5 rounded-md text-md font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text enabled:hover:bg-accent-bg-hover disabled:opacity-50 disabled:cursor-default"
             onclick={handleSave}
             disabled={saving || !dirty}
           >
             {saving ? 'Saving…' : 'Save'}
           </button>
         </div>
+      </div>
 
+      <div class="flex-1 overflow-y-auto pr-1 py-2">
         <FormComponent
           prefs={draftPrefs}
           apiKey={draftApiKey}
@@ -258,11 +270,11 @@
           {onPrefsChange}
           {onApiKeyChange}
         />
-      {:else}
-        <div class="text-md text-text-faint p-6 text-center">
-          Select or create a profile to begin.
-        </div>
-      {/if}
-    </section>
-  </div>
+      </div>
+    {:else}
+      <div class="text-md text-text-faint p-6 text-center">
+        Select or create a profile to begin.
+      </div>
+    {/if}
+  </section>
 </div>

--- a/src/renderer/src/components/preferences/AppearancePrefs.svelte
+++ b/src/renderer/src/components/preferences/AppearancePrefs.svelte
@@ -2,6 +2,8 @@
   import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import { themeNames } from '../../lib/terminal/themes'
   import CustomNumberInput from '../shared/CustomNumberInput.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   const DEFAULT_FONT_FAMILY =
     'JetBrains Mono, JetBrainsMono Nerd Font, JetBrainsMono NF, FiraCode Nerd Font, Fira Code, Menlo, monospace'
@@ -21,57 +23,66 @@
   }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Appearance</h3>
-
-  <div class="flex flex-col gap-1.5">
-    <span class="text-sm font-medium text-text-secondary uppercase tracking-[0.5px]">Theme</span>
-    <span class="text-xs text-text-faint">Terminal color scheme</span>
-    <div class="flex flex-wrap gap-1.5" role="group" aria-label="Theme">
-      {#each themeNames as name (name)}
-        <button
-          class="px-2.5 py-1 border border-border rounded-lg bg-border-subtle text-text text-sm font-inherit cursor-pointer transition-colors duration-fast hover:bg-active hover:border-text-faint"
-          class:bg-accent-bg={name === currentTheme}
-          class:border-focus-ring={name === currentTheme}
-          class:text-accent={name === currentTheme}
-          onclick={() => setTheme(name)}
-        >
-          {name}
-        </button>
-      {/each}
-    </div>
-  </div>
-
-  <div class="flex flex-col gap-1.5">
-    <label
-      class="text-sm font-medium text-text-secondary uppercase tracking-[0.5px]"
-      for="font-family">Font Family</label
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Theme" description="Color scheme used by the terminal">
+    <PrefsRow
+      label="Terminal theme"
+      help="Pick a preset; changes apply immediately to all terminal tabs"
+      search="theme color preset palette"
+      layout="stacked"
     >
-    <span class="text-xs text-text-faint">
-      Comma-separated list of fonts for the terminal. First available font is used
-    </span>
-    <input
-      id="font-family"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-mono outline-none focus:border-focus-ring"
-      type="text"
-      value={fontFamily}
-      onchange={updateFontFamily}
-      spellcheck="false"
-    />
-  </div>
+      <div class="flex flex-wrap gap-1.5" role="group" aria-label="Theme">
+        {#each themeNames as name (name)}
+          {@const active = name === currentTheme}
+          <button
+            type="button"
+            class="px-2.5 py-1 border rounded-md text-sm font-inherit cursor-pointer hover:bg-active hover:border-text-faint"
+            class:border-border={!active}
+            class:bg-border-subtle={!active}
+            class:text-text={!active}
+            class:bg-accent-bg={active}
+            class:border-focus-ring={active}
+            class:text-accent={active}
+            onclick={() => setTheme(name)}
+          >
+            {name}
+          </button>
+        {/each}
+      </div>
+    </PrefsRow>
+  </PrefsSection>
 
-  <div class="flex flex-col gap-1.5">
-    <label
-      class="text-sm font-medium text-text-secondary uppercase tracking-[0.5px]"
-      for="font-size">Font Size</label
+  <PrefsSection title="Typography" description="Font used in terminal panes and code views">
+    <PrefsRow
+      label="Font family"
+      help="Comma-separated list of fonts; the first available font is used"
+      search="font family monospace jetbrains mono fira code"
+      layout="stacked"
     >
-    <span class="text-xs text-text-faint">Terminal text size in pixels (8–24)</span>
-    <CustomNumberInput
-      id="font-size"
-      value={fontSize}
-      min={8}
-      max={24}
-      onchange={(v) => setPref('fontSize', v)}
-    />
-  </div>
+      <input
+        id="font-family"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-mono outline-none focus:border-focus-ring"
+        type="text"
+        name="fontFamily"
+        aria-label="Font family"
+        value={fontFamily}
+        onchange={updateFontFamily}
+        spellcheck="false"
+      />
+    </PrefsRow>
+
+    <PrefsRow
+      label="Font size"
+      help="Terminal text size in pixels (8–24)"
+      search="font size pixels"
+    >
+      <CustomNumberInput
+        id="font-size"
+        value={fontSize}
+        min={8}
+        max={24}
+        onchange={(v) => setPref('fontSize', v)}
+      />
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/BranchTokenBuilder.svelte
+++ b/src/renderer/src/components/preferences/BranchTokenBuilder.svelte
@@ -202,105 +202,115 @@
   }
 </script>
 
-<div class="flex items-center gap-2 mb-2">
-  <label class="text-sm text-text-secondary w-[90px] flex-shrink-0">{label}</label>
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div
-    class="flex flex-wrap gap-[3px] flex-1 min-h-7 px-1.5 py-[3px] border border-border rounded-lg bg-bg-input items-center box-content"
-    ondragover={onTrackDragOver}
-    ondrop={onTrackDrop}
-  >
-    {#each templateTokens as token, i (`${token.type}:${token.value}:${i}`)}
-      {#if token.type === 'placeholder'}
-        <span
-          class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-xs cursor-grab select-none transition-all duration-fast bg-accent-bg text-accent-text border active:cursor-grabbing {dragOverIdx ===
-          i
-            ? 'border-focus-ring shadow-[0_0_0_1px_var(--color-accent-muted)]'
-            : 'border-accent-muted'}"
-          draggable="true"
-          ondragstart={() => onTokenDragStart(i)}
-          ondragover={(e) => onTokenDragOver(i, e)}
-          ondrop={() => onTokenDrop(i)}
-          ondragend={onTokenDragEnd}
-          role="listitem"
-        >
-          {token.value}
-          <button
-            class="inline-flex items-center justify-center w-[14px] h-[14px] border-0 rounded-full bg-transparent text-text-muted text-sm leading-none cursor-pointer p-0 hover:bg-danger-bg hover:text-danger-text"
-            onclick={() => removeTokenAt(i)}
-            aria-label="Remove token">×</button
-          >
-        </span>
-      {:else}
-        <button
-          class="inline-flex items-center px-1.5 py-0.5 rounded-md text-xs cursor-grab select-none transition-all duration-fast bg-hover text-text-muted border font-mono active:cursor-grabbing {dragOverIdx ===
-          i
-            ? 'border-focus-ring shadow-[0_0_0_1px_var(--color-accent-muted)]'
-            : 'border-transparent'}"
-          draggable="true"
-          ondragstart={() => onTokenDragStart(i)}
-          ondragover={(e) => onTokenDragOver(i, e)}
-          ondrop={() => onTokenDrop(i)}
-          ondragend={onTokenDragEnd}
-          onclick={(e) => onSeparatorTokenClick(i, e)}
-        >
-          {token.value}
-        </button>
-      {/if}
-    {/each}
-    {#if templateTokens.length === 0}
-      <span class="text-xs text-text-faint px-1 py-0.5 leading-[22px]"
-        >Drag or click tags below to build template</span
-      >
-    {/if}
-  </div>
-</div>
-
-<div class="flex flex-wrap items-center gap-1 mb-1">
-  <span class="text-xs text-text-faint">Available tags: </span>
-  {#each placeholders as ph (ph.key)}
-    <button
-      class="text-xs px-1.5 py-0.5 border border-border rounded-md bg-hover text-text-secondary font-inherit cursor-pointer transition-all duration-fast hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
-      class:!opacity-35={templateInput.includes('{' + ph.key + '}')}
-      class:!cursor-default={templateInput.includes('{' + ph.key + '}')}
-      title={ph.description + ' (e.g. ' + ph.example + ')'}
-      draggable="true"
-      ondragstart={() => onAvailableDragStart(ph.key)}
-      ondragend={onTokenDragEnd}
-      onclick={(e) => addPlaceholderToTemplate(ph.key, e)}
+<div class="flex flex-col gap-1.5">
+  <div class="flex items-center gap-3">
+    <span class="text-sm text-text-secondary w-20 shrink-0">{label}</span>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="flex flex-wrap gap-1 flex-1 min-h-7 px-1.5 py-1 border border-border rounded-md bg-bg-input items-center"
+      ondragover={onTrackDragOver}
+      ondrop={onTrackDrop}
     >
-      &#123;{ph.key}&#125;
-    </button>
-  {/each}
-</div>
+      {#each templateTokens as token, i (`${token.type}:${token.value}:${i}`)}
+        {#if token.type === 'placeholder'}
+          <span
+            class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-sm text-xs font-mono cursor-grab select-none bg-accent-bg text-accent-text border active:cursor-grabbing {dragOverIdx ===
+            i
+              ? 'border-focus-ring'
+              : 'border-accent-muted'}"
+            draggable="true"
+            ondragstart={() => onTokenDragStart(i)}
+            ondragover={(e) => onTokenDragOver(i, e)}
+            ondrop={() => onTokenDrop(i)}
+            ondragend={onTokenDragEnd}
+            role="listitem"
+          >
+            {token.value}
+            <button
+              type="button"
+              class="inline-flex items-center justify-center size-3.5 border-0 rounded-full bg-transparent text-text-muted text-sm leading-none cursor-pointer p-0 hover:bg-danger-bg hover:text-danger-text"
+              onclick={() => removeTokenAt(i)}
+              aria-label="Remove token">×</button
+            >
+          </span>
+        {:else}
+          <button
+            type="button"
+            class="inline-flex items-center px-1.5 py-0.5 rounded-sm text-xs font-mono cursor-grab select-none bg-bg-input text-text-muted border active:cursor-grabbing {dragOverIdx ===
+            i
+              ? 'border-focus-ring'
+              : 'border-border-subtle'}"
+            draggable="true"
+            ondragstart={() => onTokenDragStart(i)}
+            ondragover={(e) => onTokenDragOver(i, e)}
+            ondrop={() => onTokenDrop(i)}
+            ondragend={onTokenDragEnd}
+            onclick={(e) => onSeparatorTokenClick(i, e)}
+          >
+            {token.value}
+          </button>
+        {/if}
+      {/each}
+      {#if templateTokens.length === 0}
+        <span class="text-xs text-text-faint px-1">Drag or click tags below to build template</span>
+      {/if}
+    </div>
+  </div>
 
-<details class="mt-2 mb-2">
-  <summary class="text-xs text-text-faint cursor-pointer mb-1.5">Manual edit</summary>
-  <input
-    class="w-full box-border flex-1 px-2 py-1 border border-border rounded-lg bg-bg-input text-text text-sm font-inherit outline-none focus:border-focus-ring"
-    bind:value={templateInput}
-    oninput={() => onSave()}
-  />
-  <p class="text-sm text-text-muted m-0 mt-1.5 mb-3">
-    Conditional: <code>{'{?parentKey}...{/parentKey}'}</code> — only renders if value exists.
-  </p>
-</details>
+  <div class="flex flex-wrap items-center gap-1 pl-23">
+    <span class="text-2xs uppercase tracking-caps-tight text-text-faint mr-1">Tags</span>
+    {#each placeholders as ph (ph.key)}
+      {@const used = templateInput.includes('{' + ph.key + '}')}
+      <button
+        type="button"
+        class="text-xs px-1.5 py-0.5 border border-border rounded-sm bg-bg-input text-text-secondary font-mono cursor-pointer hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
+        class:opacity-35={used}
+        class:!cursor-default={used}
+        title={ph.description + ' (e.g. ' + ph.example + ')'}
+        draggable="true"
+        ondragstart={() => onAvailableDragStart(ph.key)}
+        ondragend={onTokenDragEnd}
+        onclick={(e) => addPlaceholderToTemplate(ph.key, e)}
+      >
+        {`{${ph.key}}`}
+      </button>
+    {/each}
+  </div>
+
+  <details class="pl-23">
+    <summary class="text-2xs uppercase tracking-caps-tight text-text-faint cursor-pointer mb-1.5"
+      >Manual edit</summary
+    >
+    <input
+      class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-sm font-mono outline-none focus:border-focus-ring"
+      name="manualTemplate"
+      aria-label="Manual template"
+      bind:value={templateInput}
+      oninput={() => onSave()}
+    />
+    <p class="text-xs text-text-muted m-0 mt-1.5">
+      Conditional: <code class="font-mono">{'{?parentKey}…{/parentKey}'}</code> — only renders if value
+      exists.
+    </p>
+  </details>
+</div>
 
 {#if sepPopup.visible}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="fixed inset-0 z-[1100]" onclick={closeSepPopup}>
+  <div class="fixed inset-0 z-popover" onclick={closeSepPopup}>
     <div
-      class="fixed flex items-center gap-1 px-2 py-1 bg-bg-overlay border border-border rounded-lg shadow-[0_4px_16px_var(--color-scrim)] -translate-x-1/2 -translate-y-full -mt-2"
+      class="fixed flex items-center gap-1 px-2 py-1 bg-bg-overlay border border-border rounded-md shadow-popover -translate-x-1/2 -translate-y-full -mt-2"
       style="left:{sepPopup.x}px;top:{sepPopup.y}px"
       onclick={(e) => e.stopPropagation()}
     >
-      <span class="text-2xs text-text-muted mr-0.5">Separator:</span>
+      <span class="text-2xs uppercase tracking-caps-tight text-text-muted mr-0.5">Separator</span>
       {#each SEPARATORS as sep (sep)}
         <button
-          class="px-2.5 py-[3px] border border-border rounded-md bg-hover text-text-secondary text-sm font-inherit cursor-pointer hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
+          type="button"
+          class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-text-secondary text-sm font-mono cursor-pointer hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
           onclick={() => confirmSeparatorAndAdd(sep)}
         >
-          <code>{sep}</code>
+          {sep}
         </button>
       {/each}
     </div>
@@ -309,24 +319,26 @@
 
 {#if editSepPopup.visible}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="fixed inset-0 z-[1100]" onclick={closeEditSepPopup}>
+  <div class="fixed inset-0 z-popover" onclick={closeEditSepPopup}>
     <div
-      class="fixed flex items-center gap-1 px-2 py-1 bg-bg-overlay border border-border rounded-lg shadow-[0_4px_16px_var(--color-scrim)] -translate-x-1/2 -translate-y-full -mt-2"
+      class="fixed flex items-center gap-1 px-2 py-1 bg-bg-overlay border border-border rounded-md shadow-popover -translate-x-1/2 -translate-y-full -mt-2"
       style="left:{editSepPopup.x}px;top:{editSepPopup.y}px"
       onclick={(e) => e.stopPropagation()}
     >
-      <span class="text-2xs text-text-muted mr-0.5">Change to:</span>
+      <span class="text-2xs uppercase tracking-caps-tight text-text-muted mr-0.5">Change to</span>
       {#each SEPARATORS as sep (sep)}
         <button
-          class="px-2.5 py-[3px] border border-border rounded-md bg-hover text-text-secondary text-sm font-inherit cursor-pointer hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
+          type="button"
+          class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-text-secondary text-sm font-mono cursor-pointer hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
           onclick={() => changeSeparator(sep)}
         >
-          <code>{sep}</code>
+          {sep}
         </button>
       {/each}
       <button
-        class="px-2.5 py-[3px] border border-border rounded-md bg-hover text-danger-text text-sm font-inherit cursor-pointer hover:bg-danger-bg hover:border-danger-text"
-        onclick={removeSeparatorToken}>x</button
+        type="button"
+        class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-danger-text text-sm font-mono cursor-pointer hover:bg-danger-bg hover:border-danger-text"
+        onclick={removeSeparatorToken}>×</button
       >
     </div>
   </div>

--- a/src/renderer/src/components/preferences/BranchTokenBuilder.svelte
+++ b/src/renderer/src/components/preferences/BranchTokenBuilder.svelte
@@ -31,17 +31,31 @@
   let dragOverIdx: number | null = $state(null)
   let dragFromAvailable: string | null = $state(null)
 
-  let sepPopup = $state<{ visible: boolean; pendingKey: string; x: number; y: number }>({
+  let sepPopup = $state<{
+    visible: boolean
+    pendingKey: string
+    x: number
+    y: number
+    triggerEl: HTMLElement | null
+  }>({
     visible: false,
     pendingKey: '',
     x: 0,
     y: 0,
+    triggerEl: null,
   })
-  let editSepPopup = $state<{ visible: boolean; tokenIdx: number; x: number; y: number }>({
+  let editSepPopup = $state<{
+    visible: boolean
+    tokenIdx: number
+    x: number
+    y: number
+    triggerEl: HTMLElement | null
+  }>({
     visible: false,
     tokenIdx: -1,
     x: 0,
     y: 0,
+    triggerEl: null,
   })
 
   function parseTemplate(tpl: string): TemplateToken[] {
@@ -78,6 +92,7 @@
         pendingKey: key,
         x: e?.clientX ?? 200,
         y: e?.clientY ?? 200,
+        triggerEl: (e?.currentTarget as HTMLElement) ?? null,
       }
     }
   }
@@ -85,33 +100,39 @@
   function confirmSeparatorAndAdd(sep: string): void {
     const tag = `{${sepPopup.pendingKey}}`
     templateInput = templateInput + sep + tag
-    sepPopup = { visible: false, pendingKey: '', x: 0, y: 0 }
+    sepPopup = { visible: false, pendingKey: '', x: 0, y: 0, triggerEl: null }
     onSave()
   }
 
   function closeSepPopup(): void {
-    sepPopup = { visible: false, pendingKey: '', x: 0, y: 0 }
+    sepPopup = { visible: false, pendingKey: '', x: 0, y: 0, triggerEl: null }
   }
 
   function onSeparatorTokenClick(index: number, e: MouseEvent): void {
-    editSepPopup = { visible: true, tokenIdx: index, x: e.clientX, y: e.clientY }
+    editSepPopup = {
+      visible: true,
+      tokenIdx: index,
+      x: e.clientX,
+      y: e.clientY,
+      triggerEl: e.currentTarget as HTMLElement,
+    }
   }
 
   function changeSeparator(newSep: string): void {
     const tokens = [...templateTokens]
     tokens[editSepPopup.tokenIdx] = { type: 'separator', value: newSep }
     templateInput = tokensToTemplate(tokens)
-    editSepPopup = { visible: false, tokenIdx: -1, x: 0, y: 0 }
+    editSepPopup = { visible: false, tokenIdx: -1, x: 0, y: 0, triggerEl: null }
     onSave()
   }
 
   function removeSeparatorToken(): void {
     removeTokenAt(editSepPopup.tokenIdx)
-    editSepPopup = { visible: false, tokenIdx: -1, x: 0, y: 0 }
+    editSepPopup = { visible: false, tokenIdx: -1, x: 0, y: 0, triggerEl: null }
   }
 
   function closeEditSepPopup(): void {
-    editSepPopup = { visible: false, tokenIdx: -1, x: 0, y: 0 }
+    editSepPopup = { visible: false, tokenIdx: -1, x: 0, y: 0, triggerEl: null }
   }
 
   function ensureSeparators(tokens: TemplateToken[]): TemplateToken[] {
@@ -303,6 +324,7 @@
     y={sepPopup.y}
     label="Separator"
     separators={SEPARATORS}
+    triggerEl={sepPopup.triggerEl}
     onPick={confirmSeparatorAndAdd}
     onClose={closeSepPopup}
   />
@@ -314,6 +336,7 @@
     y={editSepPopup.y}
     label="Change to"
     separators={SEPARATORS}
+    triggerEl={editSepPopup.triggerEl}
     onPick={changeSeparator}
     onClose={closeEditSepPopup}
     onRemove={removeSeparatorToken}

--- a/src/renderer/src/components/preferences/BranchTokenBuilder.svelte
+++ b/src/renderer/src/components/preferences/BranchTokenBuilder.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import SeparatorPopover from './_partials/SeparatorPopover.svelte'
+
   interface TemplateToken {
     type: 'placeholder' | 'separator'
     value: string
@@ -296,50 +298,24 @@
 </div>
 
 {#if sepPopup.visible}
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="fixed inset-0 z-popover" onclick={closeSepPopup}>
-    <div
-      class="fixed flex items-center gap-1 px-2 py-1 bg-bg-overlay border border-border rounded-md shadow-popover -translate-x-1/2 -translate-y-full -mt-2"
-      style="left:{sepPopup.x}px;top:{sepPopup.y}px"
-      onclick={(e) => e.stopPropagation()}
-    >
-      <span class="text-2xs uppercase tracking-caps-tight text-text-muted mr-0.5">Separator</span>
-      {#each SEPARATORS as sep (sep)}
-        <button
-          type="button"
-          class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-text-secondary text-sm font-mono cursor-pointer hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
-          onclick={() => confirmSeparatorAndAdd(sep)}
-        >
-          {sep}
-        </button>
-      {/each}
-    </div>
-  </div>
+  <SeparatorPopover
+    x={sepPopup.x}
+    y={sepPopup.y}
+    label="Separator"
+    separators={SEPARATORS}
+    onPick={confirmSeparatorAndAdd}
+    onClose={closeSepPopup}
+  />
 {/if}
 
 {#if editSepPopup.visible}
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="fixed inset-0 z-popover" onclick={closeEditSepPopup}>
-    <div
-      class="fixed flex items-center gap-1 px-2 py-1 bg-bg-overlay border border-border rounded-md shadow-popover -translate-x-1/2 -translate-y-full -mt-2"
-      style="left:{editSepPopup.x}px;top:{editSepPopup.y}px"
-      onclick={(e) => e.stopPropagation()}
-    >
-      <span class="text-2xs uppercase tracking-caps-tight text-text-muted mr-0.5">Change to</span>
-      {#each SEPARATORS as sep (sep)}
-        <button
-          type="button"
-          class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-text-secondary text-sm font-mono cursor-pointer hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
-          onclick={() => changeSeparator(sep)}
-        >
-          {sep}
-        </button>
-      {/each}
-      <button
-        type="button"
-        class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-danger-text text-sm font-mono cursor-pointer hover:bg-danger-bg hover:border-danger-text"
-        onclick={removeSeparatorToken}>×</button
-      >
-    </div>
-  </div>
+  <SeparatorPopover
+    x={editSepPopup.x}
+    y={editSepPopup.y}
+    label="Change to"
+    separators={SEPARATORS}
+    onPick={changeSeparator}
+    onClose={closeEditSepPopup}
+    onRemove={removeSeparatorToken}
+  />
 {/if}

--- a/src/renderer/src/components/preferences/ClaudePrefs.svelte
+++ b/src/renderer/src/components/preferences/ClaudePrefs.svelte
@@ -3,4 +3,4 @@
   import ClaudeProfileForm from './ClaudeProfileForm.svelte'
 </script>
 
-<AgentProfilesPanel agentType="claude" title="Claude Code" form={ClaudeProfileForm} />
+<AgentProfilesPanel agentType="claude" form={ClaudeProfileForm} />

--- a/src/renderer/src/components/preferences/ClaudeProfileForm.svelte
+++ b/src/renderer/src/components/preferences/ClaudeProfileForm.svelte
@@ -2,6 +2,8 @@
   import type { ProfilePrefs } from '../../../../main/profiles/types'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import ProfileEnvVarsSection from './ProfileEnvVarsSection.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let {
     prefs,
@@ -23,174 +25,187 @@
 
   function onTextInput<K extends keyof ProfilePrefs>(key: K) {
     return (e: Event): void => {
+      // Bound only to <input>/<textarea> elements; their .value is a string.
       const target = e.target as HTMLInputElement | HTMLTextAreaElement
+      // ProfilePrefs fields used here are all string | undefined, so the string value satisfies ProfilePrefs[K].
       set(key, target.value as ProfilePrefs[K])
     }
   }
+
+  function onApiKeyInput(e: Event): void {
+    // Bound to a password <input>; .value is a string.
+    onApiKeyChange((e.target as HTMLInputElement).value)
+  }
 </script>
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">
-    Model & behavior
-  </h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="claude-model">Model</label>
-    <span class="text-xs text-text-faint">Short name (sonnet, opus, haiku) or full model ID</span>
-    <input
-      id="claude-model"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="text"
-      value={prefs.model ?? ''}
-      oninput={onTextInput('model')}
-      placeholder="sonnet, opus, haiku, or model ID"
-      spellcheck="false"
-    />
-  </div>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="claude-perm">Permission mode</label>
-    <span class="text-xs text-text-faint"
-      >Controls what Claude can do without asking. Plan = read-only, Auto = full autonomy</span
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Model & behavior">
+    <PrefsRow
+      label="Model"
+      help="Short name (sonnet, opus, haiku) or full model ID"
+      search="claude model sonnet opus haiku"
+      layout="stacked"
     >
-    <CustomSelect
-      id="claude-perm"
-      value={prefs.permissionMode ?? ''}
-      options={[
-        { value: '', label: 'Default' },
-        { value: 'plan', label: 'Plan' },
-        { value: 'auto', label: 'Auto' },
-        { value: 'acceptEdits', label: 'Accept edits' },
-        { value: 'bypassPermissions', label: 'Bypass permissions' },
-      ]}
-      onchange={(v) => set('permissionMode', v)}
-    />
-  </div>
+      <input
+        id="claude-model"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="text"
+        name="claudeModel"
+        aria-label="Claude model"
+        value={prefs.model ?? ''}
+        oninput={onTextInput('model')}
+        placeholder="sonnet, opus, haiku, or model ID"
+        spellcheck="false"
+      />
+    </PrefsRow>
 
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="claude-effort">Effort level</label>
-    <span class="text-xs text-text-faint"
-      >Higher effort means more thorough but slower responses</span
+    <PrefsRow
+      label="Permission mode"
+      help="Controls what Claude can do without asking. Plan = read-only, Auto = full autonomy."
+      search="claude permission mode plan auto bypass accept edits"
     >
-    <CustomSelect
-      id="claude-effort"
-      value={prefs.effortLevel ?? ''}
-      options={[
-        { value: '', label: 'Default' },
-        { value: 'low', label: 'Low' },
-        { value: 'medium', label: 'Medium' },
-        { value: 'high', label: 'High' },
-        { value: 'xhigh', label: 'Extra High' },
-        { value: 'max', label: 'Max' },
-      ]}
-      onchange={(v) => set('effortLevel', v)}
-    />
-  </div>
-</div>
+      <CustomSelect
+        id="claude-perm"
+        value={prefs.permissionMode ?? ''}
+        options={[
+          { value: '', label: 'Default' },
+          { value: 'plan', label: 'Plan' },
+          { value: 'auto', label: 'Auto' },
+          { value: 'acceptEdits', label: 'Accept edits' },
+          { value: 'bypassPermissions', label: 'Bypass permissions' },
+        ]}
+        onchange={(v) => set('permissionMode', v)}
+        maxWidth="200px"
+      />
+    </PrefsRow>
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">
-    API / Provider
-  </h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="claude-apikey">API key</label>
-    <span class="text-xs text-text-faint"
-      >Anthropic API key. Falls back to ANTHROPIC_API_KEY env variable</span
+    <PrefsRow
+      label="Effort level"
+      help="Higher effort means more thorough but slower responses"
+      search="claude effort level low medium high max thinking"
     >
-    <input
-      id="claude-apikey"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="password"
-      value={apiKey}
-      oninput={(e) => onApiKeyChange((e.target as HTMLInputElement).value)}
-      placeholder={hasApiKey ? '•••• (saved — leave empty to keep)' : 'sk-ant-...'}
-      spellcheck="false"
-      autocomplete="off"
-    />
-  </div>
+      <CustomSelect
+        id="claude-effort"
+        value={prefs.effortLevel ?? ''}
+        options={[
+          { value: '', label: 'Default' },
+          { value: 'low', label: 'Low' },
+          { value: 'medium', label: 'Medium' },
+          { value: 'high', label: 'High' },
+          { value: 'xhigh', label: 'Extra high' },
+          { value: 'max', label: 'Max' },
+        ]}
+        onchange={(v) => set('effortLevel', v)}
+        maxWidth="200px"
+      />
+    </PrefsRow>
+  </PrefsSection>
 
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="claude-baseurl">Base URL</label>
-    <span class="text-xs text-text-faint"
-      >Custom API endpoint. Use for Ollama, GLM, MinMax, or any OpenAI-compatible Anthropic proxy.</span
+  <PrefsSection title="API & provider">
+    <PrefsRow
+      label="API key"
+      help="Anthropic API key. Falls back to ANTHROPIC_API_KEY env variable."
+      search="claude anthropic api key secret"
+      layout="stacked"
     >
-    <input
-      id="claude-baseurl"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="text"
-      value={prefs.baseUrl ?? ''}
-      oninput={onTextInput('baseUrl')}
-      placeholder="https://api.anthropic.com"
-      spellcheck="false"
-    />
-  </div>
+      <input
+        id="claude-apikey"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="password"
+        name="claudeApiKey"
+        aria-label="Claude API key"
+        value={apiKey}
+        oninput={onApiKeyInput}
+        placeholder={hasApiKey ? '•••• (saved — leave empty to keep)' : 'sk-ant-…'}
+        spellcheck="false"
+        autocomplete="off"
+      />
+    </PrefsRow>
 
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="claude-provider">Provider</label>
-    <span class="text-xs text-text-faint">Cloud provider for the Claude API backend</span>
-    <CustomSelect
-      id="claude-provider"
-      value={prefs.provider ?? ''}
-      options={[
-        { value: '', label: 'Default (Anthropic)' },
-        { value: 'bedrock', label: 'AWS Bedrock' },
-        { value: 'vertex', label: 'Google Vertex AI' },
-        { value: 'foundry', label: 'Microsoft Foundry' },
-      ]}
-      onchange={(v) => set('provider', v)}
-    />
-  </div>
-</div>
-
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">
-    System prompt
-  </h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="claude-sysprompt"
-      >Append to system prompt</label
+    <PrefsRow
+      label="Base URL"
+      help="Custom API endpoint. Use for Ollama, GLM, MinMax, or any OpenAI-compatible Anthropic proxy."
+      search="claude base url ollama glm proxy endpoint"
+      layout="stacked"
     >
-    <span class="text-xs text-text-faint"
-      >Extra instructions added after the default system prompt in every session</span
-    >
-    <textarea
-      id="claude-sysprompt"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring resize-y min-h-[60px]"
-      rows="3"
-      value={prefs.appendSystemPrompt ?? ''}
-      oninput={onTextInput('appendSystemPrompt')}
-      placeholder="Additional instructions appended to the default system prompt"
-      spellcheck="false"
-    ></textarea>
-  </div>
-</div>
+      <input
+        id="claude-baseurl"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="text"
+        name="claudeBaseUrl"
+        aria-label="Claude base URL"
+        value={prefs.baseUrl ?? ''}
+        oninput={onTextInput('baseUrl')}
+        placeholder="https://api.anthropic.com"
+        spellcheck="false"
+      />
+    </PrefsRow>
 
-<ProfileEnvVarsSection
-  customEnv={prefs.customEnv}
-  hint="Extra env vars passed to Claude Code sessions in this profile"
-  onChange={(v) => set('customEnv', v)}
-/>
-
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">Advanced</h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="claude-settings"
-      >Settings JSON override</label
+    <PrefsRow
+      label="Provider"
+      help="Cloud provider for the Claude API backend"
+      search="claude provider bedrock vertex foundry aws google azure"
     >
-    <textarea
-      id="claude-settings"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text font-mono text-sm outline-none focus:border-focus-ring resize-y min-h-[60px]"
-      rows="4"
-      value={prefs.settingsJson ?? ''}
-      oninput={onTextInput('settingsJson')}
-      placeholder={'{"language": "japanese", "effortLevel": "high"}'}
-      spellcheck="false"
-    ></textarea>
-    <span class="text-xs text-text-faint"
-      >Merged into per-session settings.json. Hooks and status line are always preserved.</span
+      <CustomSelect
+        id="claude-provider"
+        value={prefs.provider ?? ''}
+        options={[
+          { value: '', label: 'Default (Anthropic)' },
+          { value: 'bedrock', label: 'AWS Bedrock' },
+          { value: 'vertex', label: 'Google Vertex AI' },
+          { value: 'foundry', label: 'Microsoft Foundry' },
+        ]}
+        onchange={(v) => set('provider', v)}
+        maxWidth="220px"
+      />
+    </PrefsRow>
+  </PrefsSection>
+
+  <PrefsSection title="System prompt">
+    <PrefsRow
+      label="Append to system prompt"
+      help="Extra instructions added after the default system prompt in every session"
+      search="claude system prompt append instructions"
+      layout="stacked"
     >
-  </div>
+      <textarea
+        id="claude-sysprompt"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring resize-y min-h-15 placeholder:text-text-faint"
+        rows="3"
+        name="claudeSystemPrompt"
+        aria-label="Append to system prompt"
+        value={prefs.appendSystemPrompt ?? ''}
+        oninput={onTextInput('appendSystemPrompt')}
+        placeholder="Additional instructions appended to the default system prompt"
+        spellcheck="false"
+      ></textarea>
+    </PrefsRow>
+  </PrefsSection>
+
+  <ProfileEnvVarsSection
+    customEnv={prefs.customEnv}
+    hint="Extra env vars passed to Claude Code sessions in this profile"
+    onChange={(v) => set('customEnv', v)}
+  />
+
+  <PrefsSection title="Advanced">
+    <PrefsRow
+      label="Settings JSON override"
+      help="Merged into per-session settings.json. Hooks and status line are always preserved."
+      search="claude settings json override advanced"
+      layout="stacked"
+    >
+      <textarea
+        id="claude-settings"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text font-mono text-sm outline-none focus:border-focus-ring resize-y min-h-15 placeholder:text-text-faint"
+        rows="4"
+        name="claudeSettingsJson"
+        aria-label="Settings JSON override"
+        value={prefs.settingsJson ?? ''}
+        oninput={onTextInput('settingsJson')}
+        placeholder={'{"language": "japanese", "effortLevel": "high"}'}
+        spellcheck="false"
+      ></textarea>
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/CodexPrefs.svelte
+++ b/src/renderer/src/components/preferences/CodexPrefs.svelte
@@ -3,4 +3,4 @@
   import CodexProfileForm from './CodexProfileForm.svelte'
 </script>
 
-<AgentProfilesPanel agentType="codex" title="Codex" form={CodexProfileForm} />
+<AgentProfilesPanel agentType="codex" form={CodexProfileForm} />

--- a/src/renderer/src/components/preferences/CodexProfileForm.svelte
+++ b/src/renderer/src/components/preferences/CodexProfileForm.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import type { ProfilePrefs } from '../../../../main/profiles/types'
   import CustomSelect from '../shared/CustomSelect.svelte'
+  import CustomCheckbox from '../shared/CustomCheckbox.svelte'
   import ProfileEnvVarsSection from './ProfileEnvVarsSection.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let {
     prefs,
@@ -29,146 +32,164 @@
   }
 
   let fullAuto = $derived(prefs.fullAuto === 'true')
+
+  function toggleFullAuto(): void {
+    set('fullAuto', fullAuto ? '' : 'true')
+  }
 </script>
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">
-    Model & behavior
-  </h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="codex-model">Model</label>
-    <input
-      id="codex-model"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="text"
-      value={prefs.model ?? ''}
-      oninput={onTextInput('model')}
-      placeholder="Default"
-      spellcheck="false"
-    />
-    <span class="text-xs text-text-faint">Leave empty for Codex default</span>
-  </div>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="codex-approval">Approval mode</label
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Model & behavior">
+    <PrefsRow
+      label="Model"
+      help="Leave empty for Codex default"
+      search="codex model openai"
+      layout="stacked"
     >
-    <span class="text-xs text-text-faint">Controls when Codex pauses for human approval</span>
-    <CustomSelect
-      id="codex-approval"
-      value={prefs.approvalMode ?? ''}
-      options={[
-        { value: '', label: 'Default' },
-        { value: 'untrusted', label: 'Untrusted' },
-        { value: 'on-request', label: 'On Request' },
-        { value: 'never', label: 'Never' },
-      ]}
-      onchange={(v) => set('approvalMode', v)}
-    />
-  </div>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="codex-sandbox">Sandbox</label>
-    <span class="text-xs text-text-faint">Command execution policy</span>
-    <CustomSelect
-      id="codex-sandbox"
-      value={prefs.sandbox ?? ''}
-      options={[
-        { value: '', label: 'Default' },
-        { value: 'read-only', label: 'Read Only' },
-        { value: 'workspace-write', label: 'Workspace Write' },
-        { value: 'danger-full-access', label: 'Full Access' },
-      ]}
-      onchange={(v) => set('sandbox', v)}
-    />
-  </div>
-
-  <div class="flex flex-col gap-1">
-    <label class="flex items-center gap-2 text-sm font-medium text-text-secondary">
       <input
-        type="checkbox"
-        checked={fullAuto}
-        onchange={() => set('fullAuto', fullAuto ? '' : 'true')}
+        id="codex-model"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="text"
+        name="codexModel"
+        aria-label="Codex model"
+        value={prefs.model ?? ''}
+        oninput={onTextInput('model')}
+        placeholder="Default"
+        spellcheck="false"
       />
-      Full auto
-    </label>
-    <span class="text-xs text-text-faint">Workspace-write sandbox + on-request approvals</span>
-  </div>
+    </PrefsRow>
 
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="codex-profile">Profile</label>
-    <input
-      id="codex-profile"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="text"
-      value={prefs.profile ?? ''}
-      oninput={onTextInput('profile')}
-      placeholder="Default"
-      spellcheck="false"
-    />
-    <span class="text-xs text-text-faint">Configuration profile from config.toml</span>
-  </div>
-</div>
-
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">API</h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="codex-apikey">API key</label>
-    <span class="text-xs text-text-faint"
-      >OpenAI API key. Falls back to OPENAI_API_KEY env variable</span
+    <PrefsRow
+      label="Approval mode"
+      help="Controls when Codex pauses for human approval"
+      search="codex approval mode untrusted on-request never"
     >
-    <input
-      id="codex-apikey"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="password"
-      value={apiKey}
-      oninput={(e) => onApiKeyChange((e.target as HTMLInputElement).value)}
-      placeholder={hasApiKey ? '•••• (saved — leave empty to keep)' : 'Uses OPENAI_API_KEY'}
-      spellcheck="false"
-      autocomplete="off"
-    />
-  </div>
+      <CustomSelect
+        id="codex-approval"
+        value={prefs.approvalMode ?? ''}
+        options={[
+          { value: '', label: 'Default' },
+          { value: 'untrusted', label: 'Untrusted' },
+          { value: 'on-request', label: 'On request' },
+          { value: 'never', label: 'Never' },
+        ]}
+        onchange={(v) => set('approvalMode', v)}
+        maxWidth="200px"
+      />
+    </PrefsRow>
 
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="codex-baseurl">Base URL</label>
-    <input
-      id="codex-baseurl"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="text"
-      value={prefs.baseUrl ?? ''}
-      oninput={onTextInput('baseUrl')}
-      placeholder="https://api.openai.com"
-      spellcheck="false"
-    />
-    <span class="text-xs text-text-faint"
-      >Custom API endpoint (Ollama, vLLM, OpenAI-compatible proxy)</span
+    <PrefsRow
+      label="Sandbox"
+      help="Command execution policy"
+      search="codex sandbox read-only workspace-write full-access"
     >
-  </div>
-</div>
+      <CustomSelect
+        id="codex-sandbox"
+        value={prefs.sandbox ?? ''}
+        options={[
+          { value: '', label: 'Default' },
+          { value: 'read-only', label: 'Read only' },
+          { value: 'workspace-write', label: 'Workspace write' },
+          { value: 'danger-full-access', label: 'Full access' },
+        ]}
+        onchange={(v) => set('sandbox', v)}
+        maxWidth="200px"
+      />
+    </PrefsRow>
 
-<ProfileEnvVarsSection
-  customEnv={prefs.customEnv}
-  hint="Extra env vars passed to Codex sessions in this profile"
-  onChange={(v) => set('customEnv', v)}
-/>
-
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">Advanced</h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="codex-settings"
-      >Settings JSON override</label
+    <PrefsRow
+      label="Full auto"
+      help="Workspace-write sandbox + on-request approvals"
+      search="codex full auto autonomous"
     >
-    <textarea
-      id="codex-settings"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text font-mono text-sm outline-none focus:border-focus-ring resize-y min-h-[60px]"
-      rows="4"
-      value={prefs.settingsJson ?? ''}
-      oninput={onTextInput('settingsJson')}
-      placeholder={'{"key": "value"}'}
-      spellcheck="false"
-    ></textarea>
-    <span class="text-xs text-text-faint">Merged into per-session .codex/hooks.json</span>
-  </div>
+      <CustomCheckbox checked={fullAuto} onchange={toggleFullAuto} />
+    </PrefsRow>
+
+    <PrefsRow
+      label="Profile"
+      help="Configuration profile from config.toml"
+      search="codex profile config toml"
+      layout="stacked"
+    >
+      <input
+        id="codex-profile"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="text"
+        name="codexProfile"
+        aria-label="Codex profile"
+        value={prefs.profile ?? ''}
+        oninput={onTextInput('profile')}
+        placeholder="Default"
+        spellcheck="false"
+      />
+    </PrefsRow>
+  </PrefsSection>
+
+  <PrefsSection title="API">
+    <PrefsRow
+      label="API key"
+      help="OpenAI API key. Falls back to OPENAI_API_KEY env variable."
+      search="codex openai api key secret"
+      layout="stacked"
+    >
+      <input
+        id="codex-apikey"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="password"
+        name="codexApiKey"
+        aria-label="Codex API key"
+        value={apiKey}
+        oninput={(e) => onApiKeyChange((e.target as HTMLInputElement).value)}
+        placeholder={hasApiKey ? '•••• (saved — leave empty to keep)' : 'Uses OPENAI_API_KEY'}
+        spellcheck="false"
+        autocomplete="off"
+      />
+    </PrefsRow>
+
+    <PrefsRow
+      label="Base URL"
+      help="Custom API endpoint (Ollama, vLLM, OpenAI-compatible proxy)"
+      search="codex base url ollama vllm proxy endpoint"
+      layout="stacked"
+    >
+      <input
+        id="codex-baseurl"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="text"
+        name="codexBaseUrl"
+        aria-label="Codex base URL"
+        value={prefs.baseUrl ?? ''}
+        oninput={onTextInput('baseUrl')}
+        placeholder="https://api.openai.com"
+        spellcheck="false"
+      />
+    </PrefsRow>
+  </PrefsSection>
+
+  <ProfileEnvVarsSection
+    customEnv={prefs.customEnv}
+    hint="Extra env vars passed to Codex sessions in this profile"
+    onChange={(v) => set('customEnv', v)}
+  />
+
+  <PrefsSection title="Advanced">
+    <PrefsRow
+      label="Settings JSON override"
+      help="Merged into per-session .codex/hooks.json"
+      search="codex settings json override advanced"
+      layout="stacked"
+    >
+      <textarea
+        id="codex-settings"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text font-mono text-sm outline-none focus:border-focus-ring resize-y min-h-15 placeholder:text-text-faint"
+        rows="4"
+        name="codexSettingsJson"
+        aria-label="Settings JSON override"
+        value={prefs.settingsJson ?? ''}
+        oninput={onTextInput('settingsJson')}
+        placeholder={'{"key": "value"}'}
+        spellcheck="false"
+      ></textarea>
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/FileWatcherPrefs.svelte
+++ b/src/renderer/src/components/preferences/FileWatcherPrefs.svelte
@@ -2,6 +2,8 @@
   import { onMount } from 'svelte'
   import { X, RotateCcw, Plus } from '@lucide/svelte'
   import { getPref, setPref, prefs } from '../../lib/stores/preferences.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let defaults: string[] = $state([])
 
@@ -67,63 +69,78 @@
   }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">File Watcher</h3>
-  <p class="text-sm text-text-secondary m-0 leading-normal">
-    Entries listed here are excluded from the sidebar file list. Use plain names (<code
-      class="bg-hover px-1.5 py-px rounded-sm text-xs font-inherit">node_modules</code
-    >, <code class="bg-hover px-1.5 py-px rounded-sm text-xs font-inherit">.git</code>) or
-    <code class="bg-hover px-1.5 py-px rounded-sm text-xs font-inherit">name/**</code> patterns to
-    hide a top-level folder. Complex globs like
-    <code class="bg-hover px-1.5 py-px rounded-sm text-xs font-inherit">**/*.log</code> are not currently
-    supported. Changes apply immediately to all open workspaces.
-  </p>
+<div class="flex flex-col gap-7">
+  <PrefsSection
+    title="Ignored patterns"
+    description="Entries here are excluded from the sidebar file list. Use plain names or simple name/** patterns. Complex globs like **/*.log are not supported. Changes apply immediately."
+  >
+    <PrefsRow
+      label="Patterns"
+      help={patterns.length === 0
+        ? 'No patterns — all files are watched.'
+        : `${patterns.length} pattern${patterns.length === 1 ? '' : 's'}`}
+      search="ignore patterns gitignore exclude node_modules"
+      layout="stacked"
+    >
+      <div class="flex flex-col gap-2">
+        {#if patterns.length > 0}
+          <div class="flex flex-wrap gap-1.5">
+            {#each patterns as pattern (pattern)}
+              <div
+                class="inline-flex items-center gap-1 pl-2.5 pr-1 py-1 bg-bg-input border border-border rounded-md text-sm text-text"
+              >
+                <span class="font-mono">{pattern}</span>
+                <button
+                  type="button"
+                  class="flex items-center justify-center size-4 bg-transparent border-0 rounded-sm text-text-muted cursor-pointer hover:bg-hover-strong hover:text-danger-text"
+                  onclick={() => removePattern(pattern)}
+                  aria-label={`Remove ${pattern}`}
+                >
+                  <X size={11} />
+                </button>
+              </div>
+            {/each}
+          </div>
+        {/if}
 
-  <div class="flex flex-wrap gap-1.5 min-h-8">
-    {#each patterns as pattern (pattern)}
-      <div
-        class="inline-flex items-center gap-1 pl-2.5 pr-1 py-1 bg-hover border border-border rounded-md text-sm text-text"
-      >
-        <span class="font-mono">{pattern}</span>
-        <button
-          class="flex items-center justify-center w-[18px] h-[18px] bg-transparent border-0 rounded-sm text-text-secondary cursor-pointer transition-colors duration-fast hover:bg-hover-strong hover:text-danger-text"
-          onclick={() => removePattern(pattern)}
-          aria-label={`Remove ${pattern}`}
-        >
-          <X size={12} />
-        </button>
+        <div class="flex gap-1.5">
+          <input
+            type="text"
+            name="newIgnorePattern"
+            aria-label="New ignore pattern"
+            class="flex-1 px-2.5 py-1.5 bg-bg-input border border-border rounded-md text-text text-md font-mono focus:outline-none focus:border-focus-ring placeholder:text-text-faint"
+            placeholder="tmp/**"
+            spellcheck="false"
+            autocomplete="off"
+            bind:value={newPattern}
+            onkeydown={handleInputKeydown}
+          />
+          <button
+            type="button"
+            class="flex items-center gap-1 px-3 py-1.5 bg-border-subtle border border-border rounded-md text-text text-md cursor-pointer enabled:hover:bg-active disabled:opacity-40 disabled:cursor-default"
+            onclick={addPattern}
+            disabled={!newPattern.trim()}
+          >
+            <Plus size={14} />
+            <span>Add</span>
+          </button>
+        </div>
       </div>
-    {/each}
-    {#if patterns.length === 0}
-      <p class="text-sm text-text-faint italic m-0">No patterns — all files are watched.</p>
-    {/if}
-  </div>
+    </PrefsRow>
 
-  <div class="flex gap-1.5">
-    <input
-      type="text"
-      class="flex-1 px-2.5 py-1.5 bg-bg border border-border rounded-md text-text text-md font-inherit focus:outline-none focus:border-focus-ring"
-      placeholder="Add pattern (e.g. tmp/**)"
-      bind:value={newPattern}
-      onkeydown={handleInputKeydown}
-    />
-    <button
-      class="flex items-center gap-1 px-3 py-1.5 bg-accent-bg border border-border rounded-md text-text text-md cursor-pointer transition-colors duration-fast enabled:hover:bg-hover-strong disabled:opacity-40 disabled:cursor-default"
-      onclick={addPattern}
-      disabled={!newPattern.trim()}
+    <PrefsRow
+      label="Reset to defaults"
+      help="Restore the built-in pattern list"
+      search="reset defaults restore"
     >
-      <Plus size={14} />
-      <span>Add</span>
-    </button>
-  </div>
-
-  <div class="flex justify-end pt-2 border-t border-border">
-    <button
-      class="flex items-center gap-1 px-2.5 py-1 bg-transparent border border-border rounded-md text-text-secondary text-xs cursor-pointer transition-colors duration-fast hover:bg-hover hover:text-text"
-      onclick={resetDefaults}
-    >
-      <RotateCcw size={12} />
-      <span>Reset to defaults</span>
-    </button>
-  </div>
+      <button
+        type="button"
+        class="flex items-center gap-1 px-2.5 py-1 bg-transparent border border-border rounded-md text-text-secondary text-sm cursor-pointer hover:bg-hover hover:text-text"
+        onclick={resetDefaults}
+      >
+        <RotateCcw size={12} />
+        <span>Reset</span>
+      </button>
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/GeminiPrefs.svelte
+++ b/src/renderer/src/components/preferences/GeminiPrefs.svelte
@@ -3,4 +3,4 @@
   import GeminiProfileForm from './GeminiProfileForm.svelte'
 </script>
 
-<AgentProfilesPanel agentType="gemini" title="Gemini" form={GeminiProfileForm} />
+<AgentProfilesPanel agentType="gemini" form={GeminiProfileForm} />

--- a/src/renderer/src/components/preferences/GeminiProfileForm.svelte
+++ b/src/renderer/src/components/preferences/GeminiProfileForm.svelte
@@ -2,6 +2,8 @@
   import type { ProfilePrefs } from '../../../../main/profiles/types'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import ProfileEnvVarsSection from './ProfileEnvVarsSection.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let {
     prefs,
@@ -29,92 +31,94 @@
   }
 </script>
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">
-    Model & behavior
-  </h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="gemini-model">Model</label>
-    <input
-      id="gemini-model"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="text"
-      value={prefs.model ?? ''}
-      oninput={onTextInput('model')}
-      placeholder="Default"
-      spellcheck="false"
-    />
-    <span class="text-xs text-text-faint">Leave empty for Gemini CLI default</span>
-  </div>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="gemini-approval"
-      >Approval mode</label
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Model & behavior">
+    <PrefsRow
+      label="Model"
+      help="Leave empty for the Gemini CLI default"
+      search="gemini model"
+      layout="stacked"
     >
-    <span class="text-xs text-text-faint"
-      >Controls what Gemini can do without asking. YOLO = full autonomy, Plan = read-only</span
+      <input
+        id="gemini-model"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="text"
+        name="geminiModel"
+        aria-label="Gemini model"
+        value={prefs.model ?? ''}
+        oninput={onTextInput('model')}
+        placeholder="Default"
+        spellcheck="false"
+      />
+    </PrefsRow>
+
+    <PrefsRow
+      label="Approval mode"
+      help="Controls what Gemini can do without asking. YOLO = full autonomy, Plan = read-only."
+      search="gemini approval mode yolo plan auto edit"
     >
-    <CustomSelect
-      id="gemini-approval"
-      value={prefs.approvalMode ?? ''}
-      options={[
-        { value: '', label: 'Default' },
-        { value: 'default', label: 'Prompt' },
-        { value: 'auto_edit', label: 'Auto Edit' },
-        { value: 'yolo', label: 'YOLO' },
-        { value: 'plan', label: 'Plan (read-only)' },
-      ]}
-      onchange={(v) => set('approvalMode', v)}
-    />
-  </div>
-</div>
+      <CustomSelect
+        id="gemini-approval"
+        value={prefs.approvalMode ?? ''}
+        options={[
+          { value: '', label: 'Default' },
+          { value: 'default', label: 'Prompt' },
+          { value: 'auto_edit', label: 'Auto edit' },
+          { value: 'yolo', label: 'YOLO' },
+          { value: 'plan', label: 'Plan (read-only)' },
+        ]}
+        onchange={(v) => set('approvalMode', v)}
+        maxWidth="200px"
+      />
+    </PrefsRow>
+  </PrefsSection>
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">API</h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="gemini-apikey">API key</label>
-    <span class="text-xs text-text-faint"
-      >Google AI API key. Falls back to GEMINI_API_KEY env variable</span
+  <PrefsSection title="API">
+    <PrefsRow
+      label="API key"
+      help="Google AI API key. Falls back to GEMINI_API_KEY env variable."
+      search="gemini google api key secret"
+      layout="stacked"
     >
-    <input
-      id="gemini-apikey"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="password"
-      value={apiKey}
-      oninput={(e) => onApiKeyChange((e.target as HTMLInputElement).value)}
-      placeholder={hasApiKey ? '•••• (saved — leave empty to keep)' : 'Uses GEMINI_API_KEY'}
-      spellcheck="false"
-      autocomplete="off"
-    />
-  </div>
-</div>
+      <input
+        id="gemini-apikey"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="password"
+        name="geminiApiKey"
+        aria-label="Gemini API key"
+        value={apiKey}
+        oninput={(e) => onApiKeyChange((e.target as HTMLInputElement).value)}
+        placeholder={hasApiKey ? '•••• (saved — leave empty to keep)' : 'Uses GEMINI_API_KEY'}
+        spellcheck="false"
+        autocomplete="off"
+      />
+    </PrefsRow>
+  </PrefsSection>
 
-<ProfileEnvVarsSection
-  customEnv={prefs.customEnv}
-  hint="Extra env vars passed to Gemini CLI sessions in this profile"
-  onChange={(v) => set('customEnv', v)}
-/>
+  <ProfileEnvVarsSection
+    customEnv={prefs.customEnv}
+    hint="Extra env vars passed to Gemini CLI sessions in this profile"
+    onChange={(v) => set('customEnv', v)}
+  />
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">Advanced</h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="gemini-settings"
-      >Settings JSON override</label
+  <PrefsSection title="Advanced">
+    <PrefsRow
+      label="Settings JSON override"
+      help="Merged into per-session .gemini/settings.json (hooks always preserved)"
+      search="gemini settings json override advanced"
+      layout="stacked"
     >
-    <textarea
-      id="gemini-settings"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text font-mono text-sm outline-none focus:border-focus-ring resize-y min-h-[60px]"
-      rows="4"
-      value={prefs.settingsJson ?? ''}
-      oninput={onTextInput('settingsJson')}
-      placeholder={'{"key": "value"}'}
-      spellcheck="false"
-    ></textarea>
-    <span class="text-xs text-text-faint"
-      >Merged into per-session .gemini/settings.json (hooks always preserved)</span
-    >
-  </div>
+      <textarea
+        id="gemini-settings"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text font-mono text-sm outline-none focus:border-focus-ring resize-y min-h-15 placeholder:text-text-faint"
+        rows="4"
+        name="geminiSettingsJson"
+        aria-label="Settings JSON override"
+        value={prefs.settingsJson ?? ''}
+        oninput={onTextInput('settingsJson')}
+        placeholder={'{"key": "value"}'}
+        spellcheck="false"
+      ></textarea>
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/GeneralPrefs.svelte
+++ b/src/renderer/src/components/preferences/GeneralPrefs.svelte
@@ -9,6 +9,11 @@
   import PrefsRow from './_partials/PrefsRow.svelte'
 
   const isMac = navigator.userAgent.includes('Mac')
+  const isWin = window.api.platform === 'win32'
+
+  const shellHelp = isWin
+    ? 'Default shell on Windows is set in System Settings — restart Canopy after changing.'
+    : 'Resolved from $SHELL at launch — change with chsh, then restart.'
 
   let reopenLast = $derived(prefs.reopenLastWorkspace !== 'false')
   let perfHudEnabled = $derived(prefs['perf.hud.enabled'] === 'true')
@@ -97,11 +102,7 @@
       />
     </PrefsRow>
 
-    <PrefsRow
-      label="Shell"
-      help="Resolved from $SHELL at launch — change with chsh, then restart"
-      search="shell zsh bash fish $SHELL"
-    >
+    <PrefsRow label="Shell" help={shellHelp} search="shell zsh bash fish $SHELL powershell cmd">
       <span class="text-sm text-text-muted font-mono">auto-detected</span>
     </PrefsRow>
   </PrefsSection>

--- a/src/renderer/src/components/preferences/GeneralPrefs.svelte
+++ b/src/renderer/src/components/preferences/GeneralPrefs.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { prefs, setPref, loadPrefs } from '../../lib/stores/preferences.svelte'
+  import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import { getTools, getToolAvailability } from '../../lib/stores/tools.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
-  import { closeDialog, confirm, showOnboardingWizard } from '../../lib/stores/dialogs.svelte'
+  import { closeDialog, showOnboardingWizard } from '../../lib/stores/dialogs.svelte'
   import { initOnboarding } from '../../lib/stores/onboarding.svelte'
-  import { addToast } from '../../lib/stores/toast.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   const isMac = navigator.userAgent.includes('Mac')
 
@@ -42,128 +43,76 @@
     closeDialog()
     showOnboardingWizard()
   }
-
-  async function handleExportSettings(): Promise<void> {
-    const ok = await confirm({
-      title: 'Export settings',
-      message: 'Save all app settings and integrations to a JSON file?',
-      details:
-        'The file will contain your AI agent API keys, Linear/Jira tokens, and saved credentials as plaintext. Store it somewhere only you can access.',
-      confirmLabel: 'Export',
-    })
-    if (!ok) return
-
-    try {
-      const result = await window.api.exportSettings()
-      if (!result) return
-      addToast(`Settings exported to ${result.path}`)
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e)
-      addToast(`Export failed: ${message}`)
-    }
-  }
-
-  async function handleImportSettings(): Promise<void> {
-    const ok = await confirm({
-      title: 'Import settings',
-      message: 'Load settings from a JSON file?',
-      details:
-        'Existing settings with matching keys will be overwritten. Profiles, credentials, and custom tools not in the file are kept as-is.',
-      confirmLabel: 'Import',
-      destructive: true,
-    })
-    if (!ok) return
-
-    try {
-      const result = await window.api.importSettings()
-      if (!result) return
-      const { preferences, profiles, credentials, customTools } = result.counts
-      addToast(
-        `Imported ${preferences} preferences, ${profiles} profiles, ${credentials} credentials, ${customTools} tools`,
-      )
-      await loadPrefs()
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e)
-      addToast(`Import failed: ${message}`)
-    }
-  }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">General</h3>
-
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <CustomCheckbox checked={reopenLast} onchange={toggleReopen} />
-    <span>Reopen last workspace on startup</span>
-  </label>
-  <div class="text-xs text-text-muted leading-normal pl-6 -mt-2">
-    Restore the previous workspace tabs and layout when the app starts
-  </div>
-
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <CustomCheckbox checked={perfHudEnabled} onchange={togglePerfHud} />
-    <span>Show CPU and RAM usage in status bar</span>
-  </label>
-  {#if perfHudEnabled}
-    <div class="text-xs text-text-muted leading-normal pl-6 -mt-2">
-      Aggregates total CPU and resident memory across all Canopy processes (main, renderer, GPU,
-      utility). Sampled once per second; the sampler stops entirely when this toggle is off.
-    </div>
-  {/if}
-
-  <div class="flex items-center gap-3 text-md">
-    <span class="text-text-secondary min-w-[110px]">New tab ({isMac ? '⌘T' : 'Ctrl+T'})</span>
-    <CustomSelect
-      value={newTabTool}
-      options={startupToolOptions}
-      onchange={(v) => setPref('newTab.toolId', v)}
-      maxWidth="180px"
-    />
-  </div>
-  <div class="text-xs text-text-muted leading-normal -mt-2">
-    Default tool to open when creating a new tab
-  </div>
-
-  <div class="flex items-center gap-3 text-md">
-    <span class="text-text-secondary min-w-[110px]">New worktree</span>
-    <CustomSelect
-      value={newWorktreeTool}
-      options={startupToolOptions}
-      onchange={(v) => setPref('newWorktree.toolId', v)}
-      maxWidth="180px"
-    />
-  </div>
-  <div class="text-xs text-text-muted leading-normal -mt-2">
-    Default tool to open in new worktree tabs
-  </div>
-
-  <div class="flex items-center gap-3 text-md">
-    <span class="text-text-secondary min-w-20">Shell</span>
-    <span class="text-text font-mono text-sm">Resolved from $SHELL at launch</span>
-  </div>
-
-  <div class="pt-1">
-    <button
-      class="px-3.5 py-1.5 rounded-lg text-sm font-inherit cursor-pointer border border-border bg-border-subtle text-text-secondary transition-colors duration-fast hover:bg-active hover:text-text"
-      onclick={rerunSetupWizard}>Re-run setup wizard</button
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Startup" description="What happens when Canopy launches">
+    <PrefsRow
+      label="Reopen last workspace on startup"
+      help="Restore the previous workspace tabs and layout when the app starts"
+      search="restore previous tabs layout"
     >
-  </div>
-</div>
+      <CustomCheckbox checked={reopenLast} onchange={toggleReopen} />
+    </PrefsRow>
 
-<div class="flex flex-col gap-4 mt-6">
-  <h3 class="text-[15px] font-semibold text-text m-0">Backup & Restore</h3>
-  <div class="text-xs text-text-muted leading-normal">
-    Export all app settings, AI agent profiles, and integrations to a JSON file so you can restore
-    them on another machine. The file contains plaintext API keys and tokens — store it securely.
-  </div>
-  <div class="pt-1 flex gap-2">
-    <button
-      class="px-3.5 py-1.5 rounded-lg text-sm font-inherit cursor-pointer border border-border bg-border-subtle text-text-secondary transition-colors duration-fast hover:bg-active hover:text-text"
-      onclick={handleExportSettings}>Export Settings…</button
+    <PrefsRow
+      label="Run setup wizard"
+      help="Walk through the first-launch setup again to reconfigure tools and integrations"
+      search="onboarding first-launch reset"
     >
-    <button
-      class="px-3.5 py-1.5 rounded-lg text-sm font-inherit cursor-pointer border border-border bg-border-subtle text-text-secondary transition-colors duration-fast hover:bg-active hover:text-text"
-      onclick={handleImportSettings}>Import Settings…</button
+      <button
+        type="button"
+        class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-border-subtle text-text-secondary hover:bg-active hover:text-text"
+        onclick={rerunSetupWizard}
+      >
+        Re-run wizard
+      </button>
+    </PrefsRow>
+  </PrefsSection>
+
+  <PrefsSection title="Defaults" description="Tools used when opening new tabs and worktrees">
+    <PrefsRow
+      label="New tab"
+      help="Default tool to open when creating a new tab ({isMac ? '⌘T' : 'Ctrl+T'})"
+      search="new tab tool default cmd-t"
     >
-  </div>
+      <CustomSelect
+        value={newTabTool}
+        options={startupToolOptions}
+        onchange={(v) => setPref('newTab.toolId', v)}
+        maxWidth="200px"
+      />
+    </PrefsRow>
+
+    <PrefsRow
+      label="New worktree"
+      help="Default tool to open in new worktree tabs"
+      search="new worktree tool default"
+    >
+      <CustomSelect
+        value={newWorktreeTool}
+        options={startupToolOptions}
+        onchange={(v) => setPref('newWorktree.toolId', v)}
+        maxWidth="200px"
+      />
+    </PrefsRow>
+
+    <PrefsRow
+      label="Shell"
+      help="Resolved from $SHELL at launch — change with chsh, then restart"
+      search="shell zsh bash fish $SHELL"
+    >
+      <span class="text-sm text-text-muted font-mono">auto-detected</span>
+    </PrefsRow>
+  </PrefsSection>
+
+  <PrefsSection title="Status bar" description="Information shown in the bottom status bar">
+    <PrefsRow
+      label="Show CPU and RAM usage"
+      help="Aggregates total CPU and resident memory across all Canopy processes (main, renderer, GPU, utility). Sampled once per second; the sampler stops entirely when this toggle is off."
+      search="cpu ram performance hud monitoring memory"
+    >
+      <CustomCheckbox checked={perfHudEnabled} onchange={togglePerfHud} />
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/GitPrefs.svelte
+++ b/src/renderer/src/components/preferences/GitPrefs.svelte
@@ -2,6 +2,8 @@
   import { prefs, setPref, getPref } from '../../lib/stores/preferences.svelte'
   import CustomRadio from '../shared/CustomRadio.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let pullRebase = $derived(prefs.gitPullRebase !== 'false')
   let worktreesDir = $state(getPref('worktrees.baseDir', ''))
@@ -82,121 +84,131 @@
   }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Git</h3>
-
-  <div class="flex flex-col gap-2">
-    <span class="text-sm font-medium text-text-secondary uppercase tracking-[0.5px]"
-      >Pull Strategy</span
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Pull strategy" description="How local commits are integrated when pulling">
+    <PrefsRow
+      label="Rebase"
+      help="Replay local commits on top of upstream — keeps history linear"
+      search="git pull rebase linear history"
     >
-    <span class="text-xs text-text-faint">
-      How local commits are integrated when pulling remote changes
-    </span>
-    <div class="flex flex-col gap-1.5">
-      <label class="flex items-center gap-2 text-md text-text">
-        <CustomRadio checked={pullRebase} onchange={() => setPullStrategy(true)} />
-        <span>Rebase</span>
-        <span class="text-xs text-text-muted font-mono">git pull --rebase</span>
-      </label>
-      <label class="flex items-center gap-2 text-md text-text">
-        <CustomRadio checked={!pullRebase} onchange={() => setPullStrategy(false)} />
-        <span>Merge</span>
-        <span class="text-xs text-text-muted font-mono">git pull</span>
-      </label>
-    </div>
-  </div>
-
-  <div class="flex flex-col gap-2">
-    <span class="text-sm font-medium text-text-secondary uppercase tracking-[0.5px]"
-      >Worktrees directory</span
+      <CustomRadio checked={pullRebase} onchange={() => setPullStrategy(true)} />
+    </PrefsRow>
+    <PrefsRow
+      label="Merge"
+      help="Create a merge commit when histories diverge"
+      search="git pull merge commit"
     >
-    <input
-      class="w-full border border-border rounded-lg bg-bg-input text-text text-md font-inherit px-2.5 py-2 outline-none transition-colors duration-fast box-border focus:border-focus-ring placeholder:text-text-faint"
-      type="text"
-      value={worktreesDir}
-      oninput={(e) => updateWorktreesDir(e.currentTarget.value)}
-      placeholder="~/canopy/worktrees"
-      spellcheck="false"
-      autocomplete="off"
-    />
-    <span class="text-xs text-text-faint">Pattern: &lt;dir&gt;/&lt;project&gt;/&lt;branch&gt;</span>
-  </div>
+      <CustomRadio checked={!pullRebase} onchange={() => setPullStrategy(false)} />
+    </PrefsRow>
+  </PrefsSection>
 
-  {#if showSetup}
-    <div class="flex flex-col gap-2">
-      <span class="text-sm font-medium text-text-secondary uppercase tracking-[0.5px]"
-        >Worktree Setup</span
+  <PrefsSection
+    title="Worktrees"
+    description="Where new git worktrees are created and what runs after"
+  >
+    <PrefsRow
+      label="Base directory"
+      help="Pattern: <dir>/<project>/<branch>"
+      search="worktree directory base path"
+      layout="stacked"
+    >
+      <input
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="text"
+        name="worktreesBaseDir"
+        aria-label="Worktrees base directory"
+        value={worktreesDir}
+        oninput={(e) => updateWorktreesDir(e.currentTarget.value)}
+        placeholder="~/canopy/worktrees"
+        spellcheck="false"
+        autocomplete="off"
+      />
+    </PrefsRow>
+
+    {#if showSetup}
+      <PrefsRow
+        label="Setup actions"
+        help="Run after creating a new worktree. Variables: $MAIN_WORKTREE, $NEW_WORKTREE, $REPO_ROOT"
+        search="worktree setup post-create command copy bootstrap"
+        layout="stacked"
       >
-      <span class="text-xs text-text-faint">Actions to run after creating a new worktree</span>
-
-      {#if actions.length > 0}
-        <div class="flex flex-col gap-1.5">
-          {#each actions as action, i (i)}
-            <div class="flex items-center gap-1.5">
-              <span class="text-xs font-mono text-accent-text min-w-8 flex-shrink-0"
-                >{action.type === 'command' ? 'run' : 'copy'}</span
-              >
-              {#if action.type === 'command'}
-                <input
-                  class="flex-1 border border-border rounded-md bg-bg-input text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint box-border"
-                  type="text"
-                  bind:value={action.command}
-                  oninput={() => updateAction()}
-                  placeholder="npm install"
-                  spellcheck="false"
-                  autocomplete="off"
-                />
-              {:else}
-                <input
-                  class="flex-1 min-w-0 border border-border rounded-md bg-bg-input text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint box-border"
-                  type="text"
-                  bind:value={action.source}
-                  oninput={() => updateAction()}
-                  placeholder=".env"
-                  spellcheck="false"
-                  autocomplete="off"
-                />
-                <span class="text-sm text-text-faint flex-shrink-0">→</span>
-                <input
-                  class="flex-1 min-w-0 border border-border rounded-md bg-bg-input text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint box-border"
-                  type="text"
-                  value={action.dest ?? action.source}
-                  oninput={(e) => {
-                    const val = e.currentTarget.value
-                    action.dest = val === action.source ? undefined : val
-                    updateAction()
-                  }}
-                  placeholder=".env"
-                  spellcheck="false"
-                  autocomplete="off"
-                />
-              {/if}
-              <button
-                class="bg-transparent border-0 text-text-faint text-base cursor-pointer px-1 leading-none flex-shrink-0 transition-colors duration-fast hover:text-danger-text"
-                onclick={() => removeAction(i)}
-                title="Remove">×</button
-              >
+        <div class="flex flex-col gap-2">
+          {#if actions.length > 0}
+            <div class="flex flex-col gap-1.5">
+              {#each actions as action, i (i)}
+                <div class="flex items-center gap-1.5">
+                  <span
+                    class="text-xs font-mono text-accent-text min-w-8 shrink-0 uppercase tracking-caps-tight"
+                  >
+                    {action.type === 'command' ? 'run' : 'copy'}
+                  </span>
+                  {#if action.type === 'command'}
+                    <input
+                      class="flex-1 min-w-0 border border-border rounded-md bg-bg-input text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint"
+                      type="text"
+                      name="worktreeSetupCommand"
+                      aria-label="Worktree setup command"
+                      bind:value={action.command}
+                      oninput={() => updateAction()}
+                      placeholder="npm install"
+                      spellcheck="false"
+                      autocomplete="off"
+                    />
+                  {:else}
+                    <input
+                      class="flex-1 min-w-0 border border-border rounded-md bg-bg-input text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint"
+                      type="text"
+                      name="worktreeSetupCopySource"
+                      aria-label="Worktree setup copy source"
+                      bind:value={action.source}
+                      oninput={() => updateAction()}
+                      placeholder=".env"
+                      spellcheck="false"
+                      autocomplete="off"
+                    />
+                    <span class="text-sm text-text-faint shrink-0">→</span>
+                    <input
+                      class="flex-1 min-w-0 border border-border rounded-md bg-bg-input text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint"
+                      type="text"
+                      name="worktreeSetupCopyDest"
+                      aria-label="Worktree setup copy destination"
+                      value={action.dest ?? action.source}
+                      oninput={(e) => {
+                        const val = e.currentTarget.value
+                        action.dest = val === action.source ? undefined : val
+                        updateAction()
+                      }}
+                      placeholder=".env"
+                      spellcheck="false"
+                      autocomplete="off"
+                    />
+                  {/if}
+                  <button
+                    type="button"
+                    class="bg-transparent border-0 text-text-faint text-base cursor-pointer px-1 leading-none shrink-0 hover:text-danger-text"
+                    onclick={() => removeAction(i)}
+                    aria-label="Remove action"
+                    title="Remove">×</button
+                  >
+                </div>
+              {/each}
             </div>
-          {/each}
+          {/if}
+
+          <div class="flex gap-2">
+            <button
+              type="button"
+              class="bg-hover border border-border rounded-md text-text-secondary text-sm font-inherit px-2.5 py-1 cursor-pointer hover:bg-hover-strong hover:text-text"
+              onclick={addCommand}>+ command</button
+            >
+            <button
+              type="button"
+              class="bg-hover border border-border rounded-md text-text-secondary text-sm font-inherit px-2.5 py-1 cursor-pointer hover:bg-hover-strong hover:text-text"
+              onclick={addCopy}>+ file copy</button
+            >
+          </div>
         </div>
-      {/if}
-
-      <div class="flex gap-2">
-        <button
-          class="bg-hover border border-border rounded-md text-text-secondary text-sm font-inherit px-2.5 py-1 cursor-pointer transition-colors duration-fast hover:bg-hover-strong hover:text-text"
-          onclick={addCommand}>+ command</button
-        >
-        <button
-          class="bg-hover border border-border rounded-md text-text-secondary text-sm font-inherit px-2.5 py-1 cursor-pointer transition-colors duration-fast hover:bg-hover-strong hover:text-text"
-          onclick={addCopy}>+ file copy</button
-        >
-      </div>
-
-      {#if actions.some((a) => a.type === 'command')}
-        <span class="text-xs text-text-faint">
-          Variables: $MAIN_WORKTREE, $NEW_WORKTREE, $REPO_ROOT
-        </span>
-      {/if}
-    </div>
-  {/if}
+      </PrefsRow>
+    {/if}
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/GitPrefs.svelte
+++ b/src/renderer/src/components/preferences/GitPrefs.svelte
@@ -155,8 +155,9 @@
           <div class="flex flex-col gap-0.5 min-w-0 flex-1">
             <span class="text-md text-text truncate">{workspace.name}</span>
             {#if workspaceState.repoRoot}
-              <span class="text-2xs text-text-faint font-mono truncate"
-                >{workspaceState.repoRoot}</span
+              <span
+                class="text-2xs text-text-faint font-mono truncate"
+                title={workspaceState.repoRoot}>{workspaceState.repoRoot}</span
               >
             {/if}
           </div>

--- a/src/renderer/src/components/preferences/GitPrefs.svelte
+++ b/src/renderer/src/components/preferences/GitPrefs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { FolderGit2, Terminal, FileText, ArrowRight, Trash2, Plus } from '@lucide/svelte'
   import { prefs, setPref, getPref } from '../../lib/stores/preferences.svelte'
   import CustomRadio from '../shared/CustomRadio.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
@@ -36,9 +37,9 @@
 
   type SetupAction = SetupCommandAction | SetupCopyAction
 
-  const workspaceId = $derived(workspaceState.workspace?.id)
+  const workspace = $derived(workspaceState.workspace)
+  const workspaceId = $derived(workspace?.id)
   const prefKey = $derived(workspaceId ? `workspace:${workspaceId}:worktreeSetup` : null)
-  const showSetup = $derived(workspaceState.isGitRepo && !!workspaceId)
 
   function loadActions(): SetupAction[] {
     if (!prefKey) return []
@@ -56,6 +57,8 @@
   $effect(() => {
     if (prefKey) {
       actions = loadActions()
+    } else {
+      actions = []
     }
   })
 
@@ -82,6 +85,8 @@
   function updateAction(): void {
     persistActions()
   }
+
+  const hasCommandAction = $derived(actions.some((a) => a.type === 'command'))
 </script>
 
 <div class="flex flex-col gap-7">
@@ -102,10 +107,7 @@
     </PrefsRow>
   </PrefsSection>
 
-  <PrefsSection
-    title="Worktrees"
-    description="Where new git worktrees are created and what runs after"
-  >
+  <PrefsSection title="Worktrees" description="Where new git worktrees are created">
     <PrefsRow
       label="Base directory"
       help="Pattern: <dir>/<project>/<branch>"
@@ -124,91 +126,166 @@
         autocomplete="off"
       />
     </PrefsRow>
+  </PrefsSection>
 
-    {#if showSetup}
-      <PrefsRow
-        label="Setup actions"
-        help="Run after creating a new worktree. Variables: $MAIN_WORKTREE, $NEW_WORKTREE, $REPO_ROOT"
-        search="worktree setup post-create command copy bootstrap"
-        layout="stacked"
-      >
-        <div class="flex flex-col gap-2">
-          {#if actions.length > 0}
-            <div class="flex flex-col gap-1.5">
-              {#each actions as action, i (i)}
-                <div class="flex items-center gap-1.5">
+  <PrefsSection
+    title="Worktree setup"
+    description="Bootstrap commands and file copies that run after `git worktree add`. Stored with the active project — not shared with other workspaces."
+    badge={{ text: 'Project', tone: 'accent' }}
+  >
+    {#if !workspace}
+      <div class="px-3 py-3 rounded-md bg-bg-input border border-dashed border-border-subtle">
+        <p class="text-sm text-text-muted m-0">
+          Open a project to configure its worktree setup actions.
+        </p>
+      </div>
+    {:else if !workspaceState.isGitRepo}
+      <div class="px-3 py-3 rounded-md bg-bg-input border border-dashed border-border-subtle">
+        <p class="text-sm text-text-muted m-0">
+          <strong class="text-text-secondary font-medium">{workspace.name}</strong> isn't a git repository.
+          Initialize git in this project to use worktree setup actions.
+        </p>
+      </div>
+    {:else}
+      <div class="flex flex-col gap-4">
+        <div
+          class="flex items-start gap-2.5 px-3 py-2.5 rounded-md bg-bg-input border border-border-subtle"
+        >
+          <FolderGit2 size={14} class="shrink-0 text-accent mt-0.5" />
+          <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+            <span class="text-md text-text truncate">{workspace.name}</span>
+            {#if workspaceState.repoRoot}
+              <span class="text-2xs text-text-faint font-mono truncate"
+                >{workspaceState.repoRoot}</span
+              >
+            {/if}
+          </div>
+          <span class="text-2xs uppercase tracking-caps-tight text-text-faint shrink-0 mt-0.5"
+            >Saved in this project</span
+          >
+        </div>
+
+        {#if actions.length > 0}
+          <div class="flex flex-col gap-2">
+            {#each actions as action, i (i)}
+              <div
+                class="flex items-center gap-2 px-2 py-1.5 rounded-md bg-bg-input border border-border-subtle"
+              >
+                {#if action.type === 'command'}
                   <span
-                    class="text-xs font-mono text-accent-text min-w-8 shrink-0 uppercase tracking-caps-tight"
+                    class="flex items-center gap-1 text-2xs font-semibold uppercase tracking-caps-tight text-success-text shrink-0 min-w-13"
+                    title="Run shell command"
                   >
-                    {action.type === 'command' ? 'run' : 'copy'}
+                    <Terminal size={11} /> Run
                   </span>
-                  {#if action.type === 'command'}
-                    <input
-                      class="flex-1 min-w-0 border border-border rounded-md bg-bg-input text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint"
-                      type="text"
-                      name="worktreeSetupCommand"
-                      aria-label="Worktree setup command"
-                      bind:value={action.command}
-                      oninput={() => updateAction()}
-                      placeholder="npm install"
-                      spellcheck="false"
-                      autocomplete="off"
-                    />
-                  {:else}
-                    <input
-                      class="flex-1 min-w-0 border border-border rounded-md bg-bg-input text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint"
-                      type="text"
-                      name="worktreeSetupCopySource"
-                      aria-label="Worktree setup copy source"
-                      bind:value={action.source}
-                      oninput={() => updateAction()}
-                      placeholder=".env"
-                      spellcheck="false"
-                      autocomplete="off"
-                    />
-                    <span class="text-sm text-text-faint shrink-0">→</span>
-                    <input
-                      class="flex-1 min-w-0 border border-border rounded-md bg-bg-input text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint"
-                      type="text"
-                      name="worktreeSetupCopyDest"
-                      aria-label="Worktree setup copy destination"
-                      value={action.dest ?? action.source}
-                      oninput={(e) => {
-                        const val = e.currentTarget.value
-                        action.dest = val === action.source ? undefined : val
-                        updateAction()
-                      }}
-                      placeholder=".env"
-                      spellcheck="false"
-                      autocomplete="off"
-                    />
-                  {/if}
-                  <button
-                    type="button"
-                    class="bg-transparent border-0 text-text-faint text-base cursor-pointer px-1 leading-none shrink-0 hover:text-danger-text"
-                    onclick={() => removeAction(i)}
-                    aria-label="Remove action"
-                    title="Remove">×</button
+                  <input
+                    class="flex-1 min-w-0 border border-border rounded-md bg-bg text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint"
+                    type="text"
+                    name="worktreeSetupCommand"
+                    aria-label="Worktree setup command"
+                    bind:value={action.command}
+                    oninput={() => updateAction()}
+                    placeholder="npm install"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                {:else}
+                  <span
+                    class="flex items-center gap-1 text-2xs font-semibold uppercase tracking-caps-tight text-accent-text shrink-0 min-w-13"
+                    title="Copy file from main worktree"
                   >
-                </div>
-              {/each}
-            </div>
-          {/if}
+                    <FileText size={11} /> Copy
+                  </span>
+                  <input
+                    class="flex-1 min-w-0 border border-border rounded-md bg-bg text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint"
+                    type="text"
+                    name="worktreeSetupCopySource"
+                    aria-label="Worktree setup copy source"
+                    bind:value={action.source}
+                    oninput={() => updateAction()}
+                    placeholder=".env"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                  <ArrowRight size={12} class="shrink-0 text-text-faint" />
+                  <input
+                    class="flex-1 min-w-0 border border-border rounded-md bg-bg text-text text-sm font-mono px-2 py-1 outline-none focus:border-focus-ring placeholder:text-text-faint"
+                    type="text"
+                    name="worktreeSetupCopyDest"
+                    aria-label="Worktree setup copy destination"
+                    value={action.dest ?? action.source}
+                    oninput={(e) => {
+                      const val = e.currentTarget.value
+                      action.dest = val === action.source ? undefined : val
+                      updateAction()
+                    }}
+                    placeholder=".env"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                {/if}
+                <button
+                  type="button"
+                  class="flex items-center justify-center size-6 rounded-md bg-transparent border-0 text-text-muted cursor-pointer shrink-0 hover:bg-danger-bg hover:text-danger-text"
+                  onclick={() => removeAction(i)}
+                  aria-label="Remove action"
+                  title="Remove"
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            {/each}
+          </div>
+        {:else}
+          <p class="text-sm text-text-muted m-0 leading-snug">
+            No actions yet. Add a command (e.g. <code class="font-mono text-text-secondary"
+              >npm install</code
+            >) or copy a file (e.g.
+            <code class="font-mono text-text-secondary">.env</code>) to bootstrap new worktrees.
+          </p>
+        {/if}
 
-          <div class="flex gap-2">
-            <button
-              type="button"
-              class="bg-hover border border-border rounded-md text-text-secondary text-sm font-inherit px-2.5 py-1 cursor-pointer hover:bg-hover-strong hover:text-text"
-              onclick={addCommand}>+ command</button
+        <div class="flex gap-2">
+          <button
+            type="button"
+            class="flex items-center gap-1 px-3 py-1 rounded-md bg-border-subtle border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-active hover:text-text"
+            onclick={addCommand}
+          >
+            <Plus size={12} />
+            <Terminal size={12} />
+            <span>Run command</span>
+          </button>
+          <button
+            type="button"
+            class="flex items-center gap-1 px-3 py-1 rounded-md bg-border-subtle border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-active hover:text-text"
+            onclick={addCopy}
+          >
+            <Plus size={12} />
+            <FileText size={12} />
+            <span>Copy file</span>
+          </button>
+        </div>
+
+        {#if hasCommandAction}
+          <div class="flex flex-wrap items-center gap-1.5 pt-3 border-t border-border-subtle">
+            <span class="text-2xs uppercase tracking-caps-tight text-text-faint mr-0.5"
+              >Variables</span
             >
-            <button
-              type="button"
-              class="bg-hover border border-border rounded-md text-text-secondary text-sm font-inherit px-2.5 py-1 cursor-pointer hover:bg-hover-strong hover:text-text"
-              onclick={addCopy}>+ file copy</button
+            <code
+              class="text-xs font-mono px-1.5 py-px rounded-sm bg-bg-input border border-border-subtle text-accent-text"
+              >$MAIN_WORKTREE</code
+            >
+            <code
+              class="text-xs font-mono px-1.5 py-px rounded-sm bg-bg-input border border-border-subtle text-accent-text"
+              >$NEW_WORKTREE</code
+            >
+            <code
+              class="text-xs font-mono px-1.5 py-px rounded-sm bg-bg-input border border-border-subtle text-accent-text"
+              >$REPO_ROOT</code
             >
           </div>
-        </div>
-      </PrefsRow>
+        {/if}
+      </div>
     {/if}
   </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/MiscPrefs.svelte
+++ b/src/renderer/src/components/preferences/MiscPrefs.svelte
@@ -2,6 +2,8 @@
   import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import { resetAllSessions } from '../../lib/stores/wpmTracker.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let runToolbarEnabled = $derived(prefs['runConfig.showInTitlebar'] === 'true')
   let wpmEnabled = $derived(prefs['wpm.enabled'] === 'true')
@@ -22,38 +24,35 @@
   }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Misc</h3>
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Title bar">
+    <PrefsRow
+      label="Show Run Configurations toolbar"
+      help="A toolbar in the title bar for quick-launching run configurations"
+      search="run configuration toolbar titlebar launch"
+    >
+      <CustomCheckbox checked={runToolbarEnabled} onchange={toggleRunToolbar} />
+    </PrefsRow>
+  </PrefsSection>
 
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <CustomCheckbox checked={runToolbarEnabled} onchange={toggleRunToolbar} />
-    <span>Show Run Configurations in title bar</span>
-  </label>
-  {#if runToolbarEnabled}
-    <div class="text-xs text-text-muted leading-normal pl-6 -mt-2">
-      Display a toolbar for quick-launching run configurations from the title bar
-    </div>
-  {/if}
+  <PrefsSection
+    title="Terminal overlays"
+    description="Real-time hints displayed over terminal panes"
+  >
+    <PrefsRow
+      label="Typing speed (WPM)"
+      help="Tracks printable keystrokes in a 10-second sliding window. Control keys, arrows, and escape sequences are excluded. Shows current WPM, peak speed, and total characters."
+      search="wpm typing speed words per minute keystrokes"
+    >
+      <CustomCheckbox checked={wpmEnabled} onchange={toggleWpm} />
+    </PrefsRow>
 
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <CustomCheckbox checked={wpmEnabled} onchange={toggleWpm} />
-    <span>Show typing speed (WPM) in terminals</span>
-  </label>
-  {#if wpmEnabled}
-    <div class="text-xs text-text-muted leading-normal pl-6 -mt-2">
-      Tracks printable keystrokes in a 10-second sliding window. Control keys, arrows, and escape
-      sequences are excluded. Displays current WPM, peak speed, and total characters.
-    </div>
-  {/if}
-
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <CustomCheckbox checked={keystrokeVisualizerEnabled} onchange={toggleKeystrokeVisualizer} />
-    <span>Show keystroke overlay in terminals</span>
-  </label>
-  {#if keystrokeVisualizerEnabled}
-    <div class="text-xs text-text-muted leading-normal pl-6 -mt-2">
-      Displays pressed keys and keyboard shortcuts as a floating overlay in the bottom-left corner
-      of the terminal. Keys fade out after 2 seconds.
-    </div>
-  {/if}
+    <PrefsRow
+      label="Keystroke overlay"
+      help="Pressed keys and shortcuts shown as a floating overlay in the bottom-left corner. Keys fade out after 2 seconds."
+      search="keystroke visualizer overlay screencast presentation"
+    >
+      <CustomCheckbox checked={keystrokeVisualizerEnabled} onchange={toggleKeystrokeVisualizer} />
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/NotchPrefs.svelte
+++ b/src/renderer/src/components/preferences/NotchPrefs.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let notchEnabled = $derived(prefs['notch.enabled'] === 'true')
 
@@ -11,14 +13,14 @@
   }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Notch</h3>
-
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <CustomCheckbox checked={notchEnabled} onchange={toggleNotch} />
-    <span>Show session status in notch overlay</span>
-  </label>
-  <div class="text-xs text-text-muted leading-normal pl-6 -mt-2">
-    Show active session info in an overlay near the top of the screen
-  </div>
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Notch overlay">
+    <PrefsRow
+      label="Show session status near the notch"
+      help="A floating overlay near the top of the screen shows active session info — handy when Canopy is in the background"
+      search="notch overlay status session indicator macos"
+    >
+      <CustomCheckbox checked={notchEnabled} onchange={toggleNotch} />
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/OpenCodePrefs.svelte
+++ b/src/renderer/src/components/preferences/OpenCodePrefs.svelte
@@ -3,4 +3,4 @@
   import OpenCodeProfileForm from './OpenCodeProfileForm.svelte'
 </script>
 
-<AgentProfilesPanel agentType="opencode" title="OpenCode" form={OpenCodeProfileForm} />
+<AgentProfilesPanel agentType="opencode" form={OpenCodeProfileForm} />

--- a/src/renderer/src/components/preferences/OpenCodeProfileForm.svelte
+++ b/src/renderer/src/components/preferences/OpenCodeProfileForm.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { ProfilePrefs } from '../../../../main/profiles/types'
   import ProfileEnvVarsSection from './ProfileEnvVarsSection.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let {
     prefs,
@@ -28,71 +30,76 @@
   }
 </script>
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">
-    Model & behavior
-  </h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="opencode-model">Model</label>
-    <input
-      id="opencode-model"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="text"
-      value={prefs.model ?? ''}
-      oninput={onTextInput('model')}
-      placeholder="provider/model"
-      spellcheck="false"
-    />
-    <span class="text-xs text-text-faint"
-      >Format: provider/model (e.g. anthropic/claude-sonnet-4-20250514)</span
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Model">
+    <PrefsRow
+      label="Model"
+      help="Format: provider/model (e.g. anthropic/claude-sonnet-4-20250514)"
+      search="opencode model provider anthropic openai"
+      layout="stacked"
     >
-  </div>
-</div>
+      <input
+        id="opencode-model"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="text"
+        name="opencodeModel"
+        aria-label="OpenCode model"
+        value={prefs.model ?? ''}
+        oninput={onTextInput('model')}
+        placeholder="provider/model"
+        spellcheck="false"
+      />
+    </PrefsRow>
+  </PrefsSection>
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">API</h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="opencode-apikey">API key</label>
-    <span class="text-xs text-text-faint"
-      >Set as ANTHROPIC_API_KEY. For other providers, use environment variables below</span
+  <PrefsSection title="API">
+    <PrefsRow
+      label="API key"
+      help="Set as ANTHROPIC_API_KEY. For other providers, use environment variables below."
+      search="opencode api key secret anthropic"
+      layout="stacked"
     >
-    <input
-      id="opencode-apikey"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      type="password"
-      value={apiKey}
-      oninput={(e) => onApiKeyChange((e.target as HTMLInputElement).value)}
-      placeholder={hasApiKey ? '•••• (saved — leave empty to keep)' : 'Uses existing env variable'}
-      spellcheck="false"
-      autocomplete="off"
-    />
-  </div>
-</div>
+      <input
+        id="opencode-apikey"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="password"
+        name="opencodeApiKey"
+        aria-label="OpenCode API key"
+        value={apiKey}
+        oninput={(e) => onApiKeyChange((e.target as HTMLInputElement).value)}
+        placeholder={hasApiKey
+          ? '•••• (saved — leave empty to keep)'
+          : 'Uses existing env variable'}
+        spellcheck="false"
+        autocomplete="off"
+      />
+    </PrefsRow>
+  </PrefsSection>
 
-<ProfileEnvVarsSection
-  customEnv={prefs.customEnv}
-  hint="Extra env vars passed to OpenCode sessions in this profile"
-  onChange={(v) => set('customEnv', v)}
-/>
+  <ProfileEnvVarsSection
+    customEnv={prefs.customEnv}
+    hint="Extra env vars passed to OpenCode sessions in this profile"
+    onChange={(v) => set('customEnv', v)}
+  />
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">Advanced</h4>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary" for="opencode-settings"
-      >Config JSON override</label
+  <PrefsSection title="Advanced">
+    <PrefsRow
+      label="Config JSON override"
+      help="Passed via OPENCODE_CONFIG_CONTENT at session start"
+      search="opencode config json override advanced"
+      layout="stacked"
     >
-    <textarea
-      id="opencode-settings"
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text font-mono text-sm outline-none focus:border-focus-ring resize-y min-h-[60px]"
-      rows="4"
-      value={prefs.settingsJson ?? ''}
-      oninput={onTextInput('settingsJson')}
-      placeholder={'{"key": "value"}'}
-      spellcheck="false"
-    ></textarea>
-    <span class="text-xs text-text-faint">Passed via OPENCODE_CONFIG_CONTENT at session start</span>
-  </div>
+      <textarea
+        id="opencode-settings"
+        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text font-mono text-sm outline-none focus:border-focus-ring resize-y min-h-15 placeholder:text-text-faint"
+        rows="4"
+        name="opencodeSettingsJson"
+        aria-label="Config JSON override"
+        value={prefs.settingsJson ?? ''}
+        oninput={onTextInput('settingsJson')}
+        placeholder={'{"key": "value"}'}
+        spellcheck="false"
+      ></textarea>
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/PreferencesModal.svelte
+++ b/src/renderer/src/components/preferences/PreferencesModal.svelte
@@ -31,6 +31,8 @@
 
   let { section: initialSection }: { section?: string } = $props()
 
+  const isMac = navigator.userAgent.includes('Mac')
+
   let containerEl: HTMLDivElement | undefined = $state()
   let searchInputEl: HTMLInputElement | undefined = $state()
 
@@ -81,11 +83,29 @@
       handleClose()
       return
     }
-    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+    const shortcutModifier = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
+    if (shortcutModifier && e.key.toLowerCase() === 'k') {
       e.preventDefault()
       e.stopPropagation()
       searchInputEl?.focus()
       searchInputEl?.select()
+      return
+    }
+    if (e.key === 'Tab' && containerEl) {
+      const focusable = containerEl.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )
+      if (focusable.length === 0) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const active = document.activeElement as HTMLElement | null
+      if (e.shiftKey && (active === first || !containerEl.contains(active))) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
     }
   }
 

--- a/src/renderer/src/components/preferences/PreferencesModal.svelte
+++ b/src/renderer/src/components/preferences/PreferencesModal.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { closeDialog } from '../../lib/stores/dialogs.svelte'
+  import { Download, Upload } from '@lucide/svelte'
+  import { closeDialog, confirm } from '../../lib/stores/dialogs.svelte'
+  import { loadPrefs } from '../../lib/stores/preferences.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
   import GeneralPrefs from './GeneralPrefs.svelte'
   import AppearancePrefs from './AppearancePrefs.svelte'
   import ToolPrefs from './ToolPrefs.svelte'
@@ -21,10 +24,15 @@
   import NotchPrefs from './NotchPrefs.svelte'
   import MiscPrefs from './MiscPrefs.svelte'
   import RemoteControlPrefs from './RemoteControlPrefs.svelte'
+  import PrefsHeader from './_partials/PrefsHeader.svelte'
+  import PrefsSidebar from './_partials/PrefsSidebar.svelte'
+  import { sectionMeta } from './_partials/sectionMeta'
+  import { clearQuery } from './_partials/prefsSearch.svelte'
 
   let { section: initialSection }: { section?: string } = $props()
 
   let containerEl: HTMLDivElement | undefined = $state()
+  let searchInputEl: HTMLInputElement | undefined = $state()
 
   const groups = [
     { label: 'General', sections: ['General', 'Updates', 'Privacy', 'Shortcuts'] },
@@ -48,16 +56,81 @@
   }
 
   let activeSection: Section = $state(resolveInitialSection())
+  const activeMeta = $derived(sectionMeta[activeSection])
+
+  function selectSection(section: string): void {
+    activeSection = section as Section
+  }
+
+  function handleClose(): void {
+    clearQuery()
+    closeDialog()
+  }
 
   onMount(() => {
     containerEl?.focus()
+    return () => {
+      clearQuery()
+    }
   })
 
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === 'Escape') {
       e.preventDefault()
       e.stopPropagation()
-      closeDialog()
+      handleClose()
+      return
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault()
+      e.stopPropagation()
+      searchInputEl?.focus()
+      searchInputEl?.select()
+    }
+  }
+
+  async function handleExport(): Promise<void> {
+    const ok = await confirm({
+      title: 'Export settings',
+      message: 'Save all app settings and integrations to a JSON file?',
+      details:
+        'The file will contain your AI agent API keys, Linear/Jira tokens, and saved credentials as plaintext. Store it somewhere only you can access.',
+      confirmLabel: 'Export',
+    })
+    if (!ok) return
+
+    try {
+      const result = await window.api.exportSettings()
+      if (!result) return
+      addToast(`Settings exported to ${result.path}`)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      addToast(`Export failed: ${message}`)
+    }
+  }
+
+  async function handleImport(): Promise<void> {
+    const ok = await confirm({
+      title: 'Import settings',
+      message: 'Load settings from a JSON file?',
+      details:
+        'Existing settings with matching keys will be overwritten. Profiles, credentials, and custom tools not in the file are kept as-is.',
+      confirmLabel: 'Import',
+      destructive: true,
+    })
+    if (!ok) return
+
+    try {
+      const result = await window.api.importSettings()
+      if (!result) return
+      const { preferences, profiles, credentials, customTools } = result.counts
+      addToast(
+        `Imported ${preferences} preferences, ${profiles} profiles, ${credentials} credentials, ${customTools} tools`,
+      )
+      await loadPrefs()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      addToast(`Import failed: ${message}`)
     }
   }
 </script>
@@ -66,94 +139,106 @@
 <div
   class="fixed inset-0 z-overlay flex justify-center items-center bg-scrim"
   onkeydown={handleKeydown}
-  onmousedown={closeDialog}
+  onmousedown={handleClose}
 >
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
     bind:this={containerEl}
-    class="outline-none w-prefs max-w-prefs h-prefs max-h-prefs flex bg-bg-overlay border border-border rounded-xl shadow-modal overflow-hidden"
+    class="outline-none w-prefs max-w-prefs h-prefs max-h-prefs flex flex-col bg-bg-overlay border border-border rounded-xl shadow-modal overflow-hidden"
     role="dialog"
     aria-modal="true"
     aria-labelledby="prefs-dialog-title"
     tabindex="-1"
     onmousedown={(e) => e.stopPropagation()}
   >
-    <div
-      class="w-44 flex-shrink-0 border-r border-active py-3 flex flex-col overflow-y-auto select-none"
-    >
-      <h2
-        id="prefs-dialog-title"
-        class="text-2xs font-semibold uppercase tracking-caps-tight text-text-muted px-3 pb-2 m-0"
-      >
-        Settings
-      </h2>
-      {#each groups as group (group.label)}
-        <div
-          role="group"
-          aria-labelledby={`prefs-group-${group.label}`}
-          class="flex flex-col gap-px mt-2 first:mt-0"
-        >
-          <span
-            id={`prefs-group-${group.label}`}
-            class="block px-3 pb-1 text-2xs font-semibold text-text-faint uppercase tracking-caps-looser"
-            >{group.label}</span
-          >
-          {#each group.sections as section (section)}
-            <button
-              class="block w-full px-5 py-1 border-0 bg-transparent text-text-secondary text-sm font-inherit text-left cursor-pointer rounded-sm transition-colors duration-fast hover:bg-hover hover:text-text"
-              class:bg-active={activeSection === section}
-              class:text-text={activeSection === section}
-              onclick={() => (activeSection = section)}
-            >
-              {section}
-            </button>
-          {/each}
-        </div>
-      {/each}
-    </div>
+    <PrefsHeader
+      title="Settings"
+      breadcrumb={activeSection}
+      onclose={handleClose}
+      bind:inputEl={searchInputEl}
+    />
 
-    <div class="flex-1 overflow-y-auto px-6 py-5">
-      {#if activeSection === 'General'}
-        <GeneralPrefs />
-      {:else if activeSection === 'Updates'}
-        <UpdatePrefs />
-      {:else if activeSection === 'Appearance'}
-        <AppearancePrefs />
-      {:else if activeSection === 'Sidebar'}
-        <SidebarPrefs />
-      {:else if activeSection === 'Terminal'}
-        <TerminalPrefs />
-      {:else if activeSection === 'Tools'}
-        <ToolPrefs />
-      {:else if activeSection === 'Claude'}
-        <ClaudePrefs />
-      {:else if activeSection === 'Gemini'}
-        <GeminiPrefs />
-      {:else if activeSection === 'OpenCode'}
-        <OpenCodePrefs />
-      {:else if activeSection === 'Codex'}
-        <CodexPrefs />
-      {:else if activeSection === 'Skills'}
-        <SkillPrefs />
-      {:else if activeSection === 'Git'}
-        <GitPrefs />
-      {:else if activeSection === 'Web Browser'}
-        <ViewportsPrefs />
-      {:else if activeSection === 'Tasks'}
-        <TaskTrackerPrefs />
-      {:else if activeSection === 'File Watcher'}
-        <FileWatcherPrefs />
-      {:else if activeSection === 'Privacy'}
-        <PrivacyPrefs />
-      {:else if activeSection === 'Shortcuts'}
-        <ShortcutsPrefs />
-      {:else if activeSection === 'Notch'}
-        <NotchPrefs />
-      {:else if activeSection === 'Misc'}
-        <MiscPrefs />
-      {:else if activeSection === 'Remote Control'}
-        <RemoteControlPrefs />
-      {/if}
+    <div class="flex flex-1 min-h-0">
+      <PrefsSidebar {groups} {activeSection} onselect={selectSection}>
+        {#snippet footer()}
+          <div class="flex items-center justify-between gap-1">
+            <span class="text-2xs uppercase tracking-caps-tight text-text-faint pl-1">Backup</span>
+            <div class="flex items-center gap-0.5">
+              <button
+                type="button"
+                class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-hover hover:text-text"
+                aria-label="Export settings"
+                title="Export settings…"
+                onclick={handleExport}
+              >
+                <Download size={14} />
+              </button>
+              <button
+                type="button"
+                class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-hover hover:text-text"
+                aria-label="Import settings"
+                title="Import settings…"
+                onclick={handleImport}
+              >
+                <Upload size={14} />
+              </button>
+            </div>
+          </div>
+        {/snippet}
+      </PrefsSidebar>
+
+      <main class="flex-1 flex flex-col min-w-0 overflow-hidden">
+        <div class="px-7 pt-5 pb-3 border-b border-border-subtle shrink-0 flex flex-col gap-0.5">
+          <h2 class="text-lg font-semibold text-text m-0 leading-tight">{activeSection}</h2>
+          {#if activeMeta?.description}
+            <p class="text-xs text-text-muted m-0 leading-snug">{activeMeta.description}</p>
+          {/if}
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-7 py-5">
+          {#if activeSection === 'General'}
+            <GeneralPrefs />
+          {:else if activeSection === 'Updates'}
+            <UpdatePrefs />
+          {:else if activeSection === 'Appearance'}
+            <AppearancePrefs />
+          {:else if activeSection === 'Sidebar'}
+            <SidebarPrefs />
+          {:else if activeSection === 'Terminal'}
+            <TerminalPrefs />
+          {:else if activeSection === 'Tools'}
+            <ToolPrefs />
+          {:else if activeSection === 'Claude'}
+            <ClaudePrefs />
+          {:else if activeSection === 'Gemini'}
+            <GeminiPrefs />
+          {:else if activeSection === 'OpenCode'}
+            <OpenCodePrefs />
+          {:else if activeSection === 'Codex'}
+            <CodexPrefs />
+          {:else if activeSection === 'Skills'}
+            <SkillPrefs />
+          {:else if activeSection === 'Git'}
+            <GitPrefs />
+          {:else if activeSection === 'Web Browser'}
+            <ViewportsPrefs />
+          {:else if activeSection === 'Tasks'}
+            <TaskTrackerPrefs />
+          {:else if activeSection === 'File Watcher'}
+            <FileWatcherPrefs />
+          {:else if activeSection === 'Privacy'}
+            <PrivacyPrefs />
+          {:else if activeSection === 'Shortcuts'}
+            <ShortcutsPrefs />
+          {:else if activeSection === 'Notch'}
+            <NotchPrefs />
+          {:else if activeSection === 'Misc'}
+            <MiscPrefs />
+          {:else if activeSection === 'Remote Control'}
+            <RemoteControlPrefs />
+          {/if}
+        </div>
+      </main>
     </div>
   </div>
 </div>

--- a/src/renderer/src/components/preferences/PrivacyPrefs.svelte
+++ b/src/renderer/src/components/preferences/PrivacyPrefs.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let telemetryEnabled = $derived(prefs['telemetry.enabled'] !== 'false')
 
@@ -9,21 +11,20 @@
   }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Privacy</h3>
-
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <CustomCheckbox checked={telemetryEnabled} onchange={toggleTelemetry} />
-    <span>Minimal telemetry</span>
-  </label>
-  <div class="text-xs text-text-muted leading-normal pl-6 -mt-2">
-    Sends one daily ping so we can count active users. The payload contains only screen resolution,
-    locale, app version, OS and architecture. No stable identifier is stored or transmitted.
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Telemetry" description="What Canopy sends to its makers">
+    <PrefsRow
+      label="Send minimal telemetry"
+      help="One daily ping helps us count active users. The payload contains only screen resolution, locale, app version, OS, and architecture. No stable identifier is stored or transmitted."
+      search="telemetry diagnostics ping analytics privacy"
+    >
+      <CustomCheckbox checked={telemetryEnabled} onchange={toggleTelemetry} />
+    </PrefsRow>
     <a
-      class="text-accent no-underline hover:underline"
+      class="text-xs text-accent-text no-underline hover:underline mt-1 w-fit"
       href="https://canopy.itsol.tech/privacy-policy"
       target="_blank"
-      rel="noopener noreferrer">Privacy policy</a
+      rel="noopener noreferrer">Privacy policy →</a
     >
-  </div>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/ProfileEnvVarsSection.svelte
+++ b/src/renderer/src/components/preferences/ProfileEnvVarsSection.svelte
@@ -29,6 +29,7 @@
   let showEnvForm = $state(false)
   let newEnvKey = $state('')
   let newEnvValue = $state('')
+  let newValueRevealed = $state(false)
 
   const revealed = new SvelteSet<string>()
   function toggleReveal(key: string): void {
@@ -53,12 +54,14 @@
     persistEnvEntries([...envEntries, { key: newEnvKey.trim(), value: newEnvValue }])
     newEnvKey = ''
     newEnvValue = ''
+    newValueRevealed = false
     showEnvForm = false
   }
 
   function cancelAdd(): void {
     newEnvKey = ''
     newEnvValue = ''
+    newValueRevealed = false
     showEnvForm = false
   }
 
@@ -134,16 +137,32 @@
           autocomplete="off"
           onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
         />
-        <input
-          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
-          name="newEnvValue"
-          aria-label="Variable value"
-          bind:value={newEnvValue}
-          placeholder="value"
-          spellcheck="false"
-          autocomplete="off"
-          onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
-        />
+        <div class="flex items-center gap-1.5">
+          <input
+            class="flex-1 min-w-0 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+            type={newValueRevealed ? 'text' : 'password'}
+            name="newEnvValue"
+            aria-label="Variable value"
+            bind:value={newEnvValue}
+            placeholder="value"
+            spellcheck="false"
+            autocomplete="off"
+            onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
+          />
+          <button
+            type="button"
+            class="flex items-center justify-center size-7 rounded-md bg-transparent border border-border text-text-muted cursor-pointer shrink-0 hover:bg-hover hover:text-text"
+            onclick={() => (newValueRevealed = !newValueRevealed)}
+            title={newValueRevealed ? 'Hide value' : 'Show value'}
+            aria-label={newValueRevealed ? 'Hide value' : 'Show value'}
+          >
+            {#if newValueRevealed}
+              <EyeOff size={12} />
+            {:else}
+              <Eye size={12} />
+            {/if}
+          </button>
+        </div>
         <div class="flex justify-end gap-2">
           <button
             type="button"

--- a/src/renderer/src/components/preferences/ProfileEnvVarsSection.svelte
+++ b/src/renderer/src/components/preferences/ProfileEnvVarsSection.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { Plus, X, Eye, EyeOff } from '@lucide/svelte'
   import { SvelteSet } from 'svelte/reactivity'
   import { confirm } from '../../lib/stores/dialogs.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
 
   let {
     customEnv,
@@ -54,11 +56,17 @@
     showEnvForm = false
   }
 
+  function cancelAdd(): void {
+    newEnvKey = ''
+    newEnvValue = ''
+    showEnvForm = false
+  }
+
   async function removeEnvVar(index: number): Promise<void> {
     const entry = envEntries[index]
     if (!entry) return
     const ok = await confirm({
-      title: 'Remove Variable',
+      title: 'Remove variable',
       message: `Remove environment variable "${entry.key}"?`,
       details: 'The value is masked and cannot be recovered after removal.',
       confirmLabel: 'Remove',
@@ -69,77 +77,95 @@
   }
 </script>
 
-<div class="flex flex-col gap-2.5 mb-5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">{label}</h4>
-  {#if hint}
-    <span class="text-xs text-text-faint">{hint}</span>
-  {/if}
-
-  {#if envEntries.length > 0}
-    <div class="flex flex-col gap-1">
-      {#each envEntries as entry, i (entry.key)}
-        {@const isRevealed = revealed.has(entry.key)}
-        <div class="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-border-subtle text-md">
-          <span class="text-accent-text font-mono text-sm">{entry.key}</span>
-          <span class="text-text-faint">=</span>
-          <span
-            class="font-mono text-sm flex-1 overflow-hidden text-ellipsis whitespace-nowrap {isRevealed
-              ? 'text-text-secondary'
-              : 'text-text-faint tracking-[1px]'}"
+<PrefsSection title={label} description={hint}>
+  <div class="flex flex-col gap-2 py-3 border-t border-border-subtle first:border-t-0 first:pt-0">
+    {#if envEntries.length > 0}
+      <div class="flex flex-col gap-1">
+        {#each envEntries as entry, i (entry.key)}
+          {@const isRevealed = revealed.has(entry.key)}
+          <div
+            class="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-bg-input text-md border border-border-subtle"
           >
-            {isRevealed ? entry.value : maskValue(entry.value)}
-          </span>
-          <button
-            class="px-2 py-0.5 border border-border rounded-md bg-transparent text-text-secondary text-xs font-inherit cursor-pointer flex-shrink-0 hover:bg-hover hover:text-text"
-            onclick={() => toggleReveal(entry.key)}
-            title={isRevealed ? 'Hide value' : 'Show value'}
-            aria-label={isRevealed ? `Hide ${entry.key}` : `Show ${entry.key}`}
-          >
-            {isRevealed ? 'Hide' : 'Show'}
-          </button>
-          <button
-            class="px-2 py-0.5 border-0 rounded-md bg-danger-bg text-danger-text text-xs font-inherit cursor-pointer flex-shrink-0"
-            onclick={() => removeEnvVar(i)}
-            aria-label={`Remove environment variable ${entry.key}`}
-          >
-            Remove
-          </button>
-        </div>
-      {/each}
-    </div>
-  {/if}
-
-  {#if showEnvForm}
-    <div class="flex flex-col gap-2 p-3 border border-border rounded-xl bg-border-subtle">
-      <input
-        class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-mono outline-none focus:border-focus-ring"
-        bind:value={newEnvKey}
-        placeholder="VARIABLE_NAME"
-        spellcheck="false"
-        onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
-      />
-      <input
-        class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-mono outline-none focus:border-focus-ring"
-        bind:value={newEnvValue}
-        placeholder="value"
-        spellcheck="false"
-        onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
-      />
-      <div class="flex justify-end gap-2">
-        <button
-          class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-active text-text"
-          onclick={() => (showEnvForm = false)}>Cancel</button
-        >
-        <button
-          class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text"
-          onclick={addEnvVar}>Add</button
-        >
+            <span class="text-accent-text font-mono text-sm shrink-0">{entry.key}</span>
+            <span class="text-text-faint shrink-0">=</span>
+            <span
+              class="font-mono text-sm flex-1 truncate {isRevealed
+                ? 'text-text-secondary'
+                : 'text-text-faint tracking-wider'}"
+            >
+              {isRevealed ? entry.value : maskValue(entry.value)}
+            </span>
+            <button
+              type="button"
+              class="flex items-center justify-center size-6 rounded-md bg-transparent border-0 text-text-muted cursor-pointer shrink-0 hover:bg-hover hover:text-text"
+              onclick={() => toggleReveal(entry.key)}
+              title={isRevealed ? 'Hide value' : 'Show value'}
+              aria-label={isRevealed ? `Hide ${entry.key}` : `Show ${entry.key}`}
+            >
+              {#if isRevealed}
+                <EyeOff size={12} />
+              {:else}
+                <Eye size={12} />
+              {/if}
+            </button>
+            <button
+              type="button"
+              class="flex items-center justify-center size-6 rounded-md bg-transparent border-0 text-text-muted cursor-pointer shrink-0 hover:bg-danger-bg hover:text-danger-text"
+              onclick={() => removeEnvVar(i)}
+              aria-label={`Remove environment variable ${entry.key}`}
+              title="Remove"
+            >
+              <X size={12} />
+            </button>
+          </div>
+        {/each}
       </div>
-    </div>
-  {:else}
-    <button
-      class="self-start px-3.5 py-1.5 border border-dashed border-text-faint rounded-lg bg-transparent text-text-secondary text-md font-inherit cursor-pointer hover:bg-hover hover:text-text"
-      onclick={() => (showEnvForm = true)}>+ Add variable</button
-    >
-  {/if}
-</div>
+    {/if}
+
+    {#if showEnvForm}
+      <div class="flex flex-col gap-2 p-2.5 border border-border rounded-md bg-bg-input">
+        <input
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="newEnvKey"
+          aria-label="Variable name"
+          bind:value={newEnvKey}
+          placeholder="VARIABLE_NAME"
+          spellcheck="false"
+          autocomplete="off"
+          onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
+        />
+        <input
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="newEnvValue"
+          aria-label="Variable value"
+          bind:value={newEnvValue}
+          placeholder="value"
+          spellcheck="false"
+          autocomplete="off"
+          onkeydown={(e) => e.key === 'Enter' && addEnvVar()}
+        />
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
+            onclick={cancelAdd}>Cancel</button
+          >
+          <button
+            type="button"
+            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
+            onclick={addEnvVar}>Add</button
+          >
+        </div>
+      </div>
+    {:else}
+      <button
+        type="button"
+        class="self-start flex items-center gap-1 px-2.5 py-1 rounded-md bg-border-subtle border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-active hover:text-text"
+        onclick={() => (showEnvForm = true)}
+      >
+        <Plus size={12} />
+        <span>Add variable</span>
+      </button>
+    {/if}
+  </div>
+</PrefsSection>

--- a/src/renderer/src/components/preferences/ProfileEnvVarsSection.svelte
+++ b/src/renderer/src/components/preferences/ProfileEnvVarsSection.svelte
@@ -19,8 +19,14 @@
   let envEntries = $derived.by(() => {
     if (!customEnv) return [] as Array<{ key: string; value: string }>
     try {
-      const parsed = JSON.parse(customEnv) as Record<string, string>
-      return Object.entries(parsed).map(([key, value]) => ({ key, value }))
+      const parsed: unknown = JSON.parse(customEnv)
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return []
+      const out: Array<{ key: string; value: string }> = []
+      for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof key !== 'string' || typeof value !== 'string') continue
+        out.push({ key, value })
+      }
+      return out
     } catch {
       return [] as Array<{ key: string; value: string }>
     }
@@ -30,6 +36,13 @@
   let newEnvKey = $state('')
   let newEnvValue = $state('')
   let newValueRevealed = $state(false)
+
+  const SECRET_NAME = /(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)$/i
+  let secretWarning = $derived(
+    newEnvKey.trim().length > 0 && SECRET_NAME.test(newEnvKey.trim())
+      ? 'This name looks like a secret. Env values are stored in plaintext — use the API key field above when possible.'
+      : '',
+  )
 
   const revealed = new SvelteSet<string>()
   function toggleReveal(key: string): void {
@@ -163,6 +176,9 @@
             {/if}
           </button>
         </div>
+        {#if secretWarning}
+          <p class="text-xs text-warning-text m-0 leading-snug" role="alert">{secretWarning}</p>
+        {/if}
         <div class="flex justify-end gap-2">
           <button
             type="button"

--- a/src/renderer/src/components/preferences/RemoteControlPrefs.svelte
+++ b/src/renderer/src/components/preferences/RemoteControlPrefs.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte'
+  import { ShieldAlert, Trash2 } from '@lucide/svelte'
   import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import { confirm } from '../../lib/stores/dialogs.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
+  import CustomRadio from '../shared/CustomRadio.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   type GuardProfile = 'none' | 'destructive' | 'full'
 
@@ -41,7 +45,7 @@
 
   async function removeDevice(deviceId: string, name: string): Promise<void> {
     const ok = await confirm({
-      title: 'Remove Trusted Device',
+      title: 'Remove trusted device',
       message: `Remove "${name}" from trusted devices? It will need manual approval to connect again.`,
       confirmLabel: 'Remove',
       destructive: true,
@@ -73,154 +77,126 @@
   })
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0 inline-flex items-center gap-2">
-    Remote Control
-    <span
-      class="inline-block px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.6px] text-warning bg-experimental-bg border border-experimental-border rounded-[10px] align-middle"
-      title="This feature is in beta — expect rough edges">Beta</span
-    >
-  </h3>
-
-  <p class="text-xs text-text-muted leading-normal">
-    Control Canopy from another device on your local WiFi network — phone, tablet, or another
-    laptop. Scan a QR code from the command palette to pair a device. Connections are end-to-end
-    encrypted via WebRTC DTLS. Once you have a trusted device, the signaling server stays bound in
-    the background on every app launch so that device can reconnect without you reopening the
-    pairing modal — disable the toggle below or remove all trusted devices to stop this auto-listen
-    behavior.
-  </p>
-
+<div class="flex flex-col gap-7">
   <div
-    class="px-3 py-2.5 bg-experimental-bg border border-experimental-border rounded-lg text-xs text-text-secondary leading-normal"
+    class="flex items-start gap-3 p-3 rounded-md bg-experimental-bg border border-experimental-border"
   >
-    <strong class="text-text block mb-1">Beta security notes:</strong>
-    <ul class="m-0 pl-4">
-      <li>
-        The pairing handshake (token exchange, SDP offer/answer) travels over plain HTTP/WebSocket
-        on the LAN — anyone with a packet sniffer on the same WiFi can observe it. Only the WebRTC
-        data channels themselves are encrypted (DTLS).
-      </li>
-      <li class="mt-1">
-        "Remember this device" uses the device's self-reported random ID for recognition — it's not
+    <ShieldAlert size={16} class="shrink-0 text-warning-text mt-0.5" />
+    <div class="flex flex-col gap-1.5 text-xs text-text-secondary leading-snug">
+      <p class="m-0">
+        <strong class="text-text font-semibold">Beta security notes.</strong>
+        Pairing handshakes (token exchange, SDP offer/answer) travel over plain HTTP/WebSocket on the
+        LAN — anyone with a packet sniffer on the same WiFi can observe them. Only the WebRTC data channels
+        themselves are encrypted (DTLS).
+      </p>
+      <p class="m-0">
+        "Remember this device" uses the device's self-reported random ID for recognition — it is not
         cryptographic identity. Anyone who knows or guesses a trusted device's ID can skip the
         accept modal. Cryptographic challenge-response is planned for a future release; until then,
         avoid using this on untrusted networks.
-      </li>
-    </ul>
+      </p>
+    </div>
   </div>
 
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <CustomCheckbox checked={enabled} onchange={toggleEnabled} />
-    <span>Enable remote control</span>
-  </label>
-  <div class="text-xs text-text-muted leading-normal pl-6 -mt-2">
-    When disabled, the command palette does not expose the "Open Remote Connection" action, the
-    signaling server is never bound (including listen mode), and trusted devices cannot reconnect
-    until the toggle is re-enabled.
-  </div>
-
-  <fieldset
-    class="flex flex-col gap-2 p-3 border border-border rounded-lg"
-    class:opacity-50={!enabled}
-    disabled={!enabled}
+  <PrefsSection
+    title="Remote control"
+    description="Control Canopy from another device on your local network. Connections use end-to-end encrypted WebRTC DTLS data channels."
   >
-    <legend class="text-xs font-semibold uppercase tracking-[0.4px] text-text-secondary px-1.5"
-      >Action restrictions</legend
+    <PrefsRow
+      label="Enable remote control"
+      help="When disabled, the command palette hides the Open Remote Connection action, the signaling server is never bound, and trusted devices cannot reconnect."
+      search="remote control enable signaling pair phone tablet"
+      badge={{ text: 'Beta', tone: 'warning' }}
     >
-    <label class="flex gap-2 items-start cursor-pointer text-md text-text">
-      <input
-        class="mt-[3px]"
-        type="radio"
-        name="remote-action-guard"
-        value="none"
-        checked={guardProfile === 'none'}
-        onchange={() => setGuard('none')}
-      />
-      <span class="flex flex-col gap-0.5">
-        <strong>None</strong>
-        <small class="text-xs text-text-muted"
-          >Paired device has full access without per-action prompts.</small
-        >
-      </span>
-    </label>
-    <label class="flex gap-2 items-start cursor-pointer text-md text-text">
-      <input
-        class="mt-[3px]"
-        type="radio"
-        name="remote-action-guard"
-        value="destructive"
-        checked={guardProfile === 'destructive'}
-        onchange={() => setGuard('destructive')}
-      />
-      <span class="flex flex-col gap-0.5">
-        <strong>Destructive only (recommended)</strong>
-        <small class="text-xs text-text-muted"
-          >Ask before kills, deletes, worktree removes and tab closes.</small
-        >
-      </span>
-    </label>
-    <label class="flex gap-2 items-start cursor-pointer text-md text-text">
-      <input
-        class="mt-[3px]"
-        type="radio"
-        name="remote-action-guard"
-        value="full"
-        checked={guardProfile === 'full'}
-        onchange={() => setGuard('full')}
-      />
-      <span class="flex flex-col gap-0.5">
-        <strong>Full</strong>
-        <small class="text-xs text-text-muted"
-          >Every action from the remote device requires confirmation on this desktop.</small
-        >
-      </span>
-    </label>
-  </fieldset>
+      <CustomCheckbox checked={enabled} onchange={toggleEnabled} />
+    </PrefsRow>
+  </PrefsSection>
 
-  <div>
-    <h4 class="text-md font-semibold text-text m-0 mb-1">Trusted Devices</h4>
-    <p class="text-xs text-text-muted leading-normal">
-      Devices you mark as "Remember this device" during pairing auto-connect on future sessions
-      without showing the accept modal. Remove a device here to require manual approval again.
-    </p>
+  <PrefsSection
+    title="Action restrictions"
+    description="What the paired device may do without per-action approval on this desktop"
+  >
+    <div class="flex flex-col" class:opacity-50={!enabled} class:pointer-events-none={!enabled}>
+      <PrefsRow
+        label="None"
+        help="Paired device has full access without per-action prompts"
+        search="remote guard none full-access"
+      >
+        <CustomRadio
+          checked={guardProfile === 'none'}
+          onchange={() => setGuard('none')}
+          disabled={!enabled}
+        />
+      </PrefsRow>
+      <PrefsRow
+        label="Destructive only"
+        help="Ask before kills, deletes, worktree removes, and tab closes"
+        search="remote guard destructive recommended default"
+        badge={{ text: 'Recommended', tone: 'accent' }}
+      >
+        <CustomRadio
+          checked={guardProfile === 'destructive'}
+          onchange={() => setGuard('destructive')}
+          disabled={!enabled}
+        />
+      </PrefsRow>
+      <PrefsRow
+        label="Full"
+        help="Every action from the remote device requires confirmation on this desktop"
+        search="remote guard full strict every action"
+      >
+        <CustomRadio
+          checked={guardProfile === 'full'}
+          onchange={() => setGuard('full')}
+          disabled={!enabled}
+        />
+      </PrefsRow>
+    </div>
+  </PrefsSection>
+
+  <PrefsSection
+    title="Trusted devices"
+    description="Devices marked as remembered during pairing reconnect automatically. Remove a device here to require manual approval again."
+  >
     {#if loading}
       <p
-        class="text-sm text-text-muted px-3.5 py-3 bg-bg-input border border-dashed border-border-subtle rounded-lg mt-2"
+        class="text-sm text-text-muted px-3 py-3 bg-bg-input rounded-md border border-border-subtle"
       >
         Loading…
       </p>
     {:else if trustedDevices.length === 0}
       <p
-        class="text-sm text-text-muted px-3.5 py-3 bg-bg-input border border-dashed border-border-subtle rounded-lg mt-2"
+        class="text-sm text-text-muted px-3 py-3 bg-bg-input rounded-md border border-border-subtle"
       >
         No trusted devices yet.
       </p>
     {:else}
-      <ul class="list-none p-0 m-0 mt-2 flex flex-col gap-1.5">
+      <ul role="list" class="m-0 p-0 flex flex-col gap-1">
         {#each trustedDevices as device (device.deviceId)}
           <li
-            class="flex items-center justify-between gap-3 px-3 py-2.5 bg-bg-input border border-border-subtle rounded-lg"
+            class="flex items-center justify-between gap-3 px-3 py-2 bg-bg-input border border-border-subtle rounded-md"
           >
             <div class="flex flex-col gap-0.5 min-w-0">
-              <span class="text-md font-medium text-text">{device.name}</span>
+              <span class="text-md text-text truncate">{device.name}</span>
               <span class="text-2xs text-text-muted">
                 <code class="font-mono text-text-secondary">{device.deviceId.slice(0, 12)}…</code>
-                · added {formatRelative(device.addedAt)}
-                · last seen {formatRelative(device.lastSeen)}
+                · added {formatRelative(device.addedAt)} · last seen {formatRelative(
+                  device.lastSeen,
+                )}
               </span>
             </div>
             <button
               type="button"
-              class="px-3 py-1 rounded-md bg-bg border border-border text-danger-text text-xs cursor-pointer flex-shrink-0 hover:bg-danger-bg hover:border-danger"
+              class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer shrink-0 hover:bg-danger-bg hover:text-danger-text"
               onclick={() => removeDevice(device.deviceId, device.name)}
-              title="Remove trusted device"
+              aria-label="Remove {device.name}"
+              title="Remove"
             >
-              Remove
+              <Trash2 size={13} />
             </button>
           </li>
         {/each}
       </ul>
     {/if}
-  </div>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/ShortcutsPrefs.svelte
+++ b/src/renderer/src/components/preferences/ShortcutsPrefs.svelte
@@ -1,46 +1,85 @@
 <script lang="ts">
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import { prefsSearch, matches } from './_partials/prefsSearch.svelte'
+
   const isMac = navigator.userAgent.includes('Mac')
 
-  const shortcuts = [
-    { keys: isMac ? ['⌘', 'K'] : ['Ctrl', 'K'], action: 'Command palette' },
-    { keys: isMac ? ['⌘', 'T'] : ['Ctrl', 'T'], action: 'New shell tab' },
-    { keys: isMac ? ['⌘', 'W'] : ['Ctrl', 'W'], action: 'Close pane (or tab if last)' },
-    { keys: isMac ? ['⌘', '⇧', 'T'] : ['Ctrl', 'Shift', 'T'], action: 'Reopen closed tab' },
-    { keys: isMac ? ['⌘', '1-9'] : ['Ctrl', '1-9'], action: 'Switch to tab N' },
-    { keys: isMac ? ['⌘', '⇧', '['] : ['Ctrl', 'Shift', '['], action: 'Previous tab' },
-    { keys: isMac ? ['⌘', '⇧', ']'] : ['Ctrl', 'Shift', ']'], action: 'Next tab' },
-    { keys: isMac ? ['⌘', 'D'] : ['Ctrl', 'D'], action: 'Split pane vertical' },
-    { keys: isMac ? ['⌘', '⇧', 'D'] : ['Ctrl', 'Shift', 'D'], action: 'Split pane horizontal' },
+  interface Shortcut {
+    keys: string[]
+    action: string
+  }
+
+  interface Group {
+    title: string
+    items: Shortcut[]
+  }
+
+  const groups: Group[] = [
     {
-      keys: isMac ? ['⌘', '⌥', '←→'] : ['Ctrl', 'Alt', '←→'],
-      action: 'Move focus between panes',
+      title: 'App',
+      items: [
+        { keys: isMac ? ['⌘', 'K'] : ['Ctrl', 'K'], action: 'Command palette' },
+        { keys: isMac ? ['⌘', ','] : ['Ctrl', ','], action: 'Preferences' },
+        { keys: isMac ? ['⌘', 'O'] : ['Ctrl', 'O'], action: 'Open workspace' },
+        { keys: isMac ? ['⌘', 'B'] : ['Ctrl', 'B'], action: 'Toggle sidebar' },
+        {
+          keys: isMac ? ['⌘', '⇧', 'I'] : ['Ctrl', 'Shift', 'I'],
+          action: 'Toggle Claude Inspector',
+        },
+      ],
     },
-    { keys: isMac ? ['⌘', 'B'] : ['Ctrl', 'B'], action: 'Toggle sidebar' },
     {
-      keys: isMac ? ['⌘', '⇧', 'I'] : ['Ctrl', 'Shift', 'I'],
-      action: 'Toggle Claude Inspector',
+      title: 'Tabs',
+      items: [
+        { keys: isMac ? ['⌘', 'T'] : ['Ctrl', 'T'], action: 'New shell tab' },
+        { keys: isMac ? ['⌘', 'W'] : ['Ctrl', 'W'], action: 'Close pane (or tab if last)' },
+        { keys: isMac ? ['⌘', '⇧', 'T'] : ['Ctrl', 'Shift', 'T'], action: 'Reopen closed tab' },
+        { keys: isMac ? ['⌘', '1-9'] : ['Ctrl', '1-9'], action: 'Switch to tab N' },
+        { keys: isMac ? ['⌘', '⇧', '['] : ['Ctrl', 'Shift', '['], action: 'Previous tab' },
+        { keys: isMac ? ['⌘', '⇧', ']'] : ['Ctrl', 'Shift', ']'], action: 'Next tab' },
+      ],
     },
-    { keys: isMac ? ['⌘', 'O'] : ['Ctrl', 'O'], action: 'Open workspace' },
-    { keys: isMac ? ['⌘', ','] : ['Ctrl', ','], action: 'Preferences' },
+    {
+      title: 'Panes',
+      items: [
+        { keys: isMac ? ['⌘', 'D'] : ['Ctrl', 'D'], action: 'Split pane vertical' },
+        { keys: isMac ? ['⌘', '⇧', 'D'] : ['Ctrl', 'Shift', 'D'], action: 'Split pane horizontal' },
+        {
+          keys: isMac ? ['⌘', '⌥', '←→'] : ['Ctrl', 'Alt', '←→'],
+          action: 'Move focus between panes',
+        },
+      ],
+    },
   ]
+
+  function visible(item: Shortcut): boolean {
+    const q = prefsSearch.query.trim()
+    if (!q) return true
+    return matches(`${item.action} ${item.keys.join(' ')}`)
+  }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Keyboard Shortcuts</h3>
-
-  <div class="flex flex-col gap-0.5">
-    {#each shortcuts as shortcut, i (i)}
-      <div class="flex items-center py-1 border-b border-border-subtle">
-        <span class="min-w-[200px] flex items-center gap-1">
-          {#each shortcut.keys as key, k (k)}
-            <kbd
-              class="inline-flex items-center justify-center min-w-6 h-6 px-1.5 bg-hover border border-border rounded-sm text-sm font-inherit text-text-secondary shadow-[0_1px_0_var(--color-border)]"
-              >{key}</kbd
-            >
-          {/each}
-        </span>
-        <span class="text-md text-text ml-3">{shortcut.action}</span>
+<div class="flex flex-col gap-7">
+  {#each groups as group (group.title)}
+    <PrefsSection title={group.title}>
+      <div class="flex flex-col">
+        {#each group.items as item (item.action)}
+          <div
+            class="flex items-center justify-between gap-6 py-2 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
+            class:opacity-30={!visible(item)}
+          >
+            <span class="text-md text-text">{item.action}</span>
+            <span class="flex items-center gap-1 shrink-0">
+              {#each item.keys as key, k (k)}
+                <kbd
+                  class="inline-flex items-center justify-center min-w-6 h-6 px-1.5 bg-bg-input border border-border rounded-sm text-xs font-inherit text-text-secondary"
+                  >{key}</kbd
+                >
+              {/each}
+            </span>
+          </div>
+        {/each}
       </div>
-    {/each}
-  </div>
+    </PrefsSection>
+  {/each}
 </div>

--- a/src/renderer/src/components/preferences/SidebarPrefs.svelte
+++ b/src/renderer/src/components/preferences/SidebarPrefs.svelte
@@ -2,6 +2,7 @@
   import { tick } from 'svelte'
   import { ChevronUp, ChevronDown } from '@lucide/svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
   import {
     SECTION_DEFS,
     getSidebarConfig,
@@ -9,6 +10,7 @@
     type SidebarSectionConfig,
   } from '../../lib/stores/sidebarSections.svelte'
   import { getPref } from '../../lib/stores/preferences.svelte'
+  import { prefsSearch, matches } from './_partials/prefsSearch.svelte'
 
   let config: SidebarSectionConfig[] = $state(getSidebarConfig(getPref('sidebar.sections', '')))
 
@@ -46,50 +48,58 @@
   }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Sidebar</h3>
-  <p class="text-sm text-text-secondary m-0">
-    Choose which sections appear in the sidebar and their order.
-  </p>
-
-  <div class="flex flex-col gap-0.5">
-    {#each config as item, i (item.id)}
-      {@const def = SECTION_DEFS.find((d) => d.id === item.id)}
-      <div
-        class="flex items-center justify-between px-2 py-1.5 rounded-lg transition-colors duration-fast hover:bg-hover"
-      >
-        <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-          <CustomCheckbox
-            checked={item.visible}
-            disabled={def?.forced}
-            onchange={() => toggleVisibility(i)}
-          />
-          <span class:text-text-secondary={def?.forced}>{def?.label ?? item.id}</span>
-          {#if def?.forced}
-            <span class="text-xs text-text-faint ml-1">Always visible</span>
-          {/if}
-        </label>
-        <div class="flex gap-0.5">
-          <button
-            class="flex items-center justify-center w-6 h-6 bg-transparent border border-transparent rounded-md text-text-secondary cursor-pointer transition-colors duration-fast enabled:hover:bg-hover-strong enabled:hover:text-text disabled:opacity-20 disabled:cursor-default"
-            data-order-up={i}
-            disabled={i === 0}
-            onclick={() => moveUp(i)}
-            aria-label="Move {def?.label ?? item.id} up"
-          >
-            <ChevronUp size={14} />
-          </button>
-          <button
-            class="flex items-center justify-center w-6 h-6 bg-transparent border border-transparent rounded-md text-text-secondary cursor-pointer transition-colors duration-fast enabled:hover:bg-hover-strong enabled:hover:text-text disabled:opacity-20 disabled:cursor-default"
-            data-order-down={i}
-            disabled={i === config.length - 1}
-            onclick={() => moveDown(i)}
-            aria-label="Move {def?.label ?? item.id} down"
-          >
-            <ChevronDown size={14} />
-          </button>
+<div class="flex flex-col gap-7">
+  <PrefsSection
+    title="Sections"
+    description="Pick which sections appear in the sidebar and reorder them"
+  >
+    <div class="flex flex-col">
+      {#each config as item, i (item.id)}
+        {@const def = SECTION_DEFS.find((d) => d.id === item.id)}
+        {@const dim = prefsSearch.query.trim() !== '' && !matches(def?.label ?? item.id)}
+        <div
+          class="flex items-center justify-between gap-3 py-2 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
+          class:opacity-30={dim}
+        >
+          <label class="flex items-center gap-2 text-md text-text cursor-pointer min-w-0 flex-1">
+            <CustomCheckbox
+              checked={item.visible}
+              disabled={def?.forced}
+              onchange={() => toggleVisibility(i)}
+            />
+            <span class="truncate" class:text-text-secondary={def?.forced}
+              >{def?.label ?? item.id}</span
+            >
+            {#if def?.forced}
+              <span class="text-2xs uppercase tracking-caps-tight text-text-faint shrink-0 ml-1"
+                >Always shown</span
+              >
+            {/if}
+          </label>
+          <div class="flex gap-0.5 shrink-0">
+            <button
+              type="button"
+              class="flex items-center justify-center size-6 bg-transparent border-0 rounded-md text-text-secondary cursor-pointer enabled:hover:bg-hover enabled:hover:text-text disabled:opacity-20 disabled:cursor-default"
+              data-order-up={i}
+              disabled={i === 0}
+              onclick={() => moveUp(i)}
+              aria-label="Move {def?.label ?? item.id} up"
+            >
+              <ChevronUp size={14} />
+            </button>
+            <button
+              type="button"
+              class="flex items-center justify-center size-6 bg-transparent border-0 rounded-md text-text-secondary cursor-pointer enabled:hover:bg-hover enabled:hover:text-text disabled:opacity-20 disabled:cursor-default"
+              data-order-down={i}
+              disabled={i === config.length - 1}
+              onclick={() => moveDown(i)}
+              aria-label="Move {def?.label ?? item.id} down"
+            >
+              <ChevronDown size={14} />
+            </button>
+          </div>
         </div>
-      </div>
-    {/each}
-  </div>
+      {/each}
+    </div>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/SkillPrefs.svelte
+++ b/src/renderer/src/components/preferences/SkillPrefs.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-  import { onMount, type Snippet } from 'svelte'
-  import { ChevronDown, ChevronRight, Plus, RotateCw, Trash2 } from '@lucide/svelte'
+  import { onMount } from 'svelte'
+  import { Plus, RotateCw, Trash2 } from '@lucide/svelte'
   import { getSkills } from '../../lib/stores/skills.svelte'
   import { confirm } from '../../lib/stores/dialogs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
-  import CustomRadio from '../shared/CustomRadio.svelte'
   import PrefsSection from './_partials/PrefsSection.svelte'
+  import SkillRow from './_partials/SkillRow.svelte'
+  import SkillInstallForm from './_partials/SkillInstallForm.svelte'
   import { prefsSearch, matches } from './_partials/prefsSearch.svelte'
 
   const skills = $derived(getSkills())
@@ -23,13 +24,6 @@
   }
 
   let showInstallForm = $state(false)
-  let installSource = $state('')
-  let installScope = $state('project')
-  let installMethod = $state('copy')
-  let installAgents = $state<string[]>(['claude'])
-  let installError = $state('')
-  let installing = $state(false)
-
   let expandedId: string | null = $state(null)
 
   let scannedSkills = $state<
@@ -55,41 +49,6 @@
       console.error('Scan failed:', e)
     } finally {
       scanning = false
-    }
-  }
-
-  function resetInstallForm(): void {
-    installSource = ''
-    installAgents = ['claude']
-    installScope = 'project'
-    installMethod = 'copy'
-    installError = ''
-  }
-
-  async function installSkill(): Promise<void> {
-    if (!installSource.trim()) {
-      installError = 'Source is required'
-      return
-    }
-
-    installing = true
-    installError = ''
-
-    try {
-      await window.api.installSkill({
-        source: installSource.trim(),
-        agents: [...installAgents],
-        scope: String(installScope),
-        method: String(installMethod),
-        workspacePath: workspaceState.selectedWorktreePath ?? undefined,
-      })
-      resetInstallForm()
-      showInstallForm = false
-      await scanForSkills()
-    } catch (e) {
-      installError = e instanceof Error ? e.message : String(e)
-    } finally {
-      installing = false
     }
   }
 
@@ -149,52 +108,11 @@
     expandedId = expandedId === id ? null : id
   }
 
-  function toggleInstallAgent(agent: string): void {
-    if (installAgents.includes(agent)) {
-      installAgents = installAgents.filter((a) => a !== agent)
-    } else {
-      installAgents = [...installAgents, agent]
-    }
-  }
-
   function rowVisible(haystack: string): boolean {
     if (prefsSearch.query.trim() === '') return true
     return matches(haystack)
   }
 </script>
-
-{#snippet skillRow(
-  id: string,
-  name: string,
-  agentDisplay: string,
-  search: string,
-  details: Snippet,
-)}
-  {@const expanded = expandedId === id}
-  <div
-    class="flex flex-col border-t border-border-subtle first:border-t-0 transition-opacity duration-fast"
-    class:opacity-30={!rowVisible(`${name} ${agentDisplay} ${search}`)}
-  >
-    <button
-      type="button"
-      class="flex items-center gap-2 w-full px-1 py-2 border-0 bg-transparent text-left cursor-pointer hover:bg-row-hover rounded-md"
-      onclick={() => toggleExpand(id)}
-    >
-      {#if expanded}
-        <ChevronDown size={13} class="shrink-0 text-text-muted" />
-      {:else}
-        <ChevronRight size={13} class="shrink-0 text-text-muted" />
-      {/if}
-      <span class="text-md text-text min-w-30 truncate">{name}</span>
-      <span class="text-xs text-text-muted truncate flex-1">{agentDisplay}</span>
-    </button>
-    {#if expanded}
-      <div class="pl-6 pr-1 pb-3 flex flex-col gap-2.5">
-        {@render details()}
-      </div>
-    {/if}
-  </div>
-{/snippet}
 
 {#snippet detailField(label: string, value: string, mono = false)}
   <div class="flex flex-col gap-0.5">
@@ -202,6 +120,46 @@
     >
     <span class="text-sm text-text break-all" class:font-mono={mono}>{value}</span>
   </div>
+{/snippet}
+
+{#snippet scannedDetails(skill: (typeof scannedSkills)[number])}
+  <p class="text-sm text-text-secondary m-0 leading-snug">
+    {skill.description || 'No description'}
+  </p>
+  <div class="flex flex-wrap gap-x-6 gap-y-2">
+    {@render detailField('Agent', agentLabels[skill.agent] ?? skill.agent)}
+    {@render detailField('Scope', skill.scope)}
+  </div>
+  {@render detailField('File', skill.filePath, true)}
+  <div class="flex gap-2 pt-1">
+    <button
+      type="button"
+      class="flex items-center gap-1 px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-danger-bg text-danger-text"
+      onclick={() => deleteScannedSkill(skill.filePath, skill.name)}
+    >
+      <Trash2 size={12} /> Delete file
+    </button>
+  </div>
+{/snippet}
+
+{#snippet scannedSection(title: string, description: string, list: typeof scannedSkills)}
+  <PrefsSection {title} {description}>
+    <div class="flex flex-col">
+      {#each list as skill (skill.filePath)}
+        <SkillRow
+          name={skill.name}
+          agentDisplay={agentLabels[skill.agent] ?? skill.agent}
+          expanded={expandedId === skill.filePath}
+          dimmed={!rowVisible(
+            `${skill.name} ${agentLabels[skill.agent] ?? skill.agent} ${skill.description ?? ''} ${skill.filePath} ${skill.scope}`,
+          )}
+          onToggle={() => toggleExpand(skill.filePath)}
+        >
+          {@render scannedDetails(skill)}
+        </SkillRow>
+      {/each}
+    </div>
+  </PrefsSection>
 {/snippet}
 
 <div class="flex flex-col gap-7">
@@ -213,7 +171,15 @@
       <div class="flex flex-col">
         {#each skills as skill (skill.id)}
           {@const agentDisplay = skill.enabledAgents.map((a) => agentLabels[a] ?? a).join(', ')}
-          {#snippet details()}
+          <SkillRow
+            name={skill.name}
+            {agentDisplay}
+            expanded={expandedId === skill.id}
+            dimmed={!rowVisible(
+              `${skill.name} ${agentDisplay} ${skill.description ?? ''} ${skill.sourceUri ?? ''} ${skill.scope ?? ''}`,
+            )}
+            onToggle={() => toggleExpand(skill.id)}
+          >
             <p class="text-sm text-text-secondary m-0 leading-snug">
               {skill.description || 'No description'}
             </p>
@@ -257,87 +223,18 @@
                 <Trash2 size={12} /> Remove
               </button>
             </div>
-          {/snippet}
-          {@render skillRow(
-            skill.id,
-            skill.name,
-            agentDisplay,
-            `${skill.description ?? ''} ${skill.sourceUri ?? ''} ${skill.scope ?? ''}`,
-            details,
-          )}
+          </SkillRow>
         {/each}
       </div>
     </PrefsSection>
   {/if}
 
   {#if projectScanned.length > 0}
-    <PrefsSection title="Project skills" description="Discovered in this workspace">
-      <div class="flex flex-col">
-        {#each projectScanned as skill (skill.filePath)}
-          {#snippet details()}
-            <p class="text-sm text-text-secondary m-0 leading-snug">
-              {skill.description || 'No description'}
-            </p>
-            <div class="flex flex-wrap gap-x-6 gap-y-2">
-              {@render detailField('Agent', agentLabels[skill.agent] ?? skill.agent)}
-              {@render detailField('Scope', skill.scope)}
-            </div>
-            {@render detailField('File', skill.filePath, true)}
-            <div class="flex gap-2 pt-1">
-              <button
-                type="button"
-                class="flex items-center gap-1 px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-danger-bg text-danger-text"
-                onclick={() => deleteScannedSkill(skill.filePath, skill.name)}
-              >
-                <Trash2 size={12} /> Delete file
-              </button>
-            </div>
-          {/snippet}
-          {@render skillRow(
-            skill.filePath,
-            skill.name,
-            agentLabels[skill.agent] ?? skill.agent,
-            `${skill.description ?? ''} ${skill.filePath} ${skill.scope}`,
-            details,
-          )}
-        {/each}
-      </div>
-    </PrefsSection>
+    {@render scannedSection('Project skills', 'Discovered in this workspace', projectScanned)}
   {/if}
 
   {#if globalScanned.length > 0}
-    <PrefsSection title="Global skills" description="Discovered in your home directory">
-      <div class="flex flex-col">
-        {#each globalScanned as skill (skill.filePath)}
-          {#snippet details()}
-            <p class="text-sm text-text-secondary m-0 leading-snug">
-              {skill.description || 'No description'}
-            </p>
-            <div class="flex flex-wrap gap-x-6 gap-y-2">
-              {@render detailField('Agent', agentLabels[skill.agent] ?? skill.agent)}
-              {@render detailField('Scope', skill.scope)}
-            </div>
-            {@render detailField('File', skill.filePath, true)}
-            <div class="flex gap-2 pt-1">
-              <button
-                type="button"
-                class="flex items-center gap-1 px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-danger-bg text-danger-text"
-                onclick={() => deleteScannedSkill(skill.filePath, skill.name)}
-              >
-                <Trash2 size={12} /> Delete file
-              </button>
-            </div>
-          {/snippet}
-          {@render skillRow(
-            skill.filePath,
-            skill.name,
-            agentLabels[skill.agent] ?? skill.agent,
-            `${skill.description ?? ''} ${skill.filePath} ${skill.scope}`,
-            details,
-          )}
-        {/each}
-      </div>
-    </PrefsSection>
+    {@render scannedSection('Global skills', 'Discovered in your home directory', globalScanned)}
   {/if}
 
   {#if skills.length === 0 && scannedSkills.length === 0 && !scanning}
@@ -352,123 +249,18 @@
 
   <PrefsSection title="Install">
     {#if showInstallForm}
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input"
-        onkeydown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault()
-            installSkill()
-          }
-          if (e.key === 'Escape') {
-            showInstallForm = false
-            resetInstallForm()
-          }
-        }}
-      >
-        <input
-          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
-          name="installSource"
-          aria-label="Skill source"
-          bind:value={installSource}
-          placeholder="github:owner/repo/path, local path, or URL"
-          spellcheck="false"
-          autocomplete="off"
-        />
-
-        <div class="flex flex-col gap-1.5">
-          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
-            >Agents</span
-          >
-          <div class="flex gap-3 flex-wrap">
-            {#each Object.entries(agentLabels) as [key, label] (key)}
-              <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
-                <CustomCheckbox
-                  checked={installAgents.includes(key)}
-                  onchange={() => toggleInstallAgent(key)}
-                />
-                <span>{label}</span>
-              </label>
-            {/each}
-          </div>
-        </div>
-
-        <div class="flex flex-col gap-1.5">
-          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
-            >Scope</span
-          >
-          <div class="flex gap-3 flex-wrap">
-            <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
-              <CustomRadio
-                checked={installScope === 'project'}
-                onchange={() => (installScope = 'project')}
-              />
-              <span>Project</span>
-            </label>
-            <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
-              <CustomRadio
-                checked={installScope === 'global'}
-                onchange={() => (installScope = 'global')}
-              />
-              <span>Global</span>
-            </label>
-          </div>
-        </div>
-
-        <div class="flex flex-col gap-1.5">
-          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
-            >Method</span
-          >
-          <div class="flex gap-3 flex-wrap">
-            <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
-              <CustomRadio
-                checked={installMethod === 'copy'}
-                onchange={() => (installMethod = 'copy')}
-              />
-              <span>Copy</span>
-            </label>
-            <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
-              <CustomRadio
-                checked={installMethod === 'symlink'}
-                onchange={() => (installMethod = 'symlink')}
-              />
-              <span>Symlink</span>
-            </label>
-          </div>
-        </div>
-
-        {#if installError}
-          <p class="text-sm text-danger-text m-0">{installError}</p>
-        {/if}
-
-        <div class="flex justify-end gap-2">
-          <button
-            type="button"
-            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
-            onclick={() => {
-              showInstallForm = false
-              resetInstallForm()
-            }}>Cancel</button
-          >
-          <button
-            type="button"
-            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text disabled:opacity-60 disabled:cursor-default hover:bg-accent-bg-hover"
-            onclick={installSkill}
-            disabled={installing}
-          >
-            {installing ? 'Installing…' : 'Install'}
-          </button>
-        </div>
-      </div>
+      <SkillInstallForm
+        {agentLabels}
+        workspacePath={workspaceState.selectedWorktreePath ?? undefined}
+        onClose={() => (showInstallForm = false)}
+        onInstalled={scanForSkills}
+      />
     {:else}
       <div class="flex gap-2">
         <button
           type="button"
           class="flex items-center gap-1 px-3 py-1 rounded-md bg-border-subtle border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-active hover:text-text"
-          onclick={() => {
-            resetInstallForm()
-            showInstallForm = true
-          }}
+          onclick={() => (showInstallForm = true)}
         >
           <Plus size={12} />
           <span>Install skill</span>

--- a/src/renderer/src/components/preferences/SkillPrefs.svelte
+++ b/src/renderer/src/components/preferences/SkillPrefs.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, type Snippet } from 'svelte'
+  import { ChevronDown, ChevronRight, Plus, RotateCw, Trash2 } from '@lucide/svelte'
   import { getSkills } from '../../lib/stores/skills.svelte'
   import { confirm } from '../../lib/stores/dialogs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
+  import CustomCheckbox from '../shared/CustomCheckbox.svelte'
+  import CustomRadio from '../shared/CustomRadio.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import { prefsSearch, matches } from './_partials/prefsSearch.svelte'
 
   const skills = $derived(getSkills())
 
@@ -53,6 +58,14 @@
     }
   }
 
+  function resetInstallForm(): void {
+    installSource = ''
+    installAgents = ['claude']
+    installScope = 'project'
+    installMethod = 'copy'
+    installError = ''
+  }
+
   async function installSkill(): Promise<void> {
     if (!installSource.trim()) {
       installError = 'Source is required'
@@ -70,10 +83,7 @@
         method: String(installMethod),
         workspacePath: workspaceState.selectedWorktreePath ?? undefined,
       })
-      installSource = ''
-      installAgents = ['claude']
-      installScope = 'project'
-      installMethod = 'copy'
+      resetInstallForm()
       showInstallForm = false
       await scanForSkills()
     } catch (e) {
@@ -85,7 +95,7 @@
 
   async function removeSkill(id: string, name: string): Promise<void> {
     const ok = await confirm({
-      title: 'Remove Skill',
+      title: 'Remove skill',
       message: `Remove skill "${name}"?`,
       confirmLabel: 'Remove',
       destructive: true,
@@ -100,7 +110,7 @@
 
   async function deleteScannedSkill(filePath: string, name: string): Promise<void> {
     const ok = await confirm({
-      title: 'Delete Skill File',
+      title: 'Delete skill file',
       message: `Delete skill file "${name}" from disk? This cannot be undone.`,
       confirmLabel: 'Delete',
       destructive: true,
@@ -146,309 +156,333 @@
       installAgents = [...installAgents, agent]
     }
   }
+
+  function rowVisible(haystack: string): boolean {
+    if (prefsSearch.query.trim() === '') return true
+    return matches(haystack)
+  }
 </script>
 
 {#snippet skillRow(
   id: string,
   name: string,
   agentDisplay: string,
-  details: import('svelte').Snippet,
+  search: string,
+  details: Snippet,
 )}
-  <div class="rounded-lg bg-border-subtle overflow-hidden">
-    <div
-      class="flex items-center gap-2.5 px-2.5 py-1.5 text-md cursor-pointer hover:bg-hover"
-      role="button"
-      tabindex="0"
+  {@const expanded = expandedId === id}
+  <div
+    class="flex flex-col border-t border-border-subtle first:border-t-0 transition-opacity duration-fast"
+    class:opacity-30={!rowVisible(`${name} ${agentDisplay} ${search}`)}
+  >
+    <button
+      type="button"
+      class="flex items-center gap-2 w-full px-1 py-2 border-0 bg-transparent text-left cursor-pointer hover:bg-row-hover rounded-md"
       onclick={() => toggleExpand(id)}
-      onkeydown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          toggleExpand(id)
-        }
-      }}
     >
-      <span class="text-text min-w-[120px] font-medium">{name}</span>
-      <span class="text-text-secondary text-sm flex-1">{agentDisplay}</span>
-    </div>
-    {#if expandedId === id}
-      <div class="px-3 py-2.5 border-t border-border flex flex-col gap-2.5">
+      {#if expanded}
+        <ChevronDown size={13} class="shrink-0 text-text-muted" />
+      {:else}
+        <ChevronRight size={13} class="shrink-0 text-text-muted" />
+      {/if}
+      <span class="text-md text-text min-w-30 truncate">{name}</span>
+      <span class="text-xs text-text-muted truncate flex-1">{agentDisplay}</span>
+    </button>
+    {#if expanded}
+      <div class="pl-6 pr-1 pb-3 flex flex-col gap-2.5">
         {@render details()}
       </div>
     {/if}
   </div>
 {/snippet}
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Skills</h3>
+{#snippet detailField(label: string, value: string, mono = false)}
+  <div class="flex flex-col gap-0.5">
+    <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint">{label}</span
+    >
+    <span class="text-sm text-text break-all" class:font-mono={mono}>{value}</span>
+  </div>
+{/snippet}
 
+<div class="flex flex-col gap-7">
   {#if skills.length > 0}
-    <div class="flex flex-col gap-1">
-      {#each skills as skill (skill.id)}
-        {@const agentDisplay = skill.enabledAgents.map((a) => agentLabels[a] ?? a).join(', ')}
-        {#snippet details()}
-          <p class="text-sm text-text-secondary m-0 leading-snug">
-            {skill.description || 'No description'}
-          </p>
-          <div class="flex flex-col gap-0.5">
-            <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-              >Source</span
-            >
-            <span class="text-sm text-text break-all">{skill.sourceUri}</span>
-          </div>
-          <div class="flex gap-6">
-            <div class="flex flex-col gap-0.5">
-              <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                >Scope</span
+    <PrefsSection
+      title="Installed skills"
+      description="Skills registered with the Canopy skill store"
+    >
+      <div class="flex flex-col">
+        {#each skills as skill (skill.id)}
+          {@const agentDisplay = skill.enabledAgents.map((a) => agentLabels[a] ?? a).join(', ')}
+          {#snippet details()}
+            <p class="text-sm text-text-secondary m-0 leading-snug">
+              {skill.description || 'No description'}
+            </p>
+            {@render detailField('Source', skill.sourceUri, true)}
+            <div class="flex flex-wrap gap-x-6 gap-y-2">
+              {@render detailField('Scope', skill.scope)}
+              {@render detailField('Type', skill.sourceType)}
+              {@render detailField('Method', skill.installMethod)}
+              {@render detailField('Version', skill.version)}
+            </div>
+            <div class="flex flex-col gap-1">
+              <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+                >Agents</span
               >
-              <span class="text-sm text-text">{skill.scope}</span>
+              <div class="flex gap-4 flex-wrap">
+                {#each skill.agents as agent (agent)}
+                  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
+                    <CustomCheckbox
+                      checked={skill.enabledAgents.includes(agent)}
+                      onchange={() =>
+                        toggleAgent(skill.id, agent, !skill.enabledAgents.includes(agent))}
+                    />
+                    <span>{agentLabels[agent] ?? agent}</span>
+                  </label>
+                {/each}
+              </div>
             </div>
-            <div class="flex flex-col gap-0.5">
-              <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                >Type</span
+            <div class="flex gap-2 pt-1">
+              <button
+                type="button"
+                class="flex items-center gap-1 px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
+                onclick={() => updateSkill(skill.id)}
               >
-              <span class="text-sm text-text">{skill.sourceType}</span>
-            </div>
-            <div class="flex flex-col gap-0.5">
-              <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                >Method</span
+                <RotateCw size={12} /> Update
+              </button>
+              <button
+                type="button"
+                class="flex items-center gap-1 px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-danger-bg text-danger-text"
+                onclick={() => removeSkill(skill.id, skill.name)}
               >
-              <span class="text-sm text-text">{skill.installMethod}</span>
+                <Trash2 size={12} /> Remove
+              </button>
             </div>
-            <div class="flex flex-col gap-0.5">
-              <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                >Version</span
-              >
-              <span class="text-sm text-text">{skill.version}</span>
-            </div>
-          </div>
-          <div class="flex flex-col gap-1">
-            <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-              >Agents</span
-            >
-            <div class="flex gap-3.5">
-              {#each skill.agents as agent (agent)}
-                <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={skill.enabledAgents.includes(agent)}
-                    onchange={() =>
-                      toggleAgent(skill.id, agent, !skill.enabledAgents.includes(agent))}
-                  />
-                  {agentLabels[agent] ?? agent}
-                </label>
-              {/each}
-            </div>
-          </div>
-          <div class="flex gap-2 pt-1">
-            <button
-              class="px-3.5 py-1 rounded-lg text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
-              onclick={() => updateSkill(skill.id)}>Update</button
-            >
-            <button
-              class="px-3.5 py-1 rounded-lg text-sm font-inherit cursor-pointer border-0 bg-danger-bg text-danger-text"
-              onclick={() => removeSkill(skill.id, skill.name)}>Remove</button
-            >
-          </div>
-        {/snippet}
-        {@render skillRow(skill.id, skill.name, agentDisplay, details)}
-      {/each}
-    </div>
+          {/snippet}
+          {@render skillRow(
+            skill.id,
+            skill.name,
+            agentDisplay,
+            `${skill.description ?? ''} ${skill.sourceUri ?? ''} ${skill.scope ?? ''}`,
+            details,
+          )}
+        {/each}
+      </div>
+    </PrefsSection>
   {/if}
 
-  {#if scannedSkills.length > 0}
-    {#if projectScanned.length > 0}
-      <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.4px]"
-        >Project Skills</span
-      >
-      <div class="flex flex-col gap-1">
+  {#if projectScanned.length > 0}
+    <PrefsSection title="Project skills" description="Discovered in this workspace">
+      <div class="flex flex-col">
         {#each projectScanned as skill (skill.filePath)}
           {#snippet details()}
             <p class="text-sm text-text-secondary m-0 leading-snug">
               {skill.description || 'No description'}
             </p>
-            <div class="flex gap-6">
-              <div class="flex flex-col gap-0.5">
-                <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                  >Agent</span
-                >
-                <span class="text-sm text-text">{agentLabels[skill.agent] ?? skill.agent}</span>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                  >Scope</span
-                >
-                <span class="text-sm text-text">{skill.scope}</span>
-              </div>
+            <div class="flex flex-wrap gap-x-6 gap-y-2">
+              {@render detailField('Agent', agentLabels[skill.agent] ?? skill.agent)}
+              {@render detailField('Scope', skill.scope)}
             </div>
-            <div class="flex flex-col gap-0.5">
-              <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                >File</span
-              >
-              <span class="text-sm text-text break-all">{skill.filePath}</span>
-            </div>
+            {@render detailField('File', skill.filePath, true)}
             <div class="flex gap-2 pt-1">
               <button
-                class="px-3.5 py-1 rounded-lg text-sm font-inherit cursor-pointer border-0 bg-danger-bg text-danger-text"
-                onclick={() => deleteScannedSkill(skill.filePath, skill.name)}>Delete</button
+                type="button"
+                class="flex items-center gap-1 px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-danger-bg text-danger-text"
+                onclick={() => deleteScannedSkill(skill.filePath, skill.name)}
               >
+                <Trash2 size={12} /> Delete file
+              </button>
             </div>
           {/snippet}
           {@render skillRow(
             skill.filePath,
             skill.name,
             agentLabels[skill.agent] ?? skill.agent,
+            `${skill.description ?? ''} ${skill.filePath} ${skill.scope}`,
             details,
           )}
         {/each}
       </div>
-    {/if}
+    </PrefsSection>
+  {/if}
 
-    {#if globalScanned.length > 0}
-      <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.4px]"
-        >Global Skills</span
-      >
-      <div class="flex flex-col gap-1">
+  {#if globalScanned.length > 0}
+    <PrefsSection title="Global skills" description="Discovered in your home directory">
+      <div class="flex flex-col">
         {#each globalScanned as skill (skill.filePath)}
           {#snippet details()}
             <p class="text-sm text-text-secondary m-0 leading-snug">
               {skill.description || 'No description'}
             </p>
-            <div class="flex gap-6">
-              <div class="flex flex-col gap-0.5">
-                <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                  >Agent</span
-                >
-                <span class="text-sm text-text">{agentLabels[skill.agent] ?? skill.agent}</span>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                  >Scope</span
-                >
-                <span class="text-sm text-text">{skill.scope}</span>
-              </div>
+            <div class="flex flex-wrap gap-x-6 gap-y-2">
+              {@render detailField('Agent', agentLabels[skill.agent] ?? skill.agent)}
+              {@render detailField('Scope', skill.scope)}
             </div>
-            <div class="flex flex-col gap-0.5">
-              <span class="text-xs font-semibold text-text-secondary uppercase tracking-[0.3px]"
-                >File</span
-              >
-              <span class="text-sm text-text break-all">{skill.filePath}</span>
-            </div>
+            {@render detailField('File', skill.filePath, true)}
             <div class="flex gap-2 pt-1">
               <button
-                class="px-3.5 py-1 rounded-lg text-sm font-inherit cursor-pointer border-0 bg-danger-bg text-danger-text"
-                onclick={() => deleteScannedSkill(skill.filePath, skill.name)}>Delete</button
+                type="button"
+                class="flex items-center gap-1 px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-danger-bg text-danger-text"
+                onclick={() => deleteScannedSkill(skill.filePath, skill.name)}
               >
+                <Trash2 size={12} /> Delete file
+              </button>
             </div>
           {/snippet}
           {@render skillRow(
             skill.filePath,
             skill.name,
             agentLabels[skill.agent] ?? skill.agent,
+            `${skill.description ?? ''} ${skill.filePath} ${skill.scope}`,
             details,
           )}
         {/each}
       </div>
-    {/if}
+    </PrefsSection>
   {/if}
 
   {#if skills.length === 0 && scannedSkills.length === 0 && !scanning}
-    <p class="text-md text-text-faint m-0">
+    <p class="text-sm text-text-muted m-0">
       No skills found. Install from a local path, URL, or GitHub, or scan to discover existing ones.
     </p>
   {/if}
 
   {#if scanning}
-    <p class="text-md text-text-faint m-0">Scanning for skills...</p>
+    <p class="text-sm text-text-muted m-0">Scanning for skills…</p>
   {/if}
 
-  {#if showInstallForm}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="flex flex-col gap-2 p-3 border border-border rounded-xl bg-border-subtle"
-      onkeydown={(e) => {
-        if (e.key === 'Enter') {
-          e.preventDefault()
-          installSkill()
-        }
-        if (e.key === 'Escape') showInstallForm = false
-      }}
-    >
-      <input
-        class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-        bind:value={installSource}
-        placeholder="Source (github:owner/repo/path, local path, or URL)"
-      />
+  <PrefsSection title="Install">
+    {#if showInstallForm}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input"
+        onkeydown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            installSkill()
+          }
+          if (e.key === 'Escape') {
+            showInstallForm = false
+            resetInstallForm()
+          }
+        }}
+      >
+        <input
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="installSource"
+          aria-label="Skill source"
+          bind:value={installSource}
+          placeholder="github:owner/repo/path, local path, or URL"
+          spellcheck="false"
+          autocomplete="off"
+        />
 
-      <div class="flex items-center gap-2">
-        <label class="text-sm text-text-secondary min-w-15">Agents:</label>
-        <div class="flex gap-3 text-sm text-text">
-          {#each Object.entries(agentLabels) as [key, label] (key)}
-            <label class="flex items-center gap-1 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={installAgents.includes(key)}
-                onchange={() => toggleInstallAgent(key)}
+        <div class="flex flex-col gap-1.5">
+          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+            >Agents</span
+          >
+          <div class="flex gap-3 flex-wrap">
+            {#each Object.entries(agentLabels) as [key, label] (key)}
+              <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+                <CustomCheckbox
+                  checked={installAgents.includes(key)}
+                  onchange={() => toggleInstallAgent(key)}
+                />
+                <span>{label}</span>
+              </label>
+            {/each}
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1.5">
+          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+            >Scope</span
+          >
+          <div class="flex gap-3 flex-wrap">
+            <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+              <CustomRadio
+                checked={installScope === 'project'}
+                onchange={() => (installScope = 'project')}
               />
-              {label}
+              <span>Project</span>
             </label>
-          {/each}
+            <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+              <CustomRadio
+                checked={installScope === 'global'}
+                onchange={() => (installScope = 'global')}
+              />
+              <span>Global</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1.5">
+          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+            >Method</span
+          >
+          <div class="flex gap-3 flex-wrap">
+            <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+              <CustomRadio
+                checked={installMethod === 'copy'}
+                onchange={() => (installMethod = 'copy')}
+              />
+              <span>Copy</span>
+            </label>
+            <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+              <CustomRadio
+                checked={installMethod === 'symlink'}
+                onchange={() => (installMethod = 'symlink')}
+              />
+              <span>Symlink</span>
+            </label>
+          </div>
+        </div>
+
+        {#if installError}
+          <p class="text-sm text-danger-text m-0">{installError}</p>
+        {/if}
+
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
+            onclick={() => {
+              showInstallForm = false
+              resetInstallForm()
+            }}>Cancel</button
+          >
+          <button
+            type="button"
+            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text disabled:opacity-60 disabled:cursor-default hover:bg-accent-bg-hover"
+            onclick={installSkill}
+            disabled={installing}
+          >
+            {installing ? 'Installing…' : 'Install'}
+          </button>
         </div>
       </div>
-
-      <div class="flex items-center gap-2">
-        <label class="text-sm text-text-secondary min-w-15">Scope:</label>
-        <div class="flex gap-3 text-sm text-text">
-          <label><input type="radio" bind:group={installScope} value="project" /> Project</label>
-          <label><input type="radio" bind:group={installScope} value="global" /> Global</label>
-        </div>
-      </div>
-
-      <div class="flex items-center gap-2">
-        <label class="text-sm text-text-secondary min-w-15">Method:</label>
-        <div class="flex gap-3 text-sm text-text">
-          <label><input type="radio" bind:group={installMethod} value="copy" /> Copy</label>
-          <label><input type="radio" bind:group={installMethod} value="symlink" /> Symlink</label>
-        </div>
-      </div>
-
-      {#if installError}
-        <p class="text-sm text-danger m-0">{installError}</p>
-      {/if}
-
-      <div class="flex justify-end gap-2">
+    {:else}
+      <div class="flex gap-2">
         <button
-          class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-active text-text"
-          onclick={() => (showInstallForm = false)}>Cancel</button
+          type="button"
+          class="flex items-center gap-1 px-3 py-1 rounded-md bg-border-subtle border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-active hover:text-text"
+          onclick={() => {
+            resetInstallForm()
+            showInstallForm = true
+          }}
         >
+          <Plus size={12} />
+          <span>Install skill</span>
+        </button>
         <button
-          class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text disabled:opacity-60 disabled:cursor-not-allowed hover:bg-accent-bg-hover"
-          onclick={installSkill}
-          disabled={installing}
+          type="button"
+          class="flex items-center gap-1 px-3 py-1 rounded-md bg-transparent border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-hover hover:text-text disabled:opacity-60 disabled:cursor-default"
+          onclick={scanForSkills}
+          disabled={scanning}
         >
-          {installing ? 'Installing...' : 'Install'}
+          <RotateCw size={12} />
+          <span>{scanning ? 'Scanning…' : 'Rescan'}</span>
         </button>
       </div>
-    </div>
-  {:else}
-    <div class="flex gap-2">
-      <button
-        class="px-3.5 py-1.5 border border-dashed border-text-faint rounded-lg bg-transparent text-text-secondary text-md font-inherit cursor-pointer hover:bg-hover hover:text-text"
-        onclick={() => {
-          installSource = ''
-          installAgents = ['claude']
-          installScope = 'project'
-          installMethod = 'copy'
-          installError = ''
-          showInstallForm = true
-        }}>+ Install Skill</button
-      >
-      <button
-        class="px-3.5 py-1.5 border border-dashed border-text-faint rounded-lg bg-transparent text-text-secondary text-md font-inherit cursor-pointer disabled:opacity-60 hover:bg-hover hover:text-text"
-        onclick={scanForSkills}
-        disabled={scanning}
-      >
-        {scanning ? 'Scanning...' : 'Rescan'}
-      </button>
-    </div>
-  {/if}
+    {/if}
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/SkillPrefs.svelte
+++ b/src/renderer/src/components/preferences/SkillPrefs.svelte
@@ -3,6 +3,7 @@
   import { Plus, RotateCw, Trash2 } from '@lucide/svelte'
   import { getSkills } from '../../lib/stores/skills.svelte'
   import { confirm } from '../../lib/stores/dialogs.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
   import PrefsSection from './_partials/PrefsSection.svelte'
@@ -41,12 +42,16 @@
   const projectScanned = $derived(scannedSkills.filter((s) => s.scope === 'project'))
   const globalScanned = $derived(scannedSkills.filter((s) => s.scope === 'global'))
 
+  function errMessage(e: unknown): string {
+    return e instanceof Error ? e.message : String(e)
+  }
+
   async function scanForSkills(): Promise<void> {
     scanning = true
     try {
       scannedSkills = await window.api.scanSkills(workspaceState.selectedWorktreePath ?? undefined)
     } catch (e) {
-      console.error('Scan failed:', e)
+      addToast(`Scan failed: ${errMessage(e)}`)
     } finally {
       scanning = false
     }
@@ -63,7 +68,7 @@
     try {
       await window.api.removeSkill(id, workspaceState.selectedWorktreePath ?? undefined)
     } catch (e) {
-      console.error('Failed to remove skill:', e)
+      addToast(`Remove failed: ${errMessage(e)}`)
     }
   }
 
@@ -79,7 +84,7 @@
       await window.api.deleteSkillFile(filePath)
       await scanForSkills()
     } catch (e) {
-      console.error('Failed to delete skill file:', e)
+      addToast(`Delete failed: ${errMessage(e)}`)
     }
   }
 
@@ -87,7 +92,7 @@
     try {
       await window.api.updateSkill(id, workspaceState.selectedWorktreePath ?? undefined)
     } catch (e) {
-      console.error('Failed to update skill:', e)
+      addToast(`Update failed: ${errMessage(e)}`)
     }
   }
 
@@ -100,7 +105,7 @@
         workspaceState.selectedWorktreePath ?? undefined,
       )
     } catch (e) {
-      console.error('Failed to toggle agent:', e)
+      addToast(`Toggle failed: ${errMessage(e)}`)
     }
   }
 

--- a/src/renderer/src/components/preferences/TaskBranchNamingPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskBranchNamingPrefs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Plus } from '@lucide/svelte'
+  import { Plus, Trash2 } from '@lucide/svelte'
   import BranchTokenBuilder from './BranchTokenBuilder.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import {
@@ -8,6 +8,7 @@
     saveRepoConfig,
     saveGlobalConfig,
   } from '../../lib/stores/taskTracker.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
 
   interface Props {
     repoRoot?: string
@@ -116,76 +117,94 @@
   }
 </script>
 
-<div class="flex flex-col gap-2.5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">
-    Branch naming
-  </h4>
-
-  {#if boards.length > 0}
-    <div class="flex items-center gap-2 text-md">
-      <span class="text-text-secondary w-[90px] flex-shrink-0">Board</span>
-      <CustomSelect
-        value={templateScope}
-        options={[
-          { value: 'default', label: 'All boards (default)' },
-          ...boards.map((b) => ({ value: b.id, label: b.name })),
-        ]}
-        onchange={(v) => {
-          templateScope = v
-          templateInput = branchTemplate.template
-          updatePreview()
-        }}
-      />
-    </div>
-    {#if templateScope !== 'default' && !config?.boardOverrides[templateScope]?.branchTemplate}
-      <span class="text-xs text-text-faint">
-        No override — uses default template. Edit below to create an override.
-      </span>
-    {/if}
-  {/if}
-
-  <BranchTokenBuilder bind:templateInput {placeholders} onSave={saveBranchTemplate} />
-
-  <div class="flex items-center gap-2">
-    <span class="text-sm text-text-secondary w-[90px] flex-shrink-0">Preview</span>
-    <code class="text-sm text-accent-text bg-border-subtle px-2 py-0.5 rounded-md"
-      >{branchPreview || '—'}</code
-    >
-  </div>
-
-  <div class="flex flex-col gap-1">
-    <span class="text-sm font-medium text-text-secondary">Custom variables</span>
-    {#each Object.entries(branchTemplate.customVars) as [key, value] (key)}
-      <div class="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-border-subtle text-md">
-        <code class="text-accent-text font-mono text-sm">{'{' + key + '}'}</code>
-        <span class="text-text-secondary font-mono text-sm flex-1">{value}</span>
-        <button
-          class="px-2 py-0.5 border-0 rounded-md bg-danger-bg text-danger-text text-xs font-inherit cursor-pointer flex-shrink-0"
-          onclick={() => removeCustomVar(key)}>Remove</button
-        >
+<PrefsSection
+  title="Branch naming"
+  description="Template for branch names created from tracker tasks"
+>
+  <div class="flex flex-col gap-3 py-3 border-t border-border-subtle first:border-t-0 first:pt-0">
+    {#if boards.length > 0}
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-text-secondary w-20 shrink-0">Board</span>
+        <CustomSelect
+          value={templateScope}
+          options={[
+            { value: 'default', label: 'All boards (default)' },
+            ...boards.map((b) => ({ value: b.id, label: b.name })),
+          ]}
+          onchange={(v) => {
+            templateScope = v
+            templateInput = branchTemplate.template
+            updatePreview()
+          }}
+        />
       </div>
-    {/each}
-    <div class="flex items-center gap-1.5">
-      <input
-        class="w-[100px] px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-        bind:value={newVarKey}
-        placeholder="key"
-        spellcheck="false"
-      />
-      <input
-        class="w-[100px] px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-        bind:value={newVarValue}
-        placeholder="value"
-        spellcheck="false"
-      />
-      <button
-        class="flex items-center justify-center w-6 h-6 border-0 rounded-md bg-transparent text-text-muted cursor-pointer enabled:hover:bg-hover enabled:hover:text-text-secondary disabled:opacity-50 disabled:cursor-default"
-        onclick={addCustomVar}
-        disabled={!newVarKey.trim()}
-        title="Add"
+      {#if templateScope !== 'default' && !config?.boardOverrides[templateScope]?.branchTemplate}
+        <p class="text-xs text-text-faint m-0">
+          No override — uses default template. Edit below to create one.
+        </p>
+      {/if}
+    {/if}
+
+    <BranchTokenBuilder bind:templateInput {placeholders} onSave={saveBranchTemplate} />
+
+    <div class="flex items-center gap-3">
+      <span class="text-sm text-text-secondary w-20 shrink-0">Preview</span>
+      <code class="text-sm text-accent-text bg-bg-input px-2 py-0.5 rounded-md font-mono"
+        >{branchPreview || '—'}</code
       >
-        <Plus size={14} />
-      </button>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+        >Custom variables</span
+      >
+      {#each Object.entries(branchTemplate.customVars) as [key, value] (key)}
+        <div
+          class="flex items-center gap-2 px-2.5 py-1 rounded-md bg-bg-input border border-border-subtle text-md"
+        >
+          <code class="text-accent-text font-mono text-sm shrink-0">{'{' + key + '}'}</code>
+          <span class="text-text-secondary font-mono text-sm flex-1 truncate">{value}</span>
+          <button
+            type="button"
+            class="flex items-center justify-center size-6 rounded-md bg-transparent border-0 text-text-muted cursor-pointer shrink-0 hover:bg-danger-bg hover:text-danger-text"
+            onclick={() => removeCustomVar(key)}
+            aria-label="Remove {key}"
+            title="Remove"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      {/each}
+      <div class="flex items-center gap-1.5">
+        <input
+          class="w-25 px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="newVarKey"
+          aria-label="Variable key"
+          bind:value={newVarKey}
+          placeholder="key"
+          spellcheck="false"
+          autocomplete="off"
+        />
+        <input
+          class="w-25 px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="newVarValue"
+          aria-label="Variable value"
+          bind:value={newVarValue}
+          placeholder="value"
+          spellcheck="false"
+          autocomplete="off"
+        />
+        <button
+          type="button"
+          class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer enabled:hover:bg-hover enabled:hover:text-text disabled:opacity-50 disabled:cursor-default"
+          onclick={addCustomVar}
+          disabled={!newVarKey.trim()}
+          aria-label="Add variable"
+          title="Add"
+        >
+          <Plus size={14} />
+        </button>
+      </div>
     </div>
   </div>
-</div>
+</PrefsSection>

--- a/src/renderer/src/components/preferences/TaskConnectionsPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskConnectionsPrefs.svelte
@@ -13,6 +13,7 @@
   } from '../../lib/stores/taskTracker.svelte'
   import { addToast } from '../../lib/stores/toast.svelte'
   import { providerLabel } from '../../lib/taskTracker/providerLabel'
+  import PrefsSection from './_partials/PrefsSection.svelte'
 
   interface Props {
     repoRoot?: string
@@ -148,7 +149,7 @@
   async function removeTracker(trackerId: string): Promise<void> {
     if (!config) return
     const ok = await confirm({
-      title: 'Remove Connection',
+      title: 'Remove connection',
       message: 'Remove this tracker connection?',
       confirmLabel: 'Remove',
     })
@@ -187,72 +188,75 @@
 </script>
 
 {#if config}
-  <div class="flex flex-col gap-2">
-    <div class="flex items-center justify-between">
-      <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">
-        Connections
-      </h4>
+  <PrefsSection title="Connections" description="Trackers Canopy can pull tasks from">
+    <div class="flex flex-col gap-1">
+      {#if config.trackers.length === 0 && editingId === null}
+        <p class="text-sm text-text-faint m-0">No connections configured.</p>
+      {/if}
+
+      {#each config.trackers as tracker (tracker.id)}
+        {#if editingId === tracker.id}
+          {@render editForm()}
+        {:else}
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              class="flex-1 flex items-center gap-2 px-2.5 py-1.5 border border-border-subtle rounded-md bg-bg-input text-text text-sm font-inherit cursor-pointer text-left hover:border-border"
+              onclick={() => startEdit(tracker)}
+            >
+              <span
+                class="text-2xs font-semibold uppercase tracking-caps-tight text-accent-text bg-accent-bg px-1.5 py-px rounded-sm shrink-0"
+                >{providerLabel(tracker.provider)}</span
+              >
+              <span class="flex-1 text-text-secondary truncate"
+                >{tracker.baseUrl || 'Not configured'}</span
+              >
+              {#if tracker.projectKey}
+                <span class="font-mono text-xs text-text-muted shrink-0">{tracker.projectKey}</span>
+              {/if}
+              <span
+                class="size-1.5 rounded-full shrink-0"
+                class:bg-success={trackerCreds[tracker.id]?.hasToken}
+                class:bg-warning-text={!trackerCreds[tracker.id]?.hasToken}
+                title={trackerCreds[tracker.id]?.hasToken ? 'Has token' : 'Missing token'}
+              ></span>
+            </button>
+            <button
+              type="button"
+              class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-danger-bg hover:text-danger-text"
+              onclick={() => removeTracker(tracker.id)}
+              aria-label="Remove connection"
+              title="Remove"
+            >
+              <Trash2 size={12} />
+            </button>
+          </div>
+        {/if}
+      {/each}
+
+      {#if editingId === '__new__'}
+        {@render editForm()}
+      {/if}
+
       {#if editingId === null}
         <button
-          class="flex items-center justify-center w-6 h-6 border-0 rounded-md bg-transparent text-text-muted cursor-pointer hover:bg-hover hover:text-text-secondary"
+          type="button"
+          class="self-start flex items-center gap-1 px-3 py-1 mt-1 rounded-md bg-border-subtle border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-active hover:text-text"
           onclick={startAdd}
-          title="Add connection"
         >
-          <Plus size={14} />
+          <Plus size={12} />
+          <span>Add connection</span>
         </button>
       {/if}
     </div>
-
-    {#if config.trackers.length === 0 && editingId === null}
-      <span class="text-xs text-text-faint">No connections configured. Click + to add one.</span>
-    {/if}
-
-    {#each config.trackers as tracker (tracker.id)}
-      {#if editingId === tracker.id}
-        {@render editForm()}
-      {:else}
-        <div class="flex items-center gap-1">
-          <button
-            class="flex-1 flex items-center gap-2 px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-sm font-inherit cursor-pointer text-left hover:border-focus-ring"
-            onclick={() => startEdit(tracker)}
-          >
-            <span
-              class="text-2xs font-semibold uppercase text-accent-text bg-accent-bg px-1.5 py-px rounded-sm flex-shrink-0"
-              >{providerLabel(tracker.provider)}</span
-            >
-            <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-text-secondary"
-              >{tracker.baseUrl || 'Not configured'}</span
-            >
-            {#if tracker.projectKey}
-              <span class="font-mono text-xs text-text-muted">{tracker.projectKey}</span>
-            {/if}
-            <span
-              class="w-1.5 h-1.5 rounded-full flex-shrink-0"
-              class:bg-success={trackerCreds[tracker.id]?.hasToken}
-              class:bg-warning-text={!trackerCreds[tracker.id]?.hasToken}
-            ></span>
-          </button>
-          <button
-            class="flex items-center justify-center w-6 h-6 border-0 rounded-md bg-transparent text-text-muted cursor-pointer hover:bg-hover hover:text-danger-text"
-            onclick={() => removeTracker(tracker.id)}
-            title="Remove"
-          >
-            <Trash2 size={12} />
-          </button>
-        </div>
-      {/if}
-    {/each}
-
-    {#if editingId === '__new__'}
-      {@render editForm()}
-    {/if}
-  </div>
+  </PrefsSection>
 {/if}
 
 {#snippet editForm()}
-  <div class="flex flex-col gap-2 p-2.5 border border-border rounded-xl bg-border-subtle">
+  <div class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input">
     <div class="flex flex-col gap-1">
-      <label class="text-xs font-medium text-text-secondary flex items-center gap-2">Provider</label
+      <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+        >Provider</span
       >
       <CustomSelect
         value={editProvider}
@@ -266,10 +270,13 @@
     </div>
 
     <div class="flex flex-col gap-1">
-      <label class="text-xs font-medium text-text-secondary flex items-center gap-2">Base URL</label
+      <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+        >Base URL</span
       >
       <input
-        class="px-2 py-1 border border-border rounded-md bg-hover text-text text-sm font-inherit outline-none focus:border-focus-ring"
+        class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        name="baseUrl"
+        aria-label="Base URL"
         bind:value={editBaseUrl}
         placeholder={editProvider === 'github'
           ? 'https://github.com'
@@ -280,11 +287,13 @@
 
     {#if editProvider === 'github'}
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium text-text-secondary flex items-center gap-2"
-          >Repository (optional)</label
+        <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+          >Repository (optional)</span
         >
         <input
-          class="px-2 py-1 border border-border rounded-md bg-hover text-text text-sm font-inherit outline-none focus:border-focus-ring"
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="projectKey"
+          aria-label="Repository"
           bind:value={editProjectKey}
           placeholder="owner/repo — auto-detected if empty"
           spellcheck="false"
@@ -292,16 +301,18 @@
       </div>
     {/if}
 
-    <div class="flex flex-col gap-1.5 pt-1.5 border-t border-border">
+    <div class="flex flex-col gap-2 pt-2 border-t border-border-subtle">
       <span class="text-2xs text-text-faint">Credentials — stored locally, never committed.</span>
 
       {#if editProvider === 'jira'}
         <div class="flex flex-col gap-1">
-          <label class="text-xs font-medium text-text-secondary flex items-center gap-2"
-            >Email</label
+          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+            >Email</span
           >
           <input
-            class="px-2 py-1 border border-border rounded-md bg-hover text-text text-sm font-inherit outline-none focus:border-focus-ring"
+            class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+            name="username"
+            aria-label="Email"
             bind:value={editUsername}
             placeholder="user@company.com"
             spellcheck="false"
@@ -310,20 +321,24 @@
       {/if}
 
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium text-text-secondary flex items-center gap-2">
-          API Token
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+            >API token</span
+          >
           {#if editProvider === 'jira'}
             <button
+              type="button"
               class="text-2xs text-accent-text bg-transparent border-0 p-0 cursor-pointer underline underline-offset-2 hover:text-accent"
               onclick={() =>
                 window.api.openExternal(
                   'https://id.atlassian.com/manage-profile/security/api-tokens',
                 )}
             >
-              Generate
+              Generate →
             </button>
           {:else if editProvider === 'youtrack'}
             <button
+              type="button"
               class="text-2xs text-accent-text bg-transparent border-0 p-0 cursor-pointer underline underline-offset-2 hover:text-accent"
               onclick={() => {
                 const url = editBaseUrl
@@ -332,20 +347,23 @@
                 window.api.openExternal(url)
               }}
             >
-              Generate
+              Generate →
             </button>
           {:else if editProvider === 'github'}
             <button
+              type="button"
               class="text-2xs text-accent-text bg-transparent border-0 p-0 cursor-pointer underline underline-offset-2 hover:text-accent"
               onclick={() => window.api.openExternal('https://github.com/settings/tokens')}
             >
-              Generate
+              Generate →
             </button>
           {/if}
-        </label>
+        </div>
         <input
-          class="px-2 py-1 border border-border rounded-md bg-hover text-text text-sm font-inherit outline-none focus:border-focus-ring"
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
           type="password"
+          name="token"
+          aria-label="API token"
           bind:value={editToken}
           placeholder={editingId !== '__new__' && trackerCreds[editingId ?? '']?.hasToken
             ? '••••••••'
@@ -355,28 +373,31 @@
       </div>
     </div>
 
-    <div class="min-h-[18px]" aria-live="polite">
+    <div class="min-h-4.5" aria-live="polite">
       {#if testResult === 'success'}
-        <span class="flex items-center gap-1 text-xs text-success"><Check size={14} /> OK</span>
+        <span class="flex items-center gap-1 text-xs text-success"><Check size={13} /> OK</span>
       {:else if testResult === 'fail'}
-        <span class="flex items-center gap-1 text-xs text-danger-text"><X size={14} /> Failed</span>
+        <span class="flex items-center gap-1 text-xs text-danger-text"><X size={13} /> Failed</span>
       {/if}
     </div>
 
     <div class="flex gap-1.5 justify-end">
       <button
-        class="px-3 py-1 border-0 rounded-md text-sm font-inherit cursor-pointer bg-transparent text-text-muted hover:text-text"
+        type="button"
+        class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
         onclick={cancelEdit}>Cancel</button
       >
       <button
-        class="px-3 py-1 border-0 rounded-md text-sm font-inherit cursor-pointer bg-active text-text enabled:hover:bg-hover-strong disabled:opacity-50 disabled:cursor-default"
+        type="button"
+        class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-bg-input text-text-secondary enabled:hover:bg-hover-strong enabled:hover:text-text disabled:opacity-50 disabled:cursor-default"
         onclick={testConnection}
         disabled={testing || !editBaseUrl || !editToken}
       >
-        {#if testing}Testing...{:else}Test{/if}
+        {testing ? 'Testing…' : 'Test'}
       </button>
       <button
-        class="px-3 py-1 border-0 rounded-md text-sm font-inherit cursor-pointer bg-accent-bg text-accent-text enabled:hover:bg-accent-bg-hover disabled:opacity-50 disabled:cursor-default"
+        type="button"
+        class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text enabled:hover:bg-accent-bg-hover disabled:opacity-50 disabled:cursor-default"
         onclick={saveTracker}
         disabled={!editBaseUrl}>Save</button
       >

--- a/src/renderer/src/components/preferences/TaskConnectionsPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskConnectionsPrefs.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { Check, X, Plus, Trash2 } from '@lucide/svelte'
-  import CustomSelect from '../shared/CustomSelect.svelte'
+  import { Plus, Trash2 } from '@lucide/svelte'
   import { confirm } from '../../lib/stores/dialogs.svelte'
   import {
     getRepoConfig,
@@ -14,6 +13,7 @@
   import { addToast } from '../../lib/stores/toast.svelte'
   import { providerLabel } from '../../lib/taskTracker/providerLabel'
   import PrefsSection from './_partials/PrefsSection.svelte'
+  import TrackerEditForm from './_partials/TrackerEditForm.svelte'
 
   interface Props {
     repoRoot?: string
@@ -196,7 +196,20 @@
 
       {#each config.trackers as tracker (tracker.id)}
         {#if editingId === tracker.id}
-          {@render editForm()}
+          <TrackerEditForm
+            bind:provider={editProvider}
+            bind:baseUrl={editBaseUrl}
+            bind:projectKey={editProjectKey}
+            bind:username={editUsername}
+            bind:token={editToken}
+            isNew={false}
+            hasExistingToken={trackerCreds[tracker.id]?.hasToken ?? false}
+            {testing}
+            {testResult}
+            onCancel={cancelEdit}
+            onTest={testConnection}
+            onSave={saveTracker}
+          />
         {:else}
           <div class="flex items-center gap-1">
             <button
@@ -235,7 +248,20 @@
       {/each}
 
       {#if editingId === '__new__'}
-        {@render editForm()}
+        <TrackerEditForm
+          bind:provider={editProvider}
+          bind:baseUrl={editBaseUrl}
+          bind:projectKey={editProjectKey}
+          bind:username={editUsername}
+          bind:token={editToken}
+          isNew={true}
+          hasExistingToken={false}
+          {testing}
+          {testResult}
+          onCancel={cancelEdit}
+          onTest={testConnection}
+          onSave={saveTracker}
+        />
       {/if}
 
       {#if editingId === null}
@@ -251,156 +277,3 @@
     </div>
   </PrefsSection>
 {/if}
-
-{#snippet editForm()}
-  <div class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input">
-    <div class="flex flex-col gap-1">
-      <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
-        >Provider</span
-      >
-      <CustomSelect
-        value={editProvider}
-        options={[
-          { value: 'jira', label: 'Jira' },
-          { value: 'youtrack', label: 'YouTrack' },
-          { value: 'github', label: 'GitHub' },
-        ]}
-        onchange={(v) => (editProvider = v as 'jira' | 'youtrack' | 'github')}
-      />
-    </div>
-
-    <div class="flex flex-col gap-1">
-      <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
-        >Base URL</span
-      >
-      <input
-        class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
-        name="baseUrl"
-        aria-label="Base URL"
-        bind:value={editBaseUrl}
-        placeholder={editProvider === 'github'
-          ? 'https://github.com'
-          : 'https://company.atlassian.net'}
-        spellcheck="false"
-      />
-    </div>
-
-    {#if editProvider === 'github'}
-      <div class="flex flex-col gap-1">
-        <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
-          >Repository (optional)</span
-        >
-        <input
-          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
-          name="projectKey"
-          aria-label="Repository"
-          bind:value={editProjectKey}
-          placeholder="owner/repo — auto-detected if empty"
-          spellcheck="false"
-        />
-      </div>
-    {/if}
-
-    <div class="flex flex-col gap-2 pt-2 border-t border-border-subtle">
-      <span class="text-2xs text-text-faint">Credentials — stored locally, never committed.</span>
-
-      {#if editProvider === 'jira'}
-        <div class="flex flex-col gap-1">
-          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
-            >Email</span
-          >
-          <input
-            class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
-            name="username"
-            aria-label="Email"
-            bind:value={editUsername}
-            placeholder="user@company.com"
-            spellcheck="false"
-          />
-        </div>
-      {/if}
-
-      <div class="flex flex-col gap-1">
-        <div class="flex items-center justify-between gap-2">
-          <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
-            >API token</span
-          >
-          {#if editProvider === 'jira'}
-            <button
-              type="button"
-              class="text-2xs text-accent-text bg-transparent border-0 p-0 cursor-pointer underline underline-offset-2 hover:text-accent"
-              onclick={() =>
-                window.api.openExternal(
-                  'https://id.atlassian.com/manage-profile/security/api-tokens',
-                )}
-            >
-              Generate →
-            </button>
-          {:else if editProvider === 'youtrack'}
-            <button
-              type="button"
-              class="text-2xs text-accent-text bg-transparent border-0 p-0 cursor-pointer underline underline-offset-2 hover:text-accent"
-              onclick={() => {
-                const url = editBaseUrl
-                  ? `${editBaseUrl.replace(/\/$/, '')}/hub/tokens`
-                  : 'https://youtrack.jetbrains.com/hub/tokens'
-                window.api.openExternal(url)
-              }}
-            >
-              Generate →
-            </button>
-          {:else if editProvider === 'github'}
-            <button
-              type="button"
-              class="text-2xs text-accent-text bg-transparent border-0 p-0 cursor-pointer underline underline-offset-2 hover:text-accent"
-              onclick={() => window.api.openExternal('https://github.com/settings/tokens')}
-            >
-              Generate →
-            </button>
-          {/if}
-        </div>
-        <input
-          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
-          type="password"
-          name="token"
-          aria-label="API token"
-          bind:value={editToken}
-          placeholder={editingId !== '__new__' && trackerCreds[editingId ?? '']?.hasToken
-            ? '••••••••'
-            : 'Enter token'}
-          autocomplete="off"
-        />
-      </div>
-    </div>
-
-    <div class="min-h-4.5" aria-live="polite">
-      {#if testResult === 'success'}
-        <span class="flex items-center gap-1 text-xs text-success"><Check size={13} /> OK</span>
-      {:else if testResult === 'fail'}
-        <span class="flex items-center gap-1 text-xs text-danger-text"><X size={13} /> Failed</span>
-      {/if}
-    </div>
-
-    <div class="flex gap-1.5 justify-end">
-      <button
-        type="button"
-        class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
-        onclick={cancelEdit}>Cancel</button
-      >
-      <button
-        type="button"
-        class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-bg-input text-text-secondary enabled:hover:bg-hover-strong enabled:hover:text-text disabled:opacity-50 disabled:cursor-default"
-        onclick={testConnection}
-        disabled={testing || !editBaseUrl || !editToken}
-      >
-        {testing ? 'Testing…' : 'Test'}
-      </button>
-      <button
-        type="button"
-        class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text enabled:hover:bg-accent-bg-hover disabled:opacity-50 disabled:cursor-default"
-        onclick={saveTracker}
-        disabled={!editBaseUrl}>Save</button
-      >
-    </div>
-  </div>
-{/snippet}

--- a/src/renderer/src/components/preferences/TaskPRNamingPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskPRNamingPrefs.svelte
@@ -7,6 +7,7 @@
     saveRepoConfig,
     saveGlobalConfig,
   } from '../../lib/stores/taskTracker.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
 
   interface Props {
     repoRoot?: string
@@ -101,64 +102,73 @@
   }
 </script>
 
-<div class="flex flex-col gap-2.5">
-  <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">
-    Pull request naming
-  </h4>
+<PrefsSection
+  title="Pull request naming"
+  description="Templates applied when creating PRs from tasks"
+>
+  <div class="flex flex-col gap-3 py-3 border-t border-border-subtle first:border-t-0 first:pt-0">
+    {#if boards.length > 0}
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-text-secondary w-20 shrink-0">Board</span>
+        <CustomSelect
+          value={prScope}
+          options={[
+            { value: 'default', label: 'All boards (default)' },
+            ...boards.map((b) => ({ value: b.id, label: b.name })),
+          ]}
+          onchange={(v) => {
+            prScope = v
+            initialized = false
+          }}
+        />
+      </div>
+    {/if}
 
-  {#if boards.length > 0}
-    <div class="flex items-center gap-2 text-md">
-      <span class="text-text-secondary w-[90px] flex-shrink-0">Board</span>
-      <CustomSelect
-        value={prScope}
-        options={[
-          { value: 'default', label: 'All boards (default)' },
-          ...boards.map((b) => ({ value: b.id, label: b.name })),
-        ]}
-        onchange={(v) => {
-          prScope = v
-          initialized = false
-        }}
+    <BranchTokenBuilder
+      bind:templateInput={titleTemplateInput}
+      placeholders={PR_TAGS}
+      onSave={onTitleTemplateSave}
+      label="Title"
+      autoSeparators={false}
+    />
+
+    <BranchTokenBuilder
+      bind:templateInput={bodyTemplateInput}
+      placeholders={PR_TAGS}
+      onSave={onBodyTemplateSave}
+      label="Body"
+      autoSeparators={false}
+    />
+
+    <div class="flex flex-col gap-1">
+      <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+        >Body text</span
+      >
+      <textarea
+        class="px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring resize-y min-h-15 placeholder:text-text-faint"
+        name="prBody"
+        aria-label="PR body template"
+        bind:value={bodyTemplateInput}
+        oninput={onBodyTemplateSave}
+        rows="4"
+        placeholder="PR body template — use tags above or type freely"
+        spellcheck="false"
+      ></textarea>
+    </div>
+
+    <div class="flex flex-col gap-1">
+      <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+        >Default target branch</span
+      >
+      <input
+        class="px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        name="defaultTargetBranch"
+        aria-label="Default target branch"
+        bind:value={defaultTargetBranch}
+        oninput={() => savePRField('defaultTargetBranch', defaultTargetBranch)}
+        placeholder="develop"
+        spellcheck="false"
       />
     </div>
-  {/if}
-
-  <BranchTokenBuilder
-    bind:templateInput={titleTemplateInput}
-    placeholders={PR_TAGS}
-    onSave={onTitleTemplateSave}
-    label="Title"
-    autoSeparators={false}
-  />
-
-  <BranchTokenBuilder
-    bind:templateInput={bodyTemplateInput}
-    placeholders={PR_TAGS}
-    onSave={onBodyTemplateSave}
-    label="Body"
-    autoSeparators={false}
-  />
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary">Body text</label>
-    <textarea
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring resize-y min-h-[60px] placeholder:text-text-faint"
-      bind:value={bodyTemplateInput}
-      oninput={onBodyTemplateSave}
-      rows="4"
-      placeholder="PR body template — use tags above or type freely"
-      spellcheck="false"
-    ></textarea>
   </div>
-
-  <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-text-secondary">Default target branch</label>
-    <input
-      class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-      bind:value={defaultTargetBranch}
-      oninput={() => savePRField('defaultTargetBranch', defaultTargetBranch)}
-      placeholder="develop"
-      spellcheck="false"
-    />
-  </div>
-</div>
+</PrefsSection>

--- a/src/renderer/src/components/preferences/TaskTrackerPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskTrackerPrefs.svelte
@@ -18,6 +18,8 @@
   import TaskConnectionsPrefs from './TaskConnectionsPrefs.svelte'
   import TaskBranchNamingPrefs from './TaskBranchNamingPrefs.svelte'
   import TaskPRNamingPrefs from './TaskPRNamingPrefs.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   type ConfigScope = 'global' | 'project'
   let scope = $state<ConfigScope>('global')
@@ -141,55 +143,68 @@
   }
 </script>
 
-<div class="flex flex-col gap-5">
-  <h3 class="text-[15px] font-semibold text-text m-0">Task Tracker</h3>
+<div class="flex flex-col gap-7">
+  <div class="flex flex-col gap-2">
+    <div
+      class="inline-flex w-fit p-0.5 bg-bg-input border border-border-subtle rounded-md select-none"
+      role="tablist"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={scope === 'global'}
+        class="px-3 py-1 border-0 rounded-sm text-sm font-inherit cursor-pointer disabled:opacity-40 disabled:cursor-default"
+        class:bg-bg={scope === 'global'}
+        class:text-text={scope === 'global'}
+        class:bg-transparent={scope !== 'global'}
+        class:text-text-muted={scope !== 'global'}
+        class:hover:text-text-secondary={scope !== 'global'}
+        onclick={() => handleScopeChange('global')}
+      >
+        Global
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={scope === 'project'}
+        class="px-3 py-1 border-0 rounded-sm text-sm font-inherit cursor-pointer disabled:opacity-40 disabled:cursor-default"
+        class:bg-bg={scope === 'project'}
+        class:text-text={scope === 'project'}
+        class:bg-transparent={scope !== 'project'}
+        class:text-text-muted={scope !== 'project'}
+        class:hover:text-text-secondary={scope !== 'project'}
+        disabled={!repoRoot}
+        onclick={() => handleScopeChange('project')}
+        title={repoRoot
+          ? 'Project-specific settings (.canopy/config.json)'
+          : 'Open a repository to configure project settings'}
+      >
+        Project
+      </button>
+    </div>
 
-  <div class="flex gap-0.5 bg-border-subtle rounded-xl p-0.5 w-fit">
-    <button
-      class="px-4 py-1.5 border-0 rounded-lg text-sm font-medium font-inherit cursor-pointer transition-all duration-base disabled:opacity-40 disabled:cursor-default {scope ===
-      'global'
-        ? '!bg-bg !text-text shadow-[0_1px_2px_oklch(0_0_0/0.1)]'
-        : 'bg-transparent text-text-muted enabled:hover:text-text-secondary'}"
-      onclick={() => handleScopeChange('global')}
-    >
-      Global
-    </button>
-    <button
-      class="px-4 py-1.5 border-0 rounded-lg text-sm font-medium font-inherit cursor-pointer transition-all duration-base disabled:opacity-40 disabled:cursor-default {scope ===
-      'project'
-        ? '!bg-bg !text-text shadow-[0_1px_2px_oklch(0_0_0/0.1)]'
-        : 'bg-transparent text-text-muted enabled:hover:text-text-secondary'}"
-      disabled={!repoRoot}
-      onclick={() => handleScopeChange('project')}
-      title={repoRoot
-        ? 'Project-specific settings (.canopy/config.json)'
-        : 'Open a repository to configure project settings'}
-    >
-      Project
-    </button>
+    <p class="text-xs text-text-muted m-0 leading-snug">
+      {#if scope === 'global'}
+        Personal settings used across all projects.
+      {:else}
+        Stored in <code class="font-mono text-text-secondary">.canopy/config.json</code> — shared with
+        your team via git. Overrides global settings.
+      {/if}
+    </p>
   </div>
 
-  <span class="text-xs text-text-faint -mt-3">
-    {#if scope === 'global'}
-      Your personal settings, used across all projects.
-    {:else}
-      Stored in <code>.canopy/config.json</code> — shared with your team via git. Overrides global settings.
-    {/if}
-  </span>
-
   {#if scope === 'project' && !repoRoot}
-    <p class="text-xs text-text-faint">Open a repository to configure project settings.</p>
+    <p class="text-sm text-text-faint m-0">Open a repository to configure project settings.</p>
   {:else if scope === 'project' && !repoConfig}
-    <div>
-      <span class="text-xs text-text-faint">
-        No <code>.canopy/config.json</code> found in this repository.
-      </span>
-      <div class="mt-2">
-        <button
-          class="px-3.5 py-1.5 border-0 rounded-lg text-md font-inherit cursor-pointer bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
-          onclick={handleInitProject}>Initialize Project Config</button
-        >
-      </div>
+    <div class="flex flex-col gap-2 items-start">
+      <p class="text-sm text-text-faint m-0">
+        No <code class="font-mono text-text-secondary">.canopy/config.json</code> in this repository.
+      </p>
+      <button
+        type="button"
+        class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
+        onclick={handleInitProject}>Initialize project config</button
+      >
     </div>
   {:else if config}
     <TaskConnectionsPrefs {repoRoot} {scope} />
@@ -205,40 +220,49 @@
 
     <TaskPRNamingPrefs {repoRoot} {boards} {scope} />
 
-    <div class="flex flex-col gap-2.5">
-      <h4 class="text-xs font-semibold uppercase tracking-[0.5px] text-text-muted m-0">Filters</h4>
-
-      <label class="flex items-center gap-2 text-md text-text cursor-pointer">
+    <PrefsSection title="Filters" description="Limit which tasks appear in pickers">
+      <PrefsRow
+        label="Only show tasks assigned to me"
+        help="Hides tasks assigned to other people or unassigned"
+        search="filter assigned to me mine"
+      >
         <CustomCheckbox checked={config.filters.assignedToMe} onchange={toggleAssignedToMe} />
-        <span>Only show tasks assigned to me</span>
-      </label>
+      </PrefsRow>
 
-      <div class="flex items-center gap-1.5">
-        <span class="text-sm font-medium text-text-secondary">Status filter</span>
-        <button
-          class="flex items-center justify-center w-6 h-6 border-0 rounded-md bg-transparent text-text-muted cursor-pointer enabled:hover:bg-hover enabled:hover:text-text-secondary disabled:opacity-50 disabled:cursor-default"
-          onclick={loadStatusesFromApi}
-          disabled={loadingStatuses}
-          title="Refresh from API"
-        >
-          <RefreshCw size={12} />
-        </button>
-      </div>
-      {#if availableStatuses.length > 0}
-        {#each availableStatuses as status (status)}
-          <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-            <CustomCheckbox
-              checked={config.filters.statuses.includes(status)}
-              onchange={() => toggleStatus(status)}
-            />
-            <span>{status}</span>
-          </label>
-        {/each}
-      {:else}
-        <span class="text-xs text-text-faint"
-          >Click refresh to load statuses from your tracker.</span
-        >
-      {/if}
-    </div>
+      <PrefsRow
+        label="Status filter"
+        help={availableStatuses.length === 0
+          ? 'Click refresh to load statuses from your tracker.'
+          : `${config.filters.statuses.length} of ${availableStatuses.length} selected`}
+        search="filter status statuses"
+        layout="stacked"
+      >
+        <div class="flex flex-col gap-2">
+          <button
+            type="button"
+            class="self-start flex items-center gap-1 px-2.5 py-1 rounded-md bg-transparent border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-hover hover:text-text disabled:opacity-50 disabled:cursor-default"
+            onclick={loadStatusesFromApi}
+            disabled={loadingStatuses}
+            title="Refresh from API"
+          >
+            <RefreshCw size={12} />
+            <span>{loadingStatuses ? 'Loading…' : 'Refresh from API'}</span>
+          </button>
+          {#if availableStatuses.length > 0}
+            <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+              {#each availableStatuses as status (status)}
+                <label class="flex items-center gap-2 text-md text-text cursor-pointer">
+                  <CustomCheckbox
+                    checked={config.filters.statuses.includes(status)}
+                    onchange={() => toggleStatus(status)}
+                  />
+                  <span>{status}</span>
+                </label>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </PrefsRow>
+    </PrefsSection>
   {/if}
 </div>

--- a/src/renderer/src/components/preferences/TaskTrackerPrefs.svelte
+++ b/src/renderer/src/components/preferences/TaskTrackerPrefs.svelte
@@ -147,12 +147,12 @@
   <div class="flex flex-col gap-2">
     <div
       class="inline-flex w-fit p-0.5 bg-bg-input border border-border-subtle rounded-md select-none"
-      role="tablist"
+      role="group"
+      aria-label="Settings scope"
     >
       <button
         type="button"
-        role="tab"
-        aria-selected={scope === 'global'}
+        aria-pressed={scope === 'global'}
         class="px-3 py-1 border-0 rounded-sm text-sm font-inherit cursor-pointer disabled:opacity-40 disabled:cursor-default"
         class:bg-bg={scope === 'global'}
         class:text-text={scope === 'global'}
@@ -165,8 +165,7 @@
       </button>
       <button
         type="button"
-        role="tab"
-        aria-selected={scope === 'project'}
+        aria-pressed={scope === 'project'}
         class="px-3 py-1 border-0 rounded-sm text-sm font-inherit cursor-pointer disabled:opacity-40 disabled:cursor-default"
         class:bg-bg={scope === 'project'}
         class:text-text={scope === 'project'}

--- a/src/renderer/src/components/preferences/TerminalPrefs.svelte
+++ b/src/renderer/src/components/preferences/TerminalPrefs.svelte
@@ -2,8 +2,13 @@
   import { onMount } from 'svelte'
   import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import { closeDialog, showTmuxBrowser, confirm } from '../../lib/stores/dialogs.svelte'
+  import CustomCheckbox from '../shared/CustomCheckbox.svelte'
+  import CustomSelect from '../shared/CustomSelect.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let tmuxEnabled = $derived(prefs['tmux.enabled'] === 'true')
+  let tmuxMouse = $derived(prefs['tmux.mouse'] === 'true')
   let closePolicy = $derived(prefs['tmux.closePolicy'] ?? 'detach')
   let tmuxAvailable = $state<boolean | null>(null)
   let tmuxVersion = $state<string | null>(null)
@@ -35,9 +40,8 @@
     setPref('tmux.enabled', next ? 'true' : 'false')
   }
 
-  function handleClosePolicy(e: Event): void {
-    const value = (e.target as HTMLSelectElement).value
-    setPref('tmux.closePolicy', value)
+  function toggleMouse(): void {
+    setPref('tmux.mouse', tmuxMouse ? 'false' : 'true')
   }
 
   function openSessionBrowser(): void {
@@ -59,85 +63,87 @@
   }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Terminal</h3>
-
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <input type="checkbox" checked={tmuxEnabled} onchange={toggleTmux} class="accent-accent" />
-    <span>Enable tmux session persistence</span>
-    <span
-      class="inline-flex items-center text-2xs font-semibold uppercase tracking-caps-looser px-1.5 py-px rounded-md align-middle ml-1 bg-experimental-bg text-warning"
-      >Experimental</span
+<div class="flex flex-col gap-7">
+  <PrefsSection
+    title="tmux integration"
+    description="Run shells inside tmux so sessions survive app restarts and crashes"
+  >
+    <PrefsRow
+      label="Enable session persistence"
+      help="All sessions (shells and tools) run inside tmux. Experimental — expect rough edges."
+      search="tmux session persistence experimental"
+      badge={{ text: 'Experimental', tone: 'warning' }}
     >
-  </label>
-
-  {#if tmuxAvailable === false}
-    <div class="text-sm text-danger pl-6 -mt-2">
-      tmux not found in PATH. Install it to use this feature.
-    </div>
-  {/if}
-
-  {#if tmuxEnabled}
-    <div class="text-xs text-text-muted leading-normal pl-6 -mt-2">
-      All sessions (shells and tools) run inside tmux and survive app close, crashes, and restarts.
-    </div>
-    <div class="text-sm text-danger pl-6 -mt-2">
-      This integration is experimental and may be unstable. Use at your own risk.
-    </div>
-
-    <label class="flex items-center gap-2 text-md text-text cursor-pointer pl-6">
-      <input
-        type="checkbox"
-        class="accent-accent"
-        checked={prefs['tmux.mouse'] === 'true'}
-        onchange={() => setPref('tmux.mouse', prefs['tmux.mouse'] === 'true' ? 'false' : 'true')}
+      <CustomCheckbox
+        checked={tmuxEnabled}
+        onchange={toggleTmux}
+        disabled={tmuxAvailable === false}
       />
-      <span>Enable mouse support</span>
-    </label>
-    <div class="text-xs text-text-muted leading-normal pl-12 -mt-2">
-      Enable mouse clicks and scrolling inside tmux panes
-    </div>
+    </PrefsRow>
 
-    <div class="flex items-center gap-3 text-md pl-6">
-      <span class="text-text-secondary min-w-20">On app close</span>
-      <select
-        class="px-2 py-1 rounded-md border border-border bg-bg-elevated text-text text-sm font-inherit"
-        value={closePolicy}
-        onchange={handleClosePolicy}
-      >
-        <option value="detach">Keep sessions running</option>
-        <option value="kill">Kill sessions</option>
-        <option value="ask">Ask each time</option>
-      </select>
-    </div>
-    <div class="text-xs text-text-muted leading-normal pl-12 -mt-2">
-      What happens to tmux sessions when you quit the app
-    </div>
-  {/if}
-
-  <div class="flex items-center gap-3 text-md">
-    <span class="text-text-secondary min-w-20">tmux</span>
-    <span class="text-text font-mono text-sm"
-      >{tmuxVersion ?? (tmuxAvailable === false ? 'not installed' : '...')}</span
-    >
-  </div>
-
-  {#if tmuxEnabled && sessionCount !== null}
-    <div class="flex items-center gap-3 text-md">
-      <span class="text-text-secondary min-w-20">Sessions</span>
-      <span class="text-text font-mono text-sm">{sessionCount} active</span>
-    </div>
-    {#if sessionCount > 0}
-      <div class="flex gap-2 pt-1">
-        <button
-          class="px-3.5 py-1.5 rounded-lg text-sm font-inherit cursor-pointer border border-border bg-border-subtle text-text-secondary transition-colors duration-fast hover:bg-active hover:text-text"
-          onclick={openSessionBrowser}>Manage sessions</button
-        >
-        <button
-          class="px-3.5 py-1.5 rounded-lg text-sm font-inherit cursor-pointer border border-border bg-border-subtle text-text-secondary transition-colors duration-fast hover:bg-active hover:text-text hover:!border-danger hover:!text-danger"
-          onclick={killAllSessions}>Kill all</button
-        >
-      </div>
+    {#if tmuxAvailable === false}
+      <p class="text-xs text-danger-text leading-snug -mt-1">
+        tmux not found in PATH. Install it to use this feature.
+      </p>
     {/if}
-  {/if}
+
+    {#if tmuxEnabled}
+      <PrefsRow
+        label="Mouse support"
+        help="Enable mouse clicks and scrolling inside tmux panes"
+        search="tmux mouse click scroll"
+      >
+        <CustomCheckbox checked={tmuxMouse} onchange={toggleMouse} />
+      </PrefsRow>
+
+      <PrefsRow
+        label="On app close"
+        help="What happens to tmux sessions when you quit Canopy"
+        search="tmux close detach kill ask quit"
+      >
+        <CustomSelect
+          value={closePolicy}
+          options={[
+            { value: 'detach', label: 'Keep sessions running' },
+            { value: 'kill', label: 'Kill sessions' },
+            { value: 'ask', label: 'Ask each time' },
+          ]}
+          onchange={(v) => setPref('tmux.closePolicy', v)}
+          maxWidth="200px"
+        />
+      </PrefsRow>
+    {/if}
+  </PrefsSection>
+
+  <PrefsSection title="Status">
+    <PrefsRow label="tmux version" search="tmux version">
+      <span class="text-sm text-text-muted font-mono">
+        {tmuxVersion ?? (tmuxAvailable === false ? 'not installed' : '…')}
+      </span>
+    </PrefsRow>
+
+    {#if tmuxEnabled && sessionCount !== null}
+      <PrefsRow
+        label="Active sessions"
+        help={sessionCount === 0 ? 'No sessions yet' : undefined}
+        search="tmux sessions active"
+      >
+        <div class="flex items-center gap-2">
+          <span class="text-sm text-text-muted font-mono">{sessionCount}</span>
+          {#if sessionCount > 0}
+            <button
+              type="button"
+              class="px-2.5 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-border-subtle text-text-secondary hover:bg-active hover:text-text"
+              onclick={openSessionBrowser}>Manage</button
+            >
+            <button
+              type="button"
+              class="px-2.5 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-border-subtle text-text-secondary hover:bg-danger-hover hover:border-danger hover:text-danger-text"
+              onclick={killAllSessions}>Kill all</button
+            >
+          {/if}
+        </div>
+      </PrefsRow>
+    {/if}
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/ToolPrefs.svelte
+++ b/src/renderer/src/components/preferences/ToolPrefs.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+  import { Plus, Pencil, Trash2 } from '@lucide/svelte'
   import { getTools } from '../../lib/stores/tools.svelte'
   import { confirm } from '../../lib/stores/dialogs.svelte'
   import ToolIcon from '../shared/ToolIcon.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import { prefsSearch, matches } from './_partials/prefsSearch.svelte'
 
   let showForm = $state(false)
   let newId = $state('')
@@ -18,6 +21,22 @@
   let editArgs = $state('')
   let editCategory = $state('')
   let editError = $state('')
+
+  const categoryOptions = [
+    { value: 'ai', label: 'AI' },
+    { value: 'git', label: 'Git' },
+    { value: 'system', label: 'System' },
+    { value: 'shell', label: 'Shell' },
+  ]
+
+  function resetNewForm(): void {
+    newId = ''
+    newName = ''
+    newCommand = ''
+    newArgs = ''
+    newCategory = 'system'
+    error = ''
+  }
 
   async function addTool(): Promise<void> {
     if (!newId.trim() || !newName.trim() || !newCommand.trim()) {
@@ -40,13 +59,8 @@
           .filter(Boolean),
         category: newCategory,
       })
-      newId = ''
-      newName = ''
-      newCommand = ''
-      newArgs = ''
-      newCategory = 'system'
+      resetNewForm()
       showForm = false
-      error = ''
     } catch (e) {
       error = e instanceof Error ? e.message : String(e)
     }
@@ -54,7 +68,7 @@
 
   async function removeTool(id: string, name: string): Promise<void> {
     const ok = await confirm({
-      title: 'Remove Tool',
+      title: 'Remove tool',
       message: `Remove tool "${name}"? This cannot be undone.`,
       confirmLabel: 'Remove',
       destructive: true,
@@ -63,13 +77,13 @@
     await window.api.removeCustomTool(id)
   }
 
-  async function startEdit(tool: {
+  function startEdit(tool: {
     id: string
     name: string
     command: string
     args: string[]
     category: string
-  }): Promise<void> {
+  }): void {
     editingId = tool.id
     editName = tool.name
     editCommand = tool.command
@@ -106,155 +120,208 @@
       editError = e instanceof Error ? e.message : String(e)
     }
   }
+
+  function visible(tool: { id: string; name: string; command: string; category: string }): boolean {
+    if (prefsSearch.query.trim() === '') return true
+    return matches(`${tool.name} ${tool.command} ${tool.category} ${tool.id}`)
+  }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Tools</h3>
-  <p class="text-sm text-text-secondary m-0">
-    Register custom CLI tools that appear in the command palette and can be opened as tabs.
-  </p>
-
-  <div class="flex flex-col gap-1">
-    {#each getTools() as tool (tool.id)}
-      {#if editingId === tool.id}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-          class="flex flex-col gap-2 p-3 border border-border rounded-xl bg-border-subtle w-full"
-          onkeydown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault()
-              saveEdit()
-            }
-            if (e.key === 'Escape') cancelEdit()
-          }}
-        >
-          <div class="mb-1">
-            <span class="text-xs text-text-faint font-mono">ID: {tool.id}</span>
+<div class="flex flex-col gap-7">
+  <PrefsSection
+    title="Tools"
+    description="Register custom CLI tools that appear in the command palette and can be opened as tabs"
+  >
+    <div class="flex flex-col">
+      {#each getTools() as tool (tool.id)}
+        {#if editingId === tool.id}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="flex flex-col gap-2 p-3 my-1 border border-border rounded-md bg-bg-input"
+            onkeydown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                saveEdit()
+              }
+              if (e.key === 'Escape') cancelEdit()
+            }}
+          >
+            <div
+              class="flex items-center gap-2 text-2xs uppercase tracking-caps-tight text-text-faint"
+            >
+              <span>Editing</span>
+              <code class="font-mono text-text-muted normal-case tracking-normal">{tool.id}</code>
+            </div>
+            <input
+              class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+              name="editName"
+              aria-label="Display name"
+              bind:value={editName}
+              placeholder="Display name"
+              spellcheck="false"
+            />
+            <input
+              class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+              name="editCommand"
+              aria-label="Command"
+              bind:value={editCommand}
+              placeholder="Command (binary name)"
+              spellcheck="false"
+            />
+            <input
+              class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+              name="editArgs"
+              aria-label="Args"
+              bind:value={editArgs}
+              placeholder="Args (comma-separated)"
+              spellcheck="false"
+            />
+            <CustomSelect
+              value={editCategory}
+              options={categoryOptions}
+              maxWidth="100%"
+              onchange={(v) => (editCategory = v)}
+            />
+            {#if editError}
+              <p class="text-sm text-danger-text m-0">{editError}</p>
+            {/if}
+            <div class="flex justify-end gap-2">
+              <button
+                type="button"
+                class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
+                onclick={cancelEdit}>Cancel</button
+              >
+              <button
+                type="button"
+                class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
+                onclick={saveEdit}>Save</button
+              >
+            </div>
           </div>
-          <input
-            class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-            bind:value={editName}
-            placeholder="Display name"
-          />
-          <input
-            class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-            bind:value={editCommand}
-            placeholder="Command (binary name)"
-          />
-          <input
-            class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-            bind:value={editArgs}
-            placeholder="Args (comma-separated)"
-          />
-          <CustomSelect
-            value={editCategory}
-            options={[
-              { value: 'ai', label: 'AI' },
-              { value: 'git', label: 'Git' },
-              { value: 'system', label: 'System' },
-              { value: 'shell', label: 'Shell' },
-            ]}
-            maxWidth="100%"
-            onchange={(v) => (editCategory = v)}
-          />
-          {#if editError}
-            <p class="text-sm text-danger m-0">{editError}</p>
-          {/if}
-          <div class="flex justify-end gap-2">
-            <button
-              class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-active text-text"
-              onclick={cancelEdit}>Cancel</button
+        {:else}
+          <div
+            class="group/tool flex items-center gap-3 py-2 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
+            class:opacity-30={!visible(tool)}
+          >
+            <ToolIcon icon={tool.icon} size={16} />
+            <span class="text-md text-text min-w-30 truncate">{tool.name}</span>
+            <code class="text-sm text-text-secondary font-mono flex-1 truncate">{tool.command}</code
             >
-            <button
-              class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
-              onclick={saveEdit}>Save</button
+            <span class="text-2xs uppercase tracking-caps-tight text-text-muted shrink-0"
+              >{tool.category}</span
             >
+            {#if tool.isCustom}
+              <div class="flex items-center gap-0.5 shrink-0">
+                <button
+                  type="button"
+                  class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-hover hover:text-text"
+                  onclick={() => startEdit(tool)}
+                  aria-label="Edit {tool.name}"
+                  title="Edit"
+                >
+                  <Pencil size={13} />
+                </button>
+                <button
+                  type="button"
+                  class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-danger-bg hover:text-danger-text"
+                  onclick={() => removeTool(tool.id, tool.name)}
+                  aria-label="Remove {tool.name}"
+                  title="Remove"
+                >
+                  <Trash2 size={13} />
+                </button>
+              </div>
+            {:else}
+              <span class="text-2xs uppercase tracking-caps-tight text-text-faint shrink-0"
+                >built-in</span
+              >
+            {/if}
           </div>
-        </div>
-      {:else}
-        <div class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg bg-border-subtle text-md">
-          <ToolIcon icon={tool.icon} size={16} />
-          <span class="text-text min-w-[100px]">{tool.name}</span>
-          <span class="text-text-secondary font-mono text-sm flex-1">{tool.command}</span>
-          <span class="text-2xs text-text-muted uppercase tracking-[0.5px]">{tool.category}</span>
-          {#if tool.isCustom}
-            <button
-              class="px-2 py-0.5 border-0 rounded-md bg-accent-bg text-accent-text text-xs font-inherit cursor-pointer hover:bg-accent-bg-hover"
-              onclick={() => startEdit(tool)}>Edit</button
-            >
-            <button
-              class="px-2 py-0.5 border-0 rounded-md bg-danger-bg text-danger-text text-xs font-inherit cursor-pointer"
-              onclick={() => removeTool(tool.id, tool.name)}>Remove</button
-            >
-          {:else}
-            <span class="text-2xs text-text-faint">built-in</span>
-          {/if}
-        </div>
-      {/if}
-    {/each}
-  </div>
-
-  {#if showForm}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="flex flex-col gap-2 p-3 border border-border rounded-xl bg-border-subtle"
-      onkeydown={(e) => {
-        if (e.key === 'Enter') {
-          e.preventDefault()
-          addTool()
-        }
-        if (e.key === 'Escape') showForm = false
-      }}
-    >
-      <input
-        class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-        bind:value={newId}
-        placeholder="ID (e.g. my-tool)"
-      />
-      <input
-        class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-        bind:value={newName}
-        placeholder="Display name"
-      />
-      <input
-        class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-        bind:value={newCommand}
-        placeholder="Command (binary name)"
-      />
-      <input
-        class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-        bind:value={newArgs}
-        placeholder="Args (comma-separated)"
-      />
-      <CustomSelect
-        value={newCategory}
-        options={[
-          { value: 'ai', label: 'AI' },
-          { value: 'git', label: 'Git' },
-          { value: 'system', label: 'System' },
-          { value: 'shell', label: 'Shell' },
-        ]}
-        maxWidth="100%"
-        onchange={(v) => (newCategory = v)}
-      />
-      {#if error}
-        <p class="text-sm text-danger m-0">{error}</p>
-      {/if}
-      <div class="flex justify-end gap-2">
-        <button
-          class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-active text-text"
-          onclick={() => (showForm = false)}>Cancel</button
-        >
-        <button
-          class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
-          onclick={addTool}>Add Tool</button
-        >
-      </div>
+        {/if}
+      {/each}
     </div>
-  {:else}
-    <button
-      class="self-start px-3.5 py-1.5 border border-dashed border-text-faint rounded-lg bg-transparent text-text-secondary text-md font-inherit cursor-pointer hover:bg-hover hover:text-text"
-      onclick={() => (showForm = true)}>+ Add Custom Tool</button
-    >
-  {/if}
+
+    {#if showForm}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="flex flex-col gap-2 p-3 mt-3 border border-border rounded-md bg-bg-input"
+        onkeydown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            addTool()
+          }
+          if (e.key === 'Escape') {
+            showForm = false
+            resetNewForm()
+          }
+        }}
+      >
+        <input
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="newId"
+          aria-label="Tool ID"
+          bind:value={newId}
+          placeholder="ID (e.g. my-tool)"
+          spellcheck="false"
+        />
+        <input
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="newName"
+          aria-label="Display name"
+          bind:value={newName}
+          placeholder="Display name"
+          spellcheck="false"
+        />
+        <input
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="newCommand"
+          aria-label="Command"
+          bind:value={newCommand}
+          placeholder="Command (binary name)"
+          spellcheck="false"
+        />
+        <input
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="newArgs"
+          aria-label="Args"
+          bind:value={newArgs}
+          placeholder="Args (comma-separated)"
+          spellcheck="false"
+        />
+        <CustomSelect
+          value={newCategory}
+          options={categoryOptions}
+          maxWidth="100%"
+          onchange={(v) => (newCategory = v)}
+        />
+        {#if error}
+          <p class="text-sm text-danger-text m-0">{error}</p>
+        {/if}
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
+            onclick={() => {
+              showForm = false
+              resetNewForm()
+            }}>Cancel</button
+          >
+          <button
+            type="button"
+            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
+            onclick={addTool}>Add tool</button
+          >
+        </div>
+      </div>
+    {:else}
+      <button
+        type="button"
+        class="self-start flex items-center gap-1 px-3 py-1 mt-3 rounded-md bg-border-subtle border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-active hover:text-text"
+        onclick={() => (showForm = true)}
+      >
+        <Plus size={12} />
+        <span>Add custom tool</span>
+      </button>
+    {/if}
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/ToolPrefs.svelte
+++ b/src/renderer/src/components/preferences/ToolPrefs.svelte
@@ -3,67 +3,67 @@
   import { getTools } from '../../lib/stores/tools.svelte'
   import { confirm } from '../../lib/stores/dialogs.svelte'
   import ToolIcon from '../shared/ToolIcon.svelte'
-  import CustomSelect from '../shared/CustomSelect.svelte'
   import PrefsSection from './_partials/PrefsSection.svelte'
+  import ToolForm from './_partials/ToolForm.svelte'
   import { prefsSearch, matches } from './_partials/prefsSearch.svelte'
 
+  interface ToolDraft {
+    id: string
+    name: string
+    command: string
+    args: string
+    category: string
+  }
+
+  function emptyDraft(): ToolDraft {
+    return { id: '', name: '', command: '', args: '', category: 'system' }
+  }
+
   let showForm = $state(false)
-  let newId = $state('')
-  let newName = $state('')
-  let newCommand = $state('')
-  let newArgs = $state('')
-  let newCategory = $state('system')
+  let newDraft = $state<ToolDraft>(emptyDraft())
   let error = $state('')
 
   let editingId: string | null = $state(null)
-  let editName = $state('')
-  let editCommand = $state('')
-  let editArgs = $state('')
-  let editCategory = $state('')
+  let editDraft = $state<ToolDraft>(emptyDraft())
   let editError = $state('')
 
-  const categoryOptions = [
-    { value: 'ai', label: 'AI' },
-    { value: 'git', label: 'Git' },
-    { value: 'system', label: 'System' },
-    { value: 'shell', label: 'Shell' },
-  ]
-
-  function resetNewForm(): void {
-    newId = ''
-    newName = ''
-    newCommand = ''
-    newArgs = ''
-    newCategory = 'system'
-    error = ''
+  function parseArgs(s: string): string[] {
+    return s
+      .split(',')
+      .map((x) => x.trim())
+      .filter(Boolean)
   }
 
   async function addTool(): Promise<void> {
-    if (!newId.trim() || !newName.trim() || !newCommand.trim()) {
+    if (!newDraft.id.trim() || !newDraft.name.trim() || !newDraft.command.trim()) {
       error = 'ID, name, and command are required'
       return
     }
-    if (getTools().some((t) => t.id === newId.trim())) {
+    if (getTools().some((t) => t.id === newDraft.id.trim())) {
       error = 'Tool ID already exists'
       return
     }
 
     try {
       await window.api.addCustomTool({
-        id: newId.trim(),
-        name: newName.trim(),
-        command: newCommand.trim(),
-        args: newArgs
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean),
-        category: newCategory,
+        id: newDraft.id.trim(),
+        name: newDraft.name.trim(),
+        command: newDraft.command.trim(),
+        args: parseArgs(newDraft.args),
+        category: newDraft.category,
       })
-      resetNewForm()
+      newDraft = emptyDraft()
+      error = ''
       showForm = false
     } catch (e) {
       error = e instanceof Error ? e.message : String(e)
     }
+  }
+
+  function cancelAdd(): void {
+    newDraft = emptyDraft()
+    error = ''
+    showForm = false
   }
 
   async function removeTool(id: string, name: string): Promise<void> {
@@ -85,10 +85,13 @@
     category: string
   }): void {
     editingId = tool.id
-    editName = tool.name
-    editCommand = tool.command
-    editArgs = tool.args.join(', ')
-    editCategory = tool.category
+    editDraft = {
+      id: tool.id,
+      name: tool.name,
+      command: tool.command,
+      args: tool.args.join(', '),
+      category: tool.category,
+    }
     editError = ''
   }
 
@@ -99,20 +102,17 @@
 
   async function saveEdit(): Promise<void> {
     if (!editingId) return
-    if (!editName.trim() || !editCommand.trim()) {
+    if (!editDraft.name.trim() || !editDraft.command.trim()) {
       editError = 'Name and command are required'
       return
     }
 
     try {
       await window.api.updateCustomTool(editingId, {
-        name: editName.trim(),
-        command: editCommand.trim(),
-        args: editArgs
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean),
-        category: editCategory,
+        name: editDraft.name.trim(),
+        command: editDraft.command.trim(),
+        args: parseArgs(editDraft.args),
+        category: editDraft.category,
       })
       editingId = null
       editError = ''
@@ -135,69 +135,13 @@
     <div class="flex flex-col">
       {#each getTools() as tool (tool.id)}
         {#if editingId === tool.id}
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <div
-            class="flex flex-col gap-2 p-3 my-1 border border-border rounded-md bg-bg-input"
-            onkeydown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                saveEdit()
-              }
-              if (e.key === 'Escape') cancelEdit()
-            }}
-          >
-            <div
-              class="flex items-center gap-2 text-2xs uppercase tracking-caps-tight text-text-faint"
-            >
-              <span>Editing</span>
-              <code class="font-mono text-text-muted normal-case tracking-normal">{tool.id}</code>
-            </div>
-            <input
-              class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
-              name="editName"
-              aria-label="Display name"
-              bind:value={editName}
-              placeholder="Display name"
-              spellcheck="false"
-            />
-            <input
-              class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
-              name="editCommand"
-              aria-label="Command"
-              bind:value={editCommand}
-              placeholder="Command (binary name)"
-              spellcheck="false"
-            />
-            <input
-              class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
-              name="editArgs"
-              aria-label="Args"
-              bind:value={editArgs}
-              placeholder="Args (comma-separated)"
-              spellcheck="false"
-            />
-            <CustomSelect
-              value={editCategory}
-              options={categoryOptions}
-              maxWidth="100%"
-              onchange={(v) => (editCategory = v)}
-            />
-            {#if editError}
-              <p class="text-sm text-danger-text m-0">{editError}</p>
-            {/if}
-            <div class="flex justify-end gap-2">
-              <button
-                type="button"
-                class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
-                onclick={cancelEdit}>Cancel</button
-              >
-              <button
-                type="button"
-                class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
-                onclick={saveEdit}>Save</button
-              >
-            </div>
-          </div>
+          <ToolForm
+            bind:draft={editDraft}
+            mode="edit"
+            error={editError}
+            onCancel={cancelEdit}
+            onSubmit={saveEdit}
+          />
         {:else}
           <div
             class="group/tool flex items-center gap-3 py-2 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
@@ -242,77 +186,7 @@
     </div>
 
     {#if showForm}
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="flex flex-col gap-2 p-3 mt-3 border border-border rounded-md bg-bg-input"
-        onkeydown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault()
-            addTool()
-          }
-          if (e.key === 'Escape') {
-            showForm = false
-            resetNewForm()
-          }
-        }}
-      >
-        <input
-          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
-          name="newId"
-          aria-label="Tool ID"
-          bind:value={newId}
-          placeholder="ID (e.g. my-tool)"
-          spellcheck="false"
-        />
-        <input
-          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
-          name="newName"
-          aria-label="Display name"
-          bind:value={newName}
-          placeholder="Display name"
-          spellcheck="false"
-        />
-        <input
-          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
-          name="newCommand"
-          aria-label="Command"
-          bind:value={newCommand}
-          placeholder="Command (binary name)"
-          spellcheck="false"
-        />
-        <input
-          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
-          name="newArgs"
-          aria-label="Args"
-          bind:value={newArgs}
-          placeholder="Args (comma-separated)"
-          spellcheck="false"
-        />
-        <CustomSelect
-          value={newCategory}
-          options={categoryOptions}
-          maxWidth="100%"
-          onchange={(v) => (newCategory = v)}
-        />
-        {#if error}
-          <p class="text-sm text-danger-text m-0">{error}</p>
-        {/if}
-        <div class="flex justify-end gap-2">
-          <button
-            type="button"
-            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
-            onclick={() => {
-              showForm = false
-              resetNewForm()
-            }}>Cancel</button
-          >
-          <button
-            type="button"
-            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
-            onclick={addTool}>Add tool</button
-          >
-        </div>
-      </div>
+      <ToolForm bind:draft={newDraft} mode="add" {error} onCancel={cancelAdd} onSubmit={addTool} />
     {:else}
       <button
         type="button"

--- a/src/renderer/src/components/preferences/UpdatePrefs.svelte
+++ b/src/renderer/src/components/preferences/UpdatePrefs.svelte
@@ -132,11 +132,13 @@
         >
           {checkState === 'checking' ? 'Checking…' : 'Check now'}
         </button>
-        {#if checkState === 'up-to-date'}
-          <span class="text-sm text-success">You're up to date</span>
-        {:else if checkState === 'error'}
-          <span class="text-sm text-danger">Check failed</span>
-        {/if}
+        <span class="text-sm" role="status" aria-live="polite">
+          {#if checkState === 'up-to-date'}
+            <span class="text-success">You're up to date</span>
+          {:else if checkState === 'error'}
+            <span class="text-danger">Check failed</span>
+          {/if}
+        </span>
       </div>
     </PrefsRow>
   </PrefsSection>

--- a/src/renderer/src/components/preferences/UpdatePrefs.svelte
+++ b/src/renderer/src/components/preferences/UpdatePrefs.svelte
@@ -3,6 +3,8 @@
   import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
 
   let autoUpdate = $derived(prefs['update.autoUpdate'] !== 'false')
   let channel = $derived(prefs['update.channel'] || 'stable')
@@ -70,60 +72,72 @@
   })
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Updates</h3>
-
-  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-    <CustomCheckbox checked={autoUpdate} onchange={toggleAutoUpdate} />
-    <span>Automatically download and install updates</span>
-  </label>
-
-  <div class="flex items-center gap-3 text-md">
-    <span class="text-text min-w-40">Update channel</span>
-    <CustomSelect
-      value={channel}
-      options={[
-        { value: 'stable', label: 'Stable' },
-        { value: 'next', label: 'Pre-release' },
-      ]}
-      onchange={setChannel}
-      maxWidth="180px"
-    />
-  </div>
-  <div class="text-xs text-text-muted leading-normal -mt-2">
-    Stable gets tested releases. Pre-release includes newest features but may have bugs
-  </div>
-
-  <div class="flex items-center gap-3 text-md">
-    <span class="text-text min-w-40">Check frequency</span>
-    <CustomSelect
-      value={checkFrequency}
-      options={[
-        { value: 'hourly', label: 'Every hour' },
-        { value: 'daily', label: 'Every day' },
-        { value: 'weekly', label: 'Every week' },
-        { value: 'never', label: 'Never (manual only)' },
-      ]}
-      onchange={setCheckFrequency}
-      maxWidth="180px"
-    />
-  </div>
-  <div class="text-xs text-text-muted leading-normal -mt-2">
-    How often the app checks for new versions in the background
-  </div>
-
-  <div class="flex items-center gap-3">
-    <button
-      class="px-3.5 py-1.5 border border-text-faint rounded-lg bg-hover text-text text-md font-inherit cursor-pointer transition-colors duration-fast enabled:hover:bg-hover-strong disabled:opacity-50 disabled:cursor-default"
-      onclick={checkNow}
-      disabled={checkState === 'checking'}
+<div class="flex flex-col gap-7">
+  <PrefsSection title="Automatic updates">
+    <PrefsRow
+      label="Download and install automatically"
+      help="Updates are fetched in the background and applied on the next restart"
+      search="auto download install background"
     >
-      {checkState === 'checking' ? 'Checking...' : 'Check for updates'}
-    </button>
-    {#if checkState === 'up-to-date'}
-      <span class="text-sm text-success">You're up to date</span>
-    {:else if checkState === 'error'}
-      <span class="text-sm text-danger">Check failed</span>
-    {/if}
-  </div>
+      <CustomCheckbox checked={autoUpdate} onchange={toggleAutoUpdate} />
+    </PrefsRow>
+
+    <PrefsRow
+      label="Update channel"
+      help="Stable receives tested releases. Pre-release includes the newest features but may have bugs."
+      search="channel stable next pre-release beta"
+    >
+      <CustomSelect
+        value={channel}
+        options={[
+          { value: 'stable', label: 'Stable' },
+          { value: 'next', label: 'Pre-release' },
+        ]}
+        onchange={setChannel}
+        maxWidth="180px"
+      />
+    </PrefsRow>
+
+    <PrefsRow
+      label="Check frequency"
+      help="How often the app checks for new versions in the background"
+      search="check frequency hourly daily weekly never manual"
+    >
+      <CustomSelect
+        value={checkFrequency}
+        options={[
+          { value: 'hourly', label: 'Every hour' },
+          { value: 'daily', label: 'Every day' },
+          { value: 'weekly', label: 'Every week' },
+          { value: 'never', label: 'Never (manual only)' },
+        ]}
+        onchange={setCheckFrequency}
+        maxWidth="180px"
+      />
+    </PrefsRow>
+  </PrefsSection>
+
+  <PrefsSection title="Manual check">
+    <PrefsRow
+      label="Check for updates"
+      help="Run a one-off check against the current channel"
+      search="check now manual update"
+    >
+      <div class="flex items-center gap-3">
+        <button
+          type="button"
+          class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-border-subtle text-text-secondary hover:bg-active hover:text-text disabled:opacity-50 disabled:cursor-default"
+          onclick={checkNow}
+          disabled={checkState === 'checking'}
+        >
+          {checkState === 'checking' ? 'Checking…' : 'Check now'}
+        </button>
+        {#if checkState === 'up-to-date'}
+          <span class="text-sm text-success">You're up to date</span>
+        {:else if checkState === 'error'}
+          <span class="text-sm text-danger">Check failed</span>
+        {/if}
+      </div>
+    </PrefsRow>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/ViewportsPrefs.svelte
+++ b/src/renderer/src/components/preferences/ViewportsPrefs.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
+  import { Eye, EyeOff, Plus, Trash2 } from '@lucide/svelte'
   import {
     DEFAULT_VIEWPORTS,
     getCustomViewports,
@@ -9,8 +11,9 @@
   import { confirm } from '../../lib/stores/dialogs.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
-  import { onMount } from 'svelte'
-  import { Eye, EyeOff } from 'lucide-svelte'
+  import PrefsSection from './_partials/PrefsSection.svelte'
+  import PrefsRow from './_partials/PrefsRow.svelte'
+  import { prefsSearch, matches } from './_partials/prefsSearch.svelte'
 
   let urlOpenMode = $derived(prefs.urlOpenMode || 'ask')
 
@@ -63,6 +66,9 @@
 
   onMount(() => {
     loadCredentials()
+    return () => {
+      if (revealTimer) clearTimeout(revealTimer)
+    }
   })
 
   let showForm = $state(false)
@@ -72,6 +78,15 @@
   let newScale = $state(2)
   let newMobile = $state(true)
   let error = $state('')
+
+  function resetForm(): void {
+    newName = ''
+    newWidth = 390
+    newHeight = 844
+    newScale = 2
+    newMobile = true
+    error = ''
+  }
 
   function addViewport(): void {
     const name = newName.trim()
@@ -93,18 +108,13 @@
       [name]: { width: newWidth, height: newHeight, scaleFactor: newScale, mobile: newMobile },
     }
     saveCustomViewports(updated)
-    newName = ''
-    newWidth = 390
-    newHeight = 844
-    newScale = 2
-    newMobile = true
+    resetForm()
     showForm = false
-    error = ''
   }
 
   async function removeViewport(name: string): Promise<void> {
     const ok = await confirm({
-      title: 'Remove Viewport',
+      title: 'Remove viewport',
       message: `Remove custom viewport "${name}"?`,
       confirmLabel: 'Remove',
       destructive: true,
@@ -116,185 +126,225 @@
     }
     saveCustomViewports(updated)
   }
+
+  function viewportVisible(name: string, preset: ViewportPreset): boolean {
+    if (prefsSearch.query.trim() === '') return true
+    return matches(`${name} ${preset.width} ${preset.height} ${preset.mobile ? 'mobile' : ''}`)
+  }
+
+  function credentialVisible(cred: { domain: string; username: string; title: string }): boolean {
+    if (prefsSearch.query.trim() === '') return true
+    return matches(`${cred.domain} ${cred.username} ${cred.title}`)
+  }
 </script>
 
-<div class="flex flex-col gap-4">
-  <h3 class="text-[15px] font-semibold text-text m-0">Web Browser</h3>
-
-  <div class="flex items-center gap-3 text-md">
-    <span class="text-text-secondary min-w-40">Open external URLs in</span>
-    <CustomSelect
-      value={urlOpenMode}
-      options={[
-        { value: 'ask', label: 'Always ask' },
-        { value: 'canopy', label: 'Canopy Browser' },
-        { value: 'system', label: 'System browser' },
-      ]}
-      onchange={(v) => setPref('urlOpenMode', v)}
-      maxWidth="180px"
-    />
-  </div>
-  <div class="text-xs text-text-muted leading-normal -mt-2">
-    Where to open links clicked in terminal output or <code>target="_blank"</code> links from the browser
-    pane
-  </div>
-
-  <h4 class="text-md font-semibold text-text-secondary m-0 uppercase tracking-[0.5px]">
-    Default Viewports
-  </h4>
-
-  <div class="flex flex-col gap-1">
-    {#each Object.entries(DEFAULT_VIEWPORTS) as [name, preset] (name)}
-      <div class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg bg-border-subtle text-md">
-        <span class="text-text min-w-[140px]">{name}</span>
-        <span class="text-text-muted font-mono text-sm min-w-20"
-          >{preset.width}&times;{preset.height}</span
-        >
-        <span class="text-text-faint text-xs min-w-6">{preset.scaleFactor}x</span>
-        {#if preset.mobile}
-          <span class="text-2xs text-accent-text uppercase tracking-[0.5px]">mobile</span>
-        {/if}
-        <span class="ml-auto text-2xs text-text-faint">built-in</span>
-      </div>
-    {/each}
-  </div>
-
-  <h4 class="text-md font-semibold text-text-secondary m-0 uppercase tracking-[0.5px]">
-    Custom Viewports
-  </h4>
-
-  <div class="flex flex-col gap-1">
-    {#each Object.entries(getCustomViewports()) as [name, preset] (name)}
-      <div class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg bg-border-subtle text-md">
-        <span class="text-text min-w-[140px]">{name}</span>
-        <span class="text-text-muted font-mono text-sm min-w-20"
-          >{preset.width}&times;{preset.height}</span
-        >
-        <span class="text-text-faint text-xs min-w-6">{preset.scaleFactor}x</span>
-        {#if preset.mobile}
-          <span class="text-2xs text-accent-text uppercase tracking-[0.5px]">mobile</span>
-        {/if}
-        <button
-          class="ml-auto px-2 py-0.5 border-0 rounded-md bg-danger-bg text-danger-text text-xs font-inherit cursor-pointer"
-          onclick={() => removeViewport(name)}>Remove</button
-        >
-      </div>
-    {:else}
-      <p class="text-sm text-text-faint m-0 px-2.5 py-1">No custom viewports yet</p>
-    {/each}
-  </div>
-
-  {#if showForm}
-    <div class="flex flex-col gap-2 p-3 border border-border rounded-xl bg-border-subtle">
-      <input
-        class="px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-        bind:value={newName}
-        placeholder="Viewport name"
-      />
-      <div class="flex items-center gap-2">
-        <input
-          class="w-20 px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-          type="number"
-          bind:value={newWidth}
-          min="1"
-        />
-        <span class="text-text-faint text-md">&times;</span>
-        <input
-          class="w-20 px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-          type="number"
-          bind:value={newHeight}
-          min="1"
-        />
-        <span class="text-text-faint text-sm ml-2">Scale</span>
-        <input
-          class="w-15 px-2.5 py-1.5 border border-border rounded-lg bg-hover text-text text-md font-inherit outline-none focus:border-focus-ring"
-          type="number"
-          bind:value={newScale}
-          min="0.5"
-          step="0.5"
-        />
-      </div>
-      <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-        <CustomCheckbox checked={newMobile} onchange={(v) => (newMobile = v)} />
-        <span>Mobile device</span>
-      </label>
-      {#if error}
-        <p class="text-sm text-danger m-0">{error}</p>
-      {/if}
-      <div class="flex justify-end gap-2">
-        <button
-          class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-active text-text"
-          onclick={() => (showForm = false)}>Cancel</button
-        >
-        <button
-          class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
-          onclick={addViewport}>Add Viewport</button
-        >
-      </div>
-    </div>
-  {:else}
-    <button
-      class="self-start px-3.5 py-1.5 border border-dashed border-text-faint rounded-lg bg-transparent text-text-secondary text-md font-inherit cursor-pointer hover:bg-hover hover:text-text"
-      onclick={() => (showForm = true)}
+<div class="flex flex-col gap-7">
+  <PrefsSection title="External URLs">
+    <PrefsRow
+      label="Open external URLs in"
+      help="Where to open links clicked in terminal output or new-window links from the browser pane"
+      search="external url open canopy system browser ask"
     >
-      + Add Custom Viewport
-    </button>
-  {/if}
+      <CustomSelect
+        value={urlOpenMode}
+        options={[
+          { value: 'ask', label: 'Always ask' },
+          { value: 'canopy', label: 'Canopy browser' },
+          { value: 'system', label: 'System browser' },
+        ]}
+        onchange={(v) => setPref('urlOpenMode', v)}
+        maxWidth="200px"
+      />
+    </PrefsRow>
+  </PrefsSection>
 
-  <h4 class="text-md font-semibold text-text-secondary m-0 uppercase tracking-[0.5px]">
-    Saved Passwords
-  </h4>
-
-  <div class="flex flex-col gap-1">
-    {#each credentials as cred (cred.id)}
-      <div class="flex flex-col gap-1 px-2.5 py-2 rounded-lg bg-border-subtle">
-        <div class="flex items-baseline gap-2 min-w-0">
-          <span
-            class="text-md font-medium text-text whitespace-nowrap overflow-hidden text-ellipsis"
-            >{cred.domain}</span
+  <PrefsSection title="Default viewports" description="Built-in device presets">
+    <div class="flex flex-col">
+      {#each Object.entries(DEFAULT_VIEWPORTS) as [name, preset] (name)}
+        <div
+          class="flex items-center gap-3 py-2 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
+          class:opacity-30={!viewportVisible(name, preset)}
+        >
+          <span class="text-md text-text min-w-35 truncate">{name}</span>
+          <span class="text-sm text-text-secondary font-mono min-w-20"
+            >{preset.width}×{preset.height}</span
           >
-          {#if cred.title}
+          <span class="text-xs text-text-faint font-mono w-8">{preset.scaleFactor}x</span>
+          {#if preset.mobile}
             <span
-              class="text-xs text-text-faint whitespace-nowrap overflow-hidden text-ellipsis min-w-0"
-              >{cred.title}</span
+              class="text-2xs uppercase tracking-caps-tight px-1.5 py-px rounded-sm bg-accent-bg text-accent-text"
+              >mobile</span
             >
           {/if}
+          <span class="ml-auto text-2xs uppercase tracking-caps-tight text-text-faint"
+            >built-in</span
+          >
         </div>
-        <div class="flex items-center gap-2">
-          <span
-            class="text-sm text-text-secondary whitespace-nowrap overflow-hidden text-ellipsis min-w-0 flex-1"
-            >{cred.username}</span
+      {/each}
+    </div>
+  </PrefsSection>
+
+  <PrefsSection title="Custom viewports" description="Add your own device presets">
+    <div class="flex flex-col">
+      {#each Object.entries(getCustomViewports()) as [name, preset] (name)}
+        <div
+          class="flex items-center gap-3 py-2 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
+          class:opacity-30={!viewportVisible(name, preset)}
+        >
+          <span class="text-md text-text min-w-35 truncate">{name}</span>
+          <span class="text-sm text-text-secondary font-mono min-w-20"
+            >{preset.width}×{preset.height}</span
           >
-          <span class="flex-shrink-0">
-            {#if revealedId === cred.id}
-              <code class="text-xs text-text bg-hover px-1 py-px rounded-sm"
-                >{revealedPassword}</code
-              >
-            {:else}
-              <span class="text-text-faint text-sm tracking-[1px]"
-                >&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;</span
-              >
-            {/if}
-          </span>
+          <span class="text-xs text-text-faint font-mono w-8">{preset.scaleFactor}x</span>
+          {#if preset.mobile}
+            <span
+              class="text-2xs uppercase tracking-caps-tight px-1.5 py-px rounded-sm bg-accent-bg text-accent-text"
+              >mobile</span
+            >
+          {/if}
           <button
-            class="px-1 py-0.5 border-0 rounded-md bg-transparent text-text-muted cursor-pointer flex items-center hover:text-text hover:bg-hover"
-            onclick={() => revealPassword(cred.id, cred.domain)}
-            title={revealedId === cred.id ? 'Hide password' : 'Show password (5s)'}
+            type="button"
+            class="ml-auto flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-danger-bg hover:text-danger-text"
+            onclick={() => removeViewport(name)}
+            aria-label="Remove {name}"
+            title="Remove"
           >
-            {#if revealedId === cred.id}
-              <EyeOff size={13} />
-            {:else}
-              <Eye size={13} />
-            {/if}
+            <Trash2 size={13} />
           </button>
+        </div>
+      {:else}
+        <p class="text-sm text-text-faint m-0 py-2">No custom viewports yet</p>
+      {/each}
+    </div>
+
+    {#if showForm}
+      <div class="flex flex-col gap-2 p-3 mt-3 border border-border rounded-md bg-bg-input">
+        <input
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="newViewportName"
+          aria-label="Viewport name"
+          bind:value={newName}
+          placeholder="Viewport name"
+          spellcheck="false"
+        />
+        <div class="flex items-center gap-2 flex-wrap">
+          <input
+            class="w-20 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring"
+            type="number"
+            name="newWidth"
+            aria-label="Width"
+            bind:value={newWidth}
+            min="1"
+          />
+          <span class="text-text-faint text-md">×</span>
+          <input
+            class="w-20 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring"
+            type="number"
+            name="newHeight"
+            aria-label="Height"
+            bind:value={newHeight}
+            min="1"
+          />
+          <span class="text-xs text-text-faint ml-2">Scale</span>
+          <input
+            class="w-15 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring"
+            type="number"
+            name="newScale"
+            aria-label="Scale factor"
+            bind:value={newScale}
+            min="0.5"
+            step="0.5"
+          />
+        </div>
+        <label class="flex items-center gap-2 text-md text-text cursor-pointer">
+          <CustomCheckbox checked={newMobile} onchange={(v) => (newMobile = v)} />
+          <span>Mobile device</span>
+        </label>
+        {#if error}
+          <p class="text-sm text-danger-text m-0">{error}</p>
+        {/if}
+        <div class="flex justify-end gap-2">
           <button
-            class="ml-auto px-2 py-0.5 border-0 rounded-md bg-danger-bg text-danger-text text-xs font-inherit cursor-pointer"
-            onclick={() => deleteCredential(cred.id, cred.domain, cred.username)}>Remove</button
+            type="button"
+            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
+            onclick={() => {
+              showForm = false
+              resetForm()
+            }}>Cancel</button
+          >
+          <button
+            type="button"
+            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
+            onclick={addViewport}>Add viewport</button
           >
         </div>
       </div>
     {:else}
-      <p class="text-sm text-text-faint m-0 px-2.5 py-1">No saved passwords</p>
-    {/each}
-  </div>
+      <button
+        type="button"
+        class="self-start flex items-center gap-1 px-3 py-1 mt-3 rounded-md bg-border-subtle border border-border text-text-secondary text-sm font-inherit cursor-pointer hover:bg-active hover:text-text"
+        onclick={() => (showForm = true)}
+      >
+        <Plus size={12} />
+        <span>Add custom viewport</span>
+      </button>
+    {/if}
+  </PrefsSection>
+
+  <PrefsSection
+    title="Saved passwords"
+    description="Browser-pane credentials stored encrypted via Electron safeStorage"
+  >
+    <div class="flex flex-col gap-1">
+      {#each credentials as cred (cred.id)}
+        <div
+          class="flex flex-col gap-1 px-3 py-2 rounded-md bg-bg-input border border-border-subtle transition-opacity duration-fast"
+          class:opacity-30={!credentialVisible(cred)}
+        >
+          <div class="flex items-baseline gap-2 min-w-0">
+            <span class="text-md text-text truncate">{cred.domain}</span>
+            {#if cred.title}
+              <span class="text-xs text-text-faint truncate">{cred.title}</span>
+            {/if}
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="text-sm text-text-secondary truncate flex-1">{cred.username}</span>
+            <span class="shrink-0">
+              {#if revealedId === cred.id}
+                <code class="text-xs text-text bg-bg px-1 py-px rounded-sm font-mono"
+                  >{revealedPassword}</code
+                >
+              {:else}
+                <span class="text-text-faint text-sm tracking-wider">••••••••</span>
+              {/if}
+            </span>
+            <button
+              type="button"
+              class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-hover hover:text-text"
+              onclick={() => revealPassword(cred.id, cred.domain)}
+              title={revealedId === cred.id ? 'Hide password' : 'Show password (5s)'}
+              aria-label={revealedId === cred.id ? 'Hide password' : 'Show password'}
+            >
+              {#if revealedId === cred.id}
+                <EyeOff size={13} />
+              {:else}
+                <Eye size={13} />
+              {/if}
+            </button>
+            <button
+              type="button"
+              class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-danger-bg hover:text-danger-text"
+              onclick={() => deleteCredential(cred.id, cred.domain, cred.username)}
+              aria-label="Remove credential for {cred.username}"
+              title="Remove"
+            >
+              <Trash2 size={13} />
+            </button>
+          </div>
+        </div>
+      {:else}
+        <p class="text-sm text-text-faint m-0 py-2">No saved passwords</p>
+      {/each}
+    </div>
+  </PrefsSection>
 </div>

--- a/src/renderer/src/components/preferences/ViewportsPrefs.svelte
+++ b/src/renderer/src/components/preferences/ViewportsPrefs.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
-  import { Eye, EyeOff, Plus, Trash2 } from '@lucide/svelte'
+  import { Plus, Trash2 } from '@lucide/svelte'
   import {
     DEFAULT_VIEWPORTS,
     getCustomViewports,
@@ -10,107 +9,14 @@
   import { prefs, setPref } from '../../lib/stores/preferences.svelte'
   import { confirm } from '../../lib/stores/dialogs.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
-  import CustomCheckbox from '../shared/CustomCheckbox.svelte'
   import PrefsSection from './_partials/PrefsSection.svelte'
   import PrefsRow from './_partials/PrefsRow.svelte'
+  import CustomViewportForm from './_partials/CustomViewportForm.svelte'
+  import SavedPasswordsSection from './_partials/SavedPasswordsSection.svelte'
   import { prefsSearch, matches } from './_partials/prefsSearch.svelte'
 
   let urlOpenMode = $derived(prefs.urlOpenMode || 'ask')
-
-  let credentials: Array<{
-    id: string
-    domain: string
-    username: string
-    title: string
-    createdAt: string
-    updatedAt: string
-  }> = $state([])
-  let revealedId: string | null = $state(null)
-  let revealedPassword = $state('')
-  let revealTimer: ReturnType<typeof setTimeout> | null = null
-
-  async function loadCredentials(): Promise<void> {
-    credentials = await window.api.listCredentials()
-  }
-
-  async function deleteCredential(id: string, domain: string, username: string): Promise<void> {
-    const ok = await confirm({
-      title: 'Delete saved password',
-      message: `Delete the saved password for ${username} on ${domain}? This cannot be undone.`,
-      confirmLabel: 'Delete',
-      destructive: true,
-    })
-    if (!ok) return
-    await window.api.deleteCredential(id)
-    await loadCredentials()
-  }
-
-  async function revealPassword(id: string, domain: string): Promise<void> {
-    if (revealedId === id) {
-      revealedId = null
-      revealedPassword = ''
-      if (revealTimer) clearTimeout(revealTimer)
-      return
-    }
-    const cred = await window.api.getCredentialDecrypted(id, domain, 'reveal')
-    if (cred) {
-      revealedId = id
-      revealedPassword = cred.password
-      if (revealTimer) clearTimeout(revealTimer)
-      revealTimer = setTimeout(() => {
-        revealedId = null
-        revealedPassword = ''
-      }, 5000)
-    }
-  }
-
-  onMount(() => {
-    loadCredentials()
-    return () => {
-      if (revealTimer) clearTimeout(revealTimer)
-    }
-  })
-
   let showForm = $state(false)
-  let newName = $state('')
-  let newWidth = $state(390)
-  let newHeight = $state(844)
-  let newScale = $state(2)
-  let newMobile = $state(true)
-  let error = $state('')
-
-  function resetForm(): void {
-    newName = ''
-    newWidth = 390
-    newHeight = 844
-    newScale = 2
-    newMobile = true
-    error = ''
-  }
-
-  function addViewport(): void {
-    const name = newName.trim()
-    if (!name) {
-      error = 'Name is required'
-      return
-    }
-    if (name in DEFAULT_VIEWPORTS || name in getCustomViewports()) {
-      error = 'Viewport name already exists'
-      return
-    }
-    if (newWidth < 1 || newHeight < 1) {
-      error = 'Width and height must be positive'
-      return
-    }
-
-    const updated = {
-      ...getCustomViewports(),
-      [name]: { width: newWidth, height: newHeight, scaleFactor: newScale, mobile: newMobile },
-    }
-    saveCustomViewports(updated)
-    resetForm()
-    showForm = false
-  }
 
   async function removeViewport(name: string): Promise<void> {
     const ok = await confirm({
@@ -130,11 +36,6 @@
   function viewportVisible(name: string, preset: ViewportPreset): boolean {
     if (prefsSearch.query.trim() === '') return true
     return matches(`${name} ${preset.width} ${preset.height} ${preset.mobile ? 'mobile' : ''}`)
-  }
-
-  function credentialVisible(cred: { domain: string; username: string; title: string }): boolean {
-    if (prefsSearch.query.trim() === '') return true
-    return matches(`${cred.domain} ${cred.username} ${cred.title}`)
   }
 </script>
 
@@ -218,67 +119,7 @@
     </div>
 
     {#if showForm}
-      <div class="flex flex-col gap-2 p-3 mt-3 border border-border rounded-md bg-bg-input">
-        <input
-          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
-          name="newViewportName"
-          aria-label="Viewport name"
-          bind:value={newName}
-          placeholder="Viewport name"
-          spellcheck="false"
-        />
-        <div class="flex items-center gap-2 flex-wrap">
-          <input
-            class="w-20 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring"
-            type="number"
-            name="newWidth"
-            aria-label="Width"
-            bind:value={newWidth}
-            min="1"
-          />
-          <span class="text-text-faint text-md">×</span>
-          <input
-            class="w-20 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring"
-            type="number"
-            name="newHeight"
-            aria-label="Height"
-            bind:value={newHeight}
-            min="1"
-          />
-          <span class="text-xs text-text-faint ml-2">Scale</span>
-          <input
-            class="w-15 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring"
-            type="number"
-            name="newScale"
-            aria-label="Scale factor"
-            bind:value={newScale}
-            min="0.5"
-            step="0.5"
-          />
-        </div>
-        <label class="flex items-center gap-2 text-md text-text cursor-pointer">
-          <CustomCheckbox checked={newMobile} onchange={(v) => (newMobile = v)} />
-          <span>Mobile device</span>
-        </label>
-        {#if error}
-          <p class="text-sm text-danger-text m-0">{error}</p>
-        {/if}
-        <div class="flex justify-end gap-2">
-          <button
-            type="button"
-            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
-            onclick={() => {
-              showForm = false
-              resetForm()
-            }}>Cancel</button
-          >
-          <button
-            type="button"
-            class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
-            onclick={addViewport}>Add viewport</button
-          >
-        </div>
-      </div>
+      <CustomViewportForm onClose={() => (showForm = false)} />
     {:else}
       <button
         type="button"
@@ -291,60 +132,5 @@
     {/if}
   </PrefsSection>
 
-  <PrefsSection
-    title="Saved passwords"
-    description="Browser-pane credentials stored encrypted via Electron safeStorage"
-  >
-    <div class="flex flex-col gap-1">
-      {#each credentials as cred (cred.id)}
-        <div
-          class="flex flex-col gap-1 px-3 py-2 rounded-md bg-bg-input border border-border-subtle transition-opacity duration-fast"
-          class:opacity-30={!credentialVisible(cred)}
-        >
-          <div class="flex items-baseline gap-2 min-w-0">
-            <span class="text-md text-text truncate">{cred.domain}</span>
-            {#if cred.title}
-              <span class="text-xs text-text-faint truncate">{cred.title}</span>
-            {/if}
-          </div>
-          <div class="flex items-center gap-2">
-            <span class="text-sm text-text-secondary truncate flex-1">{cred.username}</span>
-            <span class="shrink-0">
-              {#if revealedId === cred.id}
-                <code class="text-xs text-text bg-bg px-1 py-px rounded-sm font-mono"
-                  >{revealedPassword}</code
-                >
-              {:else}
-                <span class="text-text-faint text-sm tracking-wider">••••••••</span>
-              {/if}
-            </span>
-            <button
-              type="button"
-              class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-hover hover:text-text"
-              onclick={() => revealPassword(cred.id, cred.domain)}
-              title={revealedId === cred.id ? 'Hide password' : 'Show password (5s)'}
-              aria-label={revealedId === cred.id ? 'Hide password' : 'Show password'}
-            >
-              {#if revealedId === cred.id}
-                <EyeOff size={13} />
-              {:else}
-                <Eye size={13} />
-              {/if}
-            </button>
-            <button
-              type="button"
-              class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-danger-bg hover:text-danger-text"
-              onclick={() => deleteCredential(cred.id, cred.domain, cred.username)}
-              aria-label="Remove credential for {cred.username}"
-              title="Remove"
-            >
-              <Trash2 size={13} />
-            </button>
-          </div>
-        </div>
-      {:else}
-        <p class="text-sm text-text-faint m-0 py-2">No saved passwords</p>
-      {/each}
-    </div>
-  </PrefsSection>
+  <SavedPasswordsSection />
 </div>

--- a/src/renderer/src/components/preferences/_partials/CustomViewportForm.svelte
+++ b/src/renderer/src/components/preferences/_partials/CustomViewportForm.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import CustomCheckbox from '../../shared/CustomCheckbox.svelte'
+  import {
+    DEFAULT_VIEWPORTS,
+    getCustomViewports,
+    saveCustomViewports,
+  } from '../../../lib/browser/browserState.svelte'
+
+  let { onClose }: { onClose: () => void } = $props()
+
+  let name = $state('')
+  let width = $state(390)
+  let height = $state(844)
+  let scale = $state(2)
+  let mobile = $state(true)
+  let error = $state('')
+
+  function reset(): void {
+    name = ''
+    width = 390
+    height = 844
+    scale = 2
+    mobile = true
+    error = ''
+  }
+
+  function add(): void {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      error = 'Name is required'
+      return
+    }
+    if (trimmed in DEFAULT_VIEWPORTS || trimmed in getCustomViewports()) {
+      error = 'Viewport name already exists'
+      return
+    }
+    if (width < 1 || height < 1) {
+      error = 'Width and height must be positive'
+      return
+    }
+
+    const updated = {
+      ...getCustomViewports(),
+      [trimmed]: { width, height, scaleFactor: scale, mobile },
+    }
+    saveCustomViewports(updated)
+    reset()
+    onClose()
+  }
+
+  function cancel(): void {
+    reset()
+    onClose()
+  }
+</script>
+
+<div class="flex flex-col gap-2 p-3 mt-3 border border-border rounded-md bg-bg-input">
+  <input
+    class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+    name="newViewportName"
+    aria-label="Viewport name"
+    bind:value={name}
+    placeholder="Viewport name"
+    spellcheck="false"
+  />
+  <div class="flex items-center gap-2 flex-wrap">
+    <input
+      class="w-20 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring"
+      type="number"
+      name="newWidth"
+      aria-label="Width"
+      bind:value={width}
+      min="1"
+    />
+    <span class="text-text-faint text-md">×</span>
+    <input
+      class="w-20 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring"
+      type="number"
+      name="newHeight"
+      aria-label="Height"
+      bind:value={height}
+      min="1"
+    />
+    <span class="text-xs text-text-faint ml-2">Scale</span>
+    <input
+      class="w-15 px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring"
+      type="number"
+      name="newScale"
+      aria-label="Scale factor"
+      bind:value={scale}
+      min="0.5"
+      step="0.5"
+    />
+  </div>
+  <label class="flex items-center gap-2 text-md text-text cursor-pointer">
+    <CustomCheckbox checked={mobile} onchange={(v) => (mobile = v)} />
+    <span>Mobile device</span>
+  </label>
+  {#if error}
+    <p class="text-sm text-danger-text m-0">{error}</p>
+  {/if}
+  <div class="flex justify-end gap-2">
+    <button
+      type="button"
+      class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
+      onclick={cancel}>Cancel</button
+    >
+    <button
+      type="button"
+      class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
+      onclick={add}>Add viewport</button
+    >
+  </div>
+</div>

--- a/src/renderer/src/components/preferences/_partials/PrefsHeader.svelte
+++ b/src/renderer/src/components/preferences/_partials/PrefsHeader.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import { Search, X } from '@lucide/svelte'
+  import { prefsSearch, setQuery, clearQuery } from './prefsSearch.svelte'
+
+  interface Props {
+    title: string
+    breadcrumb?: string
+    onclose: () => void
+    inputEl?: HTMLInputElement
+  }
+
+  let { title, breadcrumb, onclose, inputEl = $bindable() }: Props = $props()
+
+  const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent)
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape' && prefsSearch.query !== '') {
+      e.preventDefault()
+      e.stopPropagation()
+      clearQuery()
+      inputEl?.focus()
+    }
+  }
+</script>
+
+<div class="flex items-center gap-4 px-4 h-12 border-b border-border-subtle bg-bg-overlay shrink-0">
+  <div class="flex items-center gap-2 min-w-0 shrink-0 w-44">
+    <h2 id="prefs-dialog-title" class="text-md font-semibold text-text m-0 truncate">
+      {title}
+    </h2>
+    {#if breadcrumb}
+      <span class="text-text-faint shrink-0">/</span>
+      <span class="text-md text-text-secondary truncate">{breadcrumb}</span>
+    {/if}
+  </div>
+
+  <div class="flex-1 flex justify-center">
+    <div
+      class="relative flex items-center w-full max-w-sm h-7 rounded-md bg-bg-input border border-transparent focus-within:border-focus-ring transition-colors duration-fast"
+    >
+      <Search size={13} class="absolute left-2.5 text-text-faint pointer-events-none shrink-0" />
+      <input
+        bind:this={inputEl}
+        type="text"
+        placeholder="Search settings…"
+        aria-label="Search settings"
+        spellcheck="false"
+        autocomplete="off"
+        value={prefsSearch.query}
+        oninput={(e) => setQuery(e.currentTarget.value)}
+        onkeydown={handleKeydown}
+        class="w-full h-full pl-7 pr-12 bg-transparent border-0 outline-none text-md text-text placeholder:text-text-faint font-inherit"
+      />
+      <kbd
+        class="absolute right-2 text-2xs text-text-faint font-sans pointer-events-none select-none"
+      >
+        {isMac ? '⌘K' : 'Ctrl K'}
+      </kbd>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-1 shrink-0">
+    <button
+      type="button"
+      class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-hover hover:text-text"
+      aria-label="Close settings"
+      onclick={onclose}
+    >
+      <X size={16} />
+    </button>
+  </div>
+</div>

--- a/src/renderer/src/components/preferences/_partials/PrefsRow.svelte
+++ b/src/renderer/src/components/preferences/_partials/PrefsRow.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import { prefsSearch, matches } from './prefsSearch.svelte'
+
+  type BadgeTone = 'warning' | 'accent' | 'neutral' | 'danger'
+
+  interface Props {
+    label: string
+    help?: string
+    search?: string
+    layout?: 'inline' | 'stacked'
+    badge?: { text: string; tone?: BadgeTone }
+    children: Snippet
+  }
+
+  let { label, help, search, layout = 'inline', badge, children }: Props = $props()
+
+  const haystack = $derived(`${label} ${help ?? ''} ${search ?? ''}`)
+  const visible = $derived(prefsSearch.query.trim() === '' || matches(haystack))
+
+  const badgeClasses: Record<BadgeTone, string> = {
+    warning: 'bg-experimental-bg text-warning-text border border-experimental-border',
+    accent: 'bg-accent-bg text-accent-text',
+    neutral: 'bg-border-subtle text-text-muted',
+    danger: 'bg-danger-bg text-danger-text',
+  }
+</script>
+
+{#snippet labelBlock()}
+  <span class="flex items-center gap-1.5 flex-wrap">
+    <span class="text-md text-text leading-snug">{label}</span>
+    {#if badge}
+      <span
+        class="inline-flex items-center text-2xs font-semibold uppercase tracking-caps-tight px-1.5 py-px rounded-md {badgeClasses[
+          badge.tone ?? 'neutral'
+        ]}"
+      >
+        {badge.text}
+      </span>
+    {/if}
+  </span>
+{/snippet}
+
+{#if layout === 'inline'}
+  <div
+    class="flex items-start justify-between gap-6 py-3 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
+    class:opacity-30={!visible}
+  >
+    <div class="flex flex-col flex-1 min-w-0 gap-0.5">
+      {@render labelBlock()}
+      {#if help}
+        <span class="text-xs text-text-muted leading-snug max-w-[55ch]">{help}</span>
+      {/if}
+    </div>
+    <div class="shrink-0 pt-0.5">
+      {@render children()}
+    </div>
+  </div>
+{:else}
+  <div
+    class="flex flex-col gap-2 py-3 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
+    class:opacity-30={!visible}
+  >
+    <div class="flex flex-col gap-0.5">
+      {@render labelBlock()}
+      {#if help}
+        <span class="text-xs text-text-muted leading-snug max-w-[55ch]">{help}</span>
+      {/if}
+    </div>
+    <div>
+      {@render children()}
+    </div>
+  </div>
+{/if}

--- a/src/renderer/src/components/preferences/_partials/PrefsRow.svelte
+++ b/src/renderer/src/components/preferences/_partials/PrefsRow.svelte
@@ -15,6 +15,9 @@
 
   let { label, help, search, layout = 'inline', badge, children }: Props = $props()
 
+  const labelId = `prefs-row-label-${crypto.randomUUID()}`
+  const helpId = `prefs-row-help-${crypto.randomUUID()}`
+
   const haystack = $derived(`${label} ${help ?? ''} ${search ?? ''}`)
   const visible = $derived(prefsSearch.query.trim() === '' || matches(haystack))
 
@@ -27,7 +30,7 @@
 </script>
 
 {#snippet labelBlock()}
-  <span class="flex items-center gap-1.5 flex-wrap">
+  <span class="flex items-center gap-1.5 flex-wrap" id={labelId}>
     <span class="text-md text-text leading-snug">{label}</span>
     {#if badge}
       <span
@@ -45,14 +48,20 @@
   <div
     class="flex items-start justify-between gap-6 py-3 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
     class:opacity-30={!visible}
+    inert={!visible}
   >
     <div class="flex flex-col flex-1 min-w-0 gap-0.5">
       {@render labelBlock()}
       {#if help}
-        <span class="text-xs text-text-muted leading-snug max-w-[55ch]">{help}</span>
+        <span class="text-xs text-text-muted leading-snug max-w-[55ch]" id={helpId}>{help}</span>
       {/if}
     </div>
-    <div class="shrink-0 pt-0.5">
+    <div
+      class="shrink-0 pt-0.5"
+      role="group"
+      aria-labelledby={labelId}
+      aria-describedby={help ? helpId : undefined}
+    >
       {@render children()}
     </div>
   </div>
@@ -60,14 +69,15 @@
   <div
     class="flex flex-col gap-2 py-3 border-t border-border-subtle first:border-t-0 first:pt-0 transition-opacity duration-fast"
     class:opacity-30={!visible}
+    inert={!visible}
   >
     <div class="flex flex-col gap-0.5">
       {@render labelBlock()}
       {#if help}
-        <span class="text-xs text-text-muted leading-snug max-w-[55ch]">{help}</span>
+        <span class="text-xs text-text-muted leading-snug max-w-[55ch]" id={helpId}>{help}</span>
       {/if}
     </div>
-    <div>
+    <div role="group" aria-labelledby={labelId} aria-describedby={help ? helpId : undefined}>
       {@render children()}
     </div>
   </div>

--- a/src/renderer/src/components/preferences/_partials/PrefsSection.svelte
+++ b/src/renderer/src/components/preferences/_partials/PrefsSection.svelte
@@ -1,22 +1,43 @@
 <script lang="ts">
   import type { Snippet } from 'svelte'
 
+  type BadgeTone = 'warning' | 'accent' | 'neutral' | 'danger'
+
   interface Props {
     title: string
     description?: string
+    badge?: { text: string; tone?: BadgeTone }
     children: Snippet
   }
 
-  let { title, description, children }: Props = $props()
+  let { title, description, badge, children }: Props = $props()
+
+  const badgeClasses: Record<BadgeTone, string> = {
+    warning: 'bg-experimental-bg text-warning-text border border-experimental-border',
+    accent: 'bg-accent-bg text-accent-text',
+    neutral: 'bg-border-subtle text-text-muted',
+    danger: 'bg-danger-bg text-danger-text',
+  }
 </script>
 
 <section class="flex flex-col gap-3">
   <header class="flex flex-col gap-1">
-    <h3
-      class="text-2xs font-semibold uppercase tracking-caps-looser text-text-faint m-0 leading-tight"
-    >
-      {title}
-    </h3>
+    <div class="flex items-center gap-2">
+      <h3
+        class="text-2xs font-semibold uppercase tracking-caps-looser text-text-faint m-0 leading-tight"
+      >
+        {title}
+      </h3>
+      {#if badge}
+        <span
+          class="inline-flex items-center text-2xs font-semibold uppercase tracking-caps-tight px-1.5 py-px rounded-md leading-tight {badgeClasses[
+            badge.tone ?? 'neutral'
+          ]}"
+        >
+          {badge.text}
+        </span>
+      {/if}
+    </div>
     {#if description}
       <p class="text-xs text-text-muted leading-snug m-0 max-w-[60ch]">{description}</p>
     {/if}

--- a/src/renderer/src/components/preferences/_partials/PrefsSection.svelte
+++ b/src/renderer/src/components/preferences/_partials/PrefsSection.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    title: string
+    description?: string
+    children: Snippet
+  }
+
+  let { title, description, children }: Props = $props()
+</script>
+
+<section class="flex flex-col gap-3">
+  <header class="flex flex-col gap-1">
+    <h3
+      class="text-2xs font-semibold uppercase tracking-caps-looser text-text-faint m-0 leading-tight"
+    >
+      {title}
+    </h3>
+    {#if description}
+      <p class="text-xs text-text-muted leading-snug m-0 max-w-[60ch]">{description}</p>
+    {/if}
+  </header>
+  <div class="flex flex-col">
+    {@render children()}
+  </div>
+</section>

--- a/src/renderer/src/components/preferences/_partials/PrefsSidebar.svelte
+++ b/src/renderer/src/components/preferences/_partials/PrefsSidebar.svelte
@@ -16,6 +16,10 @@
   }
 
   let { groups, activeSection, onselect, footer }: Props = $props()
+
+  function slug(s: string): string {
+    return s.toLowerCase().replace(/\s+/g, '-')
+  }
 </script>
 
 <aside
@@ -23,9 +27,9 @@
 >
   <div class="flex-1 overflow-y-auto py-3 px-2 select-none">
     {#each groups as group, gi (group.label)}
-      <div role="group" aria-labelledby={`prefs-group-${group.label}`} class:mt-3={gi > 0}>
+      <div role="group" aria-labelledby={`prefs-group-${slug(group.label)}`} class:mt-3={gi > 0}>
         <span
-          id={`prefs-group-${group.label}`}
+          id={`prefs-group-${slug(group.label)}`}
           class="block px-2 pb-1 text-2xs font-semibold uppercase tracking-caps-looser text-text-faint"
         >
           {group.label}

--- a/src/renderer/src/components/preferences/_partials/PrefsSidebar.svelte
+++ b/src/renderer/src/components/preferences/_partials/PrefsSidebar.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import { sectionMeta, sectionMatches } from './sectionMeta'
+  import { prefsSearch } from './prefsSearch.svelte'
+
+  interface Group {
+    readonly label: string
+    readonly sections: readonly string[]
+  }
+
+  interface Props {
+    groups: readonly Group[]
+    activeSection: string
+    onselect: (section: string) => void
+    footer?: Snippet
+  }
+
+  let { groups, activeSection, onselect, footer }: Props = $props()
+</script>
+
+<aside
+  class="w-52 shrink-0 flex flex-col border-r border-border-subtle bg-bg-overlay overflow-hidden"
+>
+  <div class="flex-1 overflow-y-auto py-3 px-2 select-none">
+    {#each groups as group, gi (group.label)}
+      <div role="group" aria-labelledby={`prefs-group-${group.label}`} class:mt-3={gi > 0}>
+        <span
+          id={`prefs-group-${group.label}`}
+          class="block px-2 pb-1 text-2xs font-semibold uppercase tracking-caps-looser text-text-faint"
+        >
+          {group.label}
+        </span>
+        <div class="flex flex-col gap-px">
+          {#each group.sections as section (section)}
+            {@const meta = sectionMeta[section]}
+            {@const Icon = meta?.icon}
+            {@const dimmed =
+              prefsSearch.query.trim() !== '' && !sectionMatches(section, prefsSearch.query)}
+            {@const active = activeSection === section}
+            <button
+              type="button"
+              aria-current={active ? 'page' : undefined}
+              class="group relative flex items-center gap-2 w-full pl-3 pr-2 py-1.5 border-0 text-md font-inherit text-left cursor-pointer rounded-md outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
+              class:bg-active={active}
+              class:text-text={active}
+              class:bg-transparent={!active}
+              class:text-text-secondary={!active}
+              class:hover:bg-hover={!active}
+              class:hover:text-text={!active}
+              class:opacity-40={dimmed && !active}
+              onclick={() => onselect(section)}
+            >
+              {#if active}
+                <span
+                  aria-hidden="true"
+                  class="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-4 bg-accent rounded-r-sm"
+                ></span>
+              {/if}
+              {#if Icon}
+                <Icon size={14} class="shrink-0 {active ? 'text-accent' : 'text-text-muted'}" />
+              {/if}
+              <span class="truncate">{section}</span>
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  {#if footer}
+    <div class="border-t border-border-subtle px-2 py-2 shrink-0">
+      {@render footer()}
+    </div>
+  {/if}
+</aside>

--- a/src/renderer/src/components/preferences/_partials/SavedPasswordsSection.svelte
+++ b/src/renderer/src/components/preferences/_partials/SavedPasswordsSection.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { Eye, EyeOff, Trash2 } from '@lucide/svelte'
+  import { confirm } from '../../../lib/stores/dialogs.svelte'
+  import PrefsSection from './PrefsSection.svelte'
+  import { prefsSearch, matches } from './prefsSearch.svelte'
+
+  interface Credential {
+    id: string
+    domain: string
+    username: string
+    title: string
+    createdAt: string
+    updatedAt: string
+  }
+
+  let credentials: Credential[] = $state([])
+  let revealedId: string | null = $state(null)
+  let revealedPassword = $state('')
+  let revealTimer: ReturnType<typeof setTimeout> | null = null
+
+  async function loadCredentials(): Promise<void> {
+    credentials = await window.api.listCredentials()
+  }
+
+  async function deleteCredential(id: string, domain: string, username: string): Promise<void> {
+    const ok = await confirm({
+      title: 'Delete saved password',
+      message: `Delete the saved password for ${username} on ${domain}? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      destructive: true,
+    })
+    if (!ok) return
+    await window.api.deleteCredential(id)
+    await loadCredentials()
+  }
+
+  async function revealPassword(id: string, domain: string): Promise<void> {
+    if (revealedId === id) {
+      revealedId = null
+      revealedPassword = ''
+      if (revealTimer) clearTimeout(revealTimer)
+      return
+    }
+    const cred = await window.api.getCredentialDecrypted(id, domain, 'reveal')
+    if (cred) {
+      revealedId = id
+      revealedPassword = cred.password
+      if (revealTimer) clearTimeout(revealTimer)
+      revealTimer = setTimeout(() => {
+        revealedId = null
+        revealedPassword = ''
+      }, 5000)
+    }
+  }
+
+  onMount(() => {
+    loadCredentials()
+    return () => {
+      if (revealTimer) clearTimeout(revealTimer)
+    }
+  })
+
+  function visible(cred: Credential): boolean {
+    if (prefsSearch.query.trim() === '') return true
+    return matches(`${cred.domain} ${cred.username} ${cred.title}`)
+  }
+</script>
+
+<PrefsSection
+  title="Saved passwords"
+  description="Browser-pane credentials stored encrypted via Electron safeStorage"
+>
+  <div class="flex flex-col gap-1">
+    {#each credentials as cred (cred.id)}
+      <div
+        class="flex flex-col gap-1 px-3 py-2 rounded-md bg-bg-input border border-border-subtle transition-opacity duration-fast"
+        class:opacity-30={!visible(cred)}
+      >
+        <div class="flex items-baseline gap-2 min-w-0">
+          <span class="text-md text-text truncate">{cred.domain}</span>
+          {#if cred.title}
+            <span class="text-xs text-text-faint truncate">{cred.title}</span>
+          {/if}
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="text-sm text-text-secondary truncate flex-1">{cred.username}</span>
+          <span class="shrink-0">
+            {#if revealedId === cred.id}
+              <code class="text-xs text-text bg-bg px-1 py-px rounded-sm font-mono"
+                >{revealedPassword}</code
+              >
+            {:else}
+              <span class="text-text-faint text-sm tracking-wider">••••••••</span>
+            {/if}
+          </span>
+          <button
+            type="button"
+            class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-hover hover:text-text"
+            onclick={() => revealPassword(cred.id, cred.domain)}
+            title={revealedId === cred.id ? 'Hide password' : 'Show password (5s)'}
+            aria-label={revealedId === cred.id ? 'Hide password' : 'Show password'}
+          >
+            {#if revealedId === cred.id}
+              <EyeOff size={13} />
+            {:else}
+              <Eye size={13} />
+            {/if}
+          </button>
+          <button
+            type="button"
+            class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-danger-bg hover:text-danger-text"
+            onclick={() => deleteCredential(cred.id, cred.domain, cred.username)}
+            aria-label="Remove credential for {cred.username}"
+            title="Remove"
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+      </div>
+    {:else}
+      <p class="text-sm text-text-faint m-0 py-2">No saved passwords</p>
+    {/each}
+  </div>
+</PrefsSection>

--- a/src/renderer/src/components/preferences/_partials/SavedPasswordsSection.svelte
+++ b/src/renderer/src/components/preferences/_partials/SavedPasswordsSection.svelte
@@ -69,7 +69,7 @@
 
 <PrefsSection
   title="Saved passwords"
-  description="Browser-pane credentials stored encrypted via Electron safeStorage"
+  description="Browser-pane credentials. Encrypted with the OS keychain when available; otherwise stored as base64 only — configure a system keyring for at-rest protection."
 >
   <div class="flex flex-col gap-1">
     {#each credentials as cred (cred.id)}

--- a/src/renderer/src/components/preferences/_partials/SavedPasswordsSection.svelte
+++ b/src/renderer/src/components/preferences/_partials/SavedPasswordsSection.svelte
@@ -50,7 +50,7 @@
       revealTimer = setTimeout(() => {
         revealedId = null
         revealedPassword = ''
-      }, 5000)
+      }, 15000)
     }
   }
 
@@ -98,7 +98,7 @@
             type="button"
             class="flex items-center justify-center size-7 rounded-md bg-transparent border-0 text-text-muted cursor-pointer hover:bg-hover hover:text-text"
             onclick={() => revealPassword(cred.id, cred.domain)}
-            title={revealedId === cred.id ? 'Hide password' : 'Show password (5s)'}
+            title={revealedId === cred.id ? 'Hide password' : 'Show password (15s)'}
             aria-label={revealedId === cred.id ? 'Hide password' : 'Show password'}
           >
             {#if revealedId === cred.id}

--- a/src/renderer/src/components/preferences/_partials/SeparatorPopover.svelte
+++ b/src/renderer/src/components/preferences/_partials/SeparatorPopover.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  let {
+    x,
+    y,
+    label,
+    separators,
+    onPick,
+    onClose,
+    onRemove,
+  }: {
+    x: number
+    y: number
+    label: string
+    separators: string[]
+    onPick: (sep: string) => void
+    onClose: () => void
+    onRemove?: () => void
+  } = $props()
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="fixed inset-0 z-popover" onclick={onClose}>
+  <div
+    class="fixed flex items-center gap-1 px-2 py-1 bg-bg-overlay border border-border rounded-md shadow-popover -translate-x-1/2 -translate-y-full -mt-2"
+    style="left:{x}px;top:{y}px"
+    onclick={(e) => e.stopPropagation()}
+  >
+    <span class="text-2xs uppercase tracking-caps-tight text-text-muted mr-0.5">{label}</span>
+    {#each separators as sep (sep)}
+      <button
+        type="button"
+        class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-text-secondary text-sm font-mono cursor-pointer hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
+        onclick={() => onPick(sep)}
+      >
+        {sep}
+      </button>
+    {/each}
+    {#if onRemove}
+      <button
+        type="button"
+        class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-danger-text text-sm font-mono cursor-pointer hover:bg-danger-bg hover:border-danger-text"
+        onclick={onRemove}>×</button
+      >
+    {/if}
+  </div>
+</div>

--- a/src/renderer/src/components/preferences/_partials/SeparatorPopover.svelte
+++ b/src/renderer/src/components/preferences/_partials/SeparatorPopover.svelte
@@ -4,6 +4,7 @@
     y,
     label,
     separators,
+    triggerEl,
     onPick,
     onClose,
     onRemove,
@@ -12,11 +13,31 @@
     y: number
     label: string
     separators: string[]
+    triggerEl?: HTMLElement | null
     onPick: (sep: string) => void
     onClose: () => void
     onRemove?: () => void
   } = $props()
+
+  $effect(() => {
+    return () => {
+      triggerEl?.focus?.()
+    }
+  })
+
+  function autofocus(node: HTMLElement, enabled?: boolean): void {
+    if (enabled) node.focus()
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onClose()
+    }
+  }
 </script>
+
+<svelte:window onkeydown={onKeydown} />
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="fixed inset-0 z-popover" onclick={onClose}>
@@ -24,11 +45,14 @@
     class="fixed flex items-center gap-1 px-2 py-1 bg-bg-overlay border border-border rounded-md shadow-popover -translate-x-1/2 -translate-y-full -mt-2"
     style="left:{x}px;top:{y}px"
     onclick={(e) => e.stopPropagation()}
+    role="dialog"
+    aria-label={label}
   >
     <span class="text-2xs uppercase tracking-caps-tight text-text-muted mr-0.5">{label}</span>
-    {#each separators as sep (sep)}
+    {#each separators as sep, i (sep)}
       <button
         type="button"
+        use:autofocus={i === 0 ? true : undefined}
         class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-text-secondary text-sm font-mono cursor-pointer hover:bg-accent-bg hover:border-accent-muted hover:text-accent-text"
         onclick={() => onPick(sep)}
       >
@@ -39,8 +63,11 @@
       <button
         type="button"
         class="px-2 py-0.5 border border-border rounded-sm bg-bg-input text-danger-text text-sm font-mono cursor-pointer hover:bg-danger-bg hover:border-danger-text"
-        onclick={onRemove}>×</button
+        onclick={onRemove}
+        aria-label="Remove separator"
       >
+        <span aria-hidden="true">×</span>
+      </button>
     {/if}
   </div>
 </div>

--- a/src/renderer/src/components/preferences/_partials/SkillInstallForm.svelte
+++ b/src/renderer/src/components/preferences/_partials/SkillInstallForm.svelte
@@ -74,7 +74,7 @@
 <div
   class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input"
   onkeydown={(e) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !(e.target instanceof HTMLButtonElement)) {
       e.preventDefault()
       install()
     }

--- a/src/renderer/src/components/preferences/_partials/SkillInstallForm.svelte
+++ b/src/renderer/src/components/preferences/_partials/SkillInstallForm.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import CustomCheckbox from '../../shared/CustomCheckbox.svelte'
+  import CustomRadio from '../../shared/CustomRadio.svelte'
+
+  let {
+    agentLabels,
+    workspacePath,
+    onClose,
+    onInstalled,
+  }: {
+    agentLabels: Record<string, string>
+    workspacePath?: string
+    onClose: () => void
+    onInstalled: () => void | Promise<void>
+  } = $props()
+
+  let source = $state('')
+  let scope = $state('project')
+  let method = $state('copy')
+  let agents = $state<string[]>(['claude'])
+  let error = $state('')
+  let installing = $state(false)
+
+  function reset(): void {
+    source = ''
+    agents = ['claude']
+    scope = 'project'
+    method = 'copy'
+    error = ''
+  }
+
+  function toggleAgent(agent: string): void {
+    if (agents.includes(agent)) {
+      agents = agents.filter((a) => a !== agent)
+    } else {
+      agents = [...agents, agent]
+    }
+  }
+
+  async function install(): Promise<void> {
+    if (!source.trim()) {
+      error = 'Source is required'
+      return
+    }
+
+    installing = true
+    error = ''
+
+    try {
+      await window.api.installSkill({
+        source: source.trim(),
+        agents: [...agents],
+        scope: String(scope),
+        method: String(method),
+        workspacePath,
+      })
+      reset()
+      await onInstalled()
+      onClose()
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e)
+    } finally {
+      installing = false
+    }
+  }
+
+  function cancel(): void {
+    reset()
+    onClose()
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input"
+  onkeydown={(e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      install()
+    }
+    if (e.key === 'Escape') cancel()
+  }}
+>
+  <input
+    class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+    name="installSource"
+    aria-label="Skill source"
+    bind:value={source}
+    placeholder="github:owner/repo/path, local path, or URL"
+    spellcheck="false"
+    autocomplete="off"
+  />
+
+  <div class="flex flex-col gap-1.5">
+    <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint">Agents</span>
+    <div class="flex gap-3 flex-wrap">
+      {#each Object.entries(agentLabels) as [key, label] (key)}
+        <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+          <CustomCheckbox checked={agents.includes(key)} onchange={() => toggleAgent(key)} />
+          <span>{label}</span>
+        </label>
+      {/each}
+    </div>
+  </div>
+
+  <div class="flex flex-col gap-1.5">
+    <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint">Scope</span>
+    <div class="flex gap-3 flex-wrap">
+      <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+        <CustomRadio checked={scope === 'project'} onchange={() => (scope = 'project')} />
+        <span>Project</span>
+      </label>
+      <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+        <CustomRadio checked={scope === 'global'} onchange={() => (scope = 'global')} />
+        <span>Global</span>
+      </label>
+    </div>
+  </div>
+
+  <div class="flex flex-col gap-1.5">
+    <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint">Method</span>
+    <div class="flex gap-3 flex-wrap">
+      <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+        <CustomRadio checked={method === 'copy'} onchange={() => (method = 'copy')} />
+        <span>Copy</span>
+      </label>
+      <label class="flex items-center gap-1.5 text-md text-text cursor-pointer">
+        <CustomRadio checked={method === 'symlink'} onchange={() => (method = 'symlink')} />
+        <span>Symlink</span>
+      </label>
+    </div>
+  </div>
+
+  {#if error}
+    <p class="text-sm text-danger-text m-0">{error}</p>
+  {/if}
+
+  <div class="flex justify-end gap-2">
+    <button
+      type="button"
+      class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
+      onclick={cancel}>Cancel</button
+    >
+    <button
+      type="button"
+      class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text disabled:opacity-60 disabled:cursor-default hover:bg-accent-bg-hover"
+      onclick={install}
+      disabled={installing}
+    >
+      {installing ? 'Installing…' : 'Install'}
+    </button>
+  </div>
+</div>

--- a/src/renderer/src/components/preferences/_partials/SkillInstallForm.svelte
+++ b/src/renderer/src/components/preferences/_partials/SkillInstallForm.svelte
@@ -70,14 +70,13 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
+<form
   class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input"
+  onsubmit={(e) => {
+    e.preventDefault()
+    install()
+  }}
   onkeydown={(e) => {
-    if (e.key === 'Enter' && !(e.target instanceof HTMLButtonElement)) {
-      e.preventDefault()
-      install()
-    }
     if (e.key === 'Escape') cancel()
   }}
 >
@@ -142,12 +141,11 @@
       onclick={cancel}>Cancel</button
     >
     <button
-      type="button"
+      type="submit"
       class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text disabled:opacity-60 disabled:cursor-default hover:bg-accent-bg-hover"
-      onclick={install}
       disabled={installing}
     >
       {installing ? 'Installing…' : 'Install'}
     </button>
   </div>
-</div>
+</form>

--- a/src/renderer/src/components/preferences/_partials/SkillRow.svelte
+++ b/src/renderer/src/components/preferences/_partials/SkillRow.svelte
@@ -26,6 +26,7 @@
   <button
     type="button"
     class="flex items-center gap-2 w-full px-1 py-2 border-0 bg-transparent text-left cursor-pointer hover:bg-row-hover rounded-md"
+    aria-expanded={expanded}
     onclick={onToggle}
   >
     {#if expanded}

--- a/src/renderer/src/components/preferences/_partials/SkillRow.svelte
+++ b/src/renderer/src/components/preferences/_partials/SkillRow.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { ChevronDown, ChevronRight } from '@lucide/svelte'
+  import type { Snippet } from 'svelte'
+
+  let {
+    name,
+    agentDisplay,
+    expanded,
+    dimmed,
+    onToggle,
+    children,
+  }: {
+    name: string
+    agentDisplay: string
+    expanded: boolean
+    dimmed: boolean
+    onToggle: () => void
+    children: Snippet
+  } = $props()
+</script>
+
+<div
+  class="flex flex-col border-t border-border-subtle first:border-t-0 transition-opacity duration-fast"
+  class:opacity-30={dimmed}
+>
+  <button
+    type="button"
+    class="flex items-center gap-2 w-full px-1 py-2 border-0 bg-transparent text-left cursor-pointer hover:bg-row-hover rounded-md"
+    onclick={onToggle}
+  >
+    {#if expanded}
+      <ChevronDown size={13} class="shrink-0 text-text-muted" />
+    {:else}
+      <ChevronRight size={13} class="shrink-0 text-text-muted" />
+    {/if}
+    <span class="text-md text-text min-w-30 truncate">{name}</span>
+    <span class="text-xs text-text-muted truncate flex-1">{agentDisplay}</span>
+  </button>
+  {#if expanded}
+    <div class="pl-6 pr-1 pb-3 flex flex-col gap-2.5">
+      {@render children()}
+    </div>
+  {/if}
+</div>

--- a/src/renderer/src/components/preferences/_partials/ToolForm.svelte
+++ b/src/renderer/src/components/preferences/_partials/ToolForm.svelte
@@ -33,16 +33,15 @@
   const submitLabel = mode === 'add' ? 'Add tool' : 'Save'
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
+<form
   class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input"
   class:my-1={mode === 'edit'}
   class:mt-3={mode === 'add'}
+  onsubmit={(e) => {
+    e.preventDefault()
+    onSubmit()
+  }}
   onkeydown={(e) => {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      onSubmit()
-    }
     if (e.key === 'Escape') onCancel()
   }}
 >
@@ -101,9 +100,9 @@
       onclick={onCancel}>Cancel</button
     >
     <button
-      type="button"
+      type="submit"
       class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
-      onclick={onSubmit}>{submitLabel}</button
+      >{submitLabel}</button
     >
   </div>
-</div>
+</form>

--- a/src/renderer/src/components/preferences/_partials/ToolForm.svelte
+++ b/src/renderer/src/components/preferences/_partials/ToolForm.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import CustomSelect from '../../shared/CustomSelect.svelte'
+
+  interface ToolDraft {
+    id: string
+    name: string
+    command: string
+    args: string
+    category: string
+  }
+
+  let {
+    draft = $bindable(),
+    mode,
+    error,
+    onCancel,
+    onSubmit,
+  }: {
+    draft: ToolDraft
+    mode: 'add' | 'edit'
+    error: string
+    onCancel: () => void
+    onSubmit: () => void
+  } = $props()
+
+  const categoryOptions = [
+    { value: 'ai', label: 'AI' },
+    { value: 'git', label: 'Git' },
+    { value: 'system', label: 'System' },
+    { value: 'shell', label: 'Shell' },
+  ]
+
+  const submitLabel = mode === 'add' ? 'Add tool' : 'Save'
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input"
+  class:my-1={mode === 'edit'}
+  class:mt-3={mode === 'add'}
+  onkeydown={(e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      onSubmit()
+    }
+    if (e.key === 'Escape') onCancel()
+  }}
+>
+  {#if mode === 'edit'}
+    <div class="flex items-center gap-2 text-2xs uppercase tracking-caps-tight text-text-faint">
+      <span>Editing</span>
+      <code class="font-mono text-text-muted normal-case tracking-normal">{draft.id}</code>
+    </div>
+  {:else}
+    <input
+      class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+      name="toolId"
+      aria-label="Tool ID"
+      bind:value={draft.id}
+      placeholder="ID (e.g. my-tool)"
+      spellcheck="false"
+    />
+  {/if}
+  <input
+    class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+    name="toolName"
+    aria-label="Display name"
+    bind:value={draft.name}
+    placeholder="Display name"
+    spellcheck="false"
+  />
+  <input
+    class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+    name="toolCommand"
+    aria-label="Command"
+    bind:value={draft.command}
+    placeholder="Command (binary name)"
+    spellcheck="false"
+  />
+  <input
+    class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-md font-mono outline-none focus:border-focus-ring placeholder:text-text-faint"
+    name="toolArgs"
+    aria-label="Args"
+    bind:value={draft.args}
+    placeholder="Args (comma-separated)"
+    spellcheck="false"
+  />
+  <CustomSelect
+    value={draft.category}
+    options={categoryOptions}
+    maxWidth="100%"
+    onchange={(v) => (draft.category = v)}
+  />
+  {#if error}
+    <p class="text-sm text-danger-text m-0">{error}</p>
+  {/if}
+  <div class="flex justify-end gap-2">
+    <button
+      type="button"
+      class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
+      onclick={onCancel}>Cancel</button
+    >
+    <button
+      type="button"
+      class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text hover:bg-accent-bg-hover"
+      onclick={onSubmit}>{submitLabel}</button
+    >
+  </div>
+</div>

--- a/src/renderer/src/components/preferences/_partials/TrackerEditForm.svelte
+++ b/src/renderer/src/components/preferences/_partials/TrackerEditForm.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import { Check, X } from '@lucide/svelte'
+  import CustomSelect from '../../shared/CustomSelect.svelte'
+
+  type Provider = 'jira' | 'youtrack' | 'github'
+
+  let {
+    provider = $bindable(),
+    baseUrl = $bindable(),
+    projectKey = $bindable(),
+    username = $bindable(),
+    token = $bindable(),
+    isNew,
+    hasExistingToken,
+    testing,
+    testResult,
+    onCancel,
+    onTest,
+    onSave,
+  }: {
+    provider: Provider
+    baseUrl: string
+    projectKey: string
+    username: string
+    token: string
+    isNew: boolean
+    hasExistingToken: boolean
+    testing: boolean
+    testResult: 'success' | 'fail' | ''
+    onCancel: () => void
+    onTest: () => void
+    onSave: () => void
+  } = $props()
+
+  function openTokenPage(): void {
+    if (provider === 'jira') {
+      window.api.openExternal('https://id.atlassian.com/manage-profile/security/api-tokens')
+    } else if (provider === 'youtrack') {
+      const url = baseUrl
+        ? `${baseUrl.replace(/\/$/, '')}/hub/tokens`
+        : 'https://youtrack.jetbrains.com/hub/tokens'
+      window.api.openExternal(url)
+    } else if (provider === 'github') {
+      window.api.openExternal('https://github.com/settings/tokens')
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-2 p-3 border border-border rounded-md bg-bg-input">
+  <div class="flex flex-col gap-1">
+    <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+      >Provider</span
+    >
+    <CustomSelect
+      value={provider}
+      options={[
+        { value: 'jira', label: 'Jira' },
+        { value: 'youtrack', label: 'YouTrack' },
+        { value: 'github', label: 'GitHub' },
+      ]}
+      onchange={(v) => (provider = v as Provider)}
+    />
+  </div>
+
+  <div class="flex flex-col gap-1">
+    <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+      >Base URL</span
+    >
+    <input
+      class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+      name="baseUrl"
+      aria-label="Base URL"
+      bind:value={baseUrl}
+      placeholder={provider === 'github' ? 'https://github.com' : 'https://company.atlassian.net'}
+      spellcheck="false"
+    />
+  </div>
+
+  {#if provider === 'github'}
+    <div class="flex flex-col gap-1">
+      <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+        >Repository (optional)</span
+      >
+      <input
+        class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        name="projectKey"
+        aria-label="Repository"
+        bind:value={projectKey}
+        placeholder="owner/repo — auto-detected if empty"
+        spellcheck="false"
+      />
+    </div>
+  {/if}
+
+  <div class="flex flex-col gap-2 pt-2 border-t border-border-subtle">
+    <span class="text-2xs text-text-faint">Credentials — stored locally, never committed.</span>
+
+    {#if provider === 'jira'}
+      <div class="flex flex-col gap-1">
+        <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+          >Email</span
+        >
+        <input
+          class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+          name="username"
+          aria-label="Email"
+          bind:value={username}
+          placeholder="user@company.com"
+          spellcheck="false"
+        />
+      </div>
+    {/if}
+
+    <div class="flex flex-col gap-1">
+      <div class="flex items-center justify-between gap-2">
+        <span class="text-2xs font-semibold uppercase tracking-caps-tight text-text-faint"
+          >API token</span
+        >
+        <button
+          type="button"
+          class="text-2xs text-accent-text bg-transparent border-0 p-0 cursor-pointer underline underline-offset-2 hover:text-accent"
+          onclick={openTokenPage}
+        >
+          Generate →
+        </button>
+      </div>
+      <input
+        class="px-2.5 py-1.5 border border-border rounded-md bg-bg text-text text-sm font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+        type="password"
+        name="token"
+        aria-label="API token"
+        bind:value={token}
+        placeholder={!isNew && hasExistingToken ? '••••••••' : 'Enter token'}
+        autocomplete="off"
+      />
+    </div>
+  </div>
+
+  <div class="min-h-4.5" aria-live="polite">
+    {#if testResult === 'success'}
+      <span class="flex items-center gap-1 text-xs text-success"><Check size={13} /> OK</span>
+    {:else if testResult === 'fail'}
+      <span class="flex items-center gap-1 text-xs text-danger-text"><X size={13} /> Failed</span>
+    {/if}
+  </div>
+
+  <div class="flex gap-1.5 justify-end">
+    <button
+      type="button"
+      class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-transparent text-text-secondary hover:bg-hover hover:text-text"
+      onclick={onCancel}>Cancel</button
+    >
+    <button
+      type="button"
+      class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border border-border bg-bg-input text-text-secondary enabled:hover:bg-hover-strong enabled:hover:text-text disabled:opacity-50 disabled:cursor-default"
+      onclick={onTest}
+      disabled={testing || !baseUrl || !token}
+    >
+      {testing ? 'Testing…' : 'Test'}
+    </button>
+    <button
+      type="button"
+      class="px-3 py-1 rounded-md text-sm font-inherit cursor-pointer border-0 bg-accent-bg text-accent-text enabled:hover:bg-accent-bg-hover disabled:opacity-50 disabled:cursor-default"
+      onclick={onSave}
+      disabled={!baseUrl}>Save</button
+    >
+  </div>
+</div>

--- a/src/renderer/src/components/preferences/_partials/TrackerEditForm.svelte
+++ b/src/renderer/src/components/preferences/_partials/TrackerEditForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Check, X } from '@lucide/svelte'
+  import { match } from 'ts-pattern'
   import CustomSelect from '../../shared/CustomSelect.svelte'
 
   type Provider = 'jira' | 'youtrack' | 'github'
@@ -33,16 +34,16 @@
   } = $props()
 
   function openTokenPage(): void {
-    if (provider === 'jira') {
-      window.api.openExternal('https://id.atlassian.com/manage-profile/security/api-tokens')
-    } else if (provider === 'youtrack') {
-      const url = baseUrl
-        ? `${baseUrl.replace(/\/$/, '')}/hub/tokens`
-        : 'https://youtrack.jetbrains.com/hub/tokens'
-      window.api.openExternal(url)
-    } else if (provider === 'github') {
-      window.api.openExternal('https://github.com/settings/tokens')
-    }
+    const url = match(provider)
+      .with('jira', () => 'https://id.atlassian.com/manage-profile/security/api-tokens')
+      .with('youtrack', () =>
+        baseUrl
+          ? `${baseUrl.replace(/\/$/, '')}/hub/tokens`
+          : 'https://youtrack.jetbrains.com/hub/tokens',
+      )
+      .with('github', () => 'https://github.com/settings/tokens')
+      .exhaustive()
+    window.api.openExternal(url)
   }
 </script>
 

--- a/src/renderer/src/components/preferences/_partials/prefsSearch.svelte.ts
+++ b/src/renderer/src/components/preferences/_partials/prefsSearch.svelte.ts
@@ -1,0 +1,16 @@
+export const prefsSearch: { query: string } = $state({ query: '' })
+
+export function setQuery(q: string): void {
+  prefsSearch.query = q
+}
+
+export function clearQuery(): void {
+  prefsSearch.query = ''
+}
+
+export function matches(text: string | undefined): boolean {
+  const q = prefsSearch.query.trim().toLowerCase()
+  if (!q) return true
+  if (!text) return false
+  return text.toLowerCase().includes(q)
+}

--- a/src/renderer/src/components/preferences/_partials/sectionMeta.ts
+++ b/src/renderer/src/components/preferences/_partials/sectionMeta.ts
@@ -1,0 +1,141 @@
+import {
+  Settings2,
+  RefreshCw,
+  Shield,
+  Keyboard,
+  Bell,
+  MoreHorizontal,
+  Palette,
+  PanelLeft,
+  Sparkles,
+  Gem,
+  Code,
+  Braces,
+  Wrench,
+  TerminalSquare,
+  Hammer,
+  GitBranch,
+  ListChecks,
+  FolderSearch,
+  Globe,
+  Smartphone,
+} from '@lucide/svelte'
+import type { Component } from 'svelte'
+
+export interface SectionMeta {
+  icon: Component
+  description: string
+  keywords: string
+}
+
+export const sectionMeta: Record<string, SectionMeta> = {
+  General: {
+    icon: Settings2,
+    description: 'Startup behavior, default tools, and status bar',
+    keywords: 'reopen workspace startup new tab worktree shell cpu ram performance hud',
+  },
+  Updates: {
+    icon: RefreshCw,
+    description: 'Auto-update channel and check frequency',
+    keywords: 'auto update channel stable next hourly daily weekly version',
+  },
+  Privacy: {
+    icon: Shield,
+    description: 'Telemetry and diagnostics',
+    keywords: 'telemetry diagnostics privacy analytics ping',
+  },
+  Shortcuts: {
+    icon: Keyboard,
+    description: 'Customize keyboard shortcuts',
+    keywords: 'shortcuts hotkeys keybindings keyboard',
+  },
+  Notch: {
+    icon: Bell,
+    description: 'macOS notch overlay for session status',
+    keywords: 'notch overlay status indicator macos session',
+  },
+  Misc: {
+    icon: MoreHorizontal,
+    description: 'Other toggles and tweaks',
+    keywords: 'misc miscellaneous other',
+  },
+  Appearance: {
+    icon: Palette,
+    description: 'Terminal theme and font',
+    keywords: 'theme color font family size appearance terminal jetbrains mono',
+  },
+  Sidebar: {
+    icon: PanelLeft,
+    description: 'Sidebar layout and visibility',
+    keywords: 'sidebar layout visibility panel',
+  },
+  Claude: {
+    icon: Sparkles,
+    description: 'Claude Code integration',
+    keywords: 'claude anthropic api key model permission effort plan auto bypass bedrock vertex',
+  },
+  Gemini: {
+    icon: Gem,
+    description: 'Gemini integration',
+    keywords: 'gemini google api key model approval',
+  },
+  OpenCode: {
+    icon: Code,
+    description: 'OpenCode integration',
+    keywords: 'opencode api key model',
+  },
+  Codex: {
+    icon: Braces,
+    description: 'Codex integration',
+    keywords: 'codex openai approval sandbox full auto profile',
+  },
+  Skills: {
+    icon: Wrench,
+    description: 'Available skills',
+    keywords: 'skills tools agents',
+  },
+  Terminal: {
+    icon: TerminalSquare,
+    description: 'tmux session persistence and terminal behavior',
+    keywords: 'terminal tmux mouse close detach kill ask session persistence',
+  },
+  Tools: {
+    icon: Hammer,
+    description: 'Custom tools and commands',
+    keywords: 'tools custom command icon category shell git ai',
+  },
+  Git: {
+    icon: GitBranch,
+    description: 'Pull strategy and worktree setup',
+    keywords: 'git pull rebase merge worktree directory base setup actions copy command',
+  },
+  Tasks: {
+    icon: ListChecks,
+    description: 'Linear, Jira and branch/PR templates',
+    keywords:
+      'tasks linear jira tracker branch pr template naming token connections boards statuses',
+  },
+  'File Watcher': {
+    icon: FolderSearch,
+    description: 'Ignore patterns for the workspace file watcher',
+    keywords: 'file watcher ignore patterns gitignore exclude',
+  },
+  'Web Browser': {
+    icon: Globe,
+    description: 'Webview viewports and devices',
+    keywords: 'web browser viewport device webview responsive',
+  },
+  'Remote Control': {
+    icon: Smartphone,
+    description: 'Remote sessions and trusted devices',
+    keywords: 'remote control phone session trusted device port pair',
+  },
+}
+
+export function sectionMatches(name: string, query: string): boolean {
+  const q = query.trim().toLowerCase()
+  if (!q) return true
+  const meta = sectionMeta[name]
+  const haystack = `${name} ${meta?.description ?? ''} ${meta?.keywords ?? ''}`.toLowerCase()
+  return haystack.includes(q)
+}

--- a/src/renderer/src/components/shared/CustomCheckbox.svelte
+++ b/src/renderer/src/components/shared/CustomCheckbox.svelte
@@ -5,9 +5,21 @@
     checked: boolean
     onchange?: (checked: boolean) => void
     disabled?: boolean
+    id?: string
+    ariaLabel?: string
+    ariaLabelledby?: string
+    ariaDescribedby?: string
   }
 
-  let { checked, onchange, disabled = false }: Props = $props()
+  let {
+    checked,
+    onchange,
+    disabled = false,
+    id,
+    ariaLabel,
+    ariaLabelledby,
+    ariaDescribedby,
+  }: Props = $props()
 
   function toggle(): void {
     if (disabled) return
@@ -35,9 +47,15 @@
   class:hover:border-accent={!disabled && !checked}
   class:hover:border-accent-text={!disabled && checked}
   class:hover:bg-accent-text={!disabled && checked}
+  {id}
+  type="button"
   role="checkbox"
   aria-checked={checked}
   aria-disabled={disabled}
+  aria-label={ariaLabel}
+  aria-labelledby={ariaLabelledby}
+  aria-describedby={ariaDescribedby}
+  {disabled}
   onclick={toggle}
   onkeydown={handleKeydown}
 >

--- a/src/renderer/src/components/shared/CustomRadio.svelte
+++ b/src/renderer/src/components/shared/CustomRadio.svelte
@@ -3,9 +3,21 @@
     checked: boolean
     onchange?: () => void
     disabled?: boolean
+    id?: string
+    ariaLabel?: string
+    ariaLabelledby?: string
+    ariaDescribedby?: string
   }
 
-  let { checked, onchange, disabled = false }: Props = $props()
+  let {
+    checked,
+    onchange,
+    disabled = false,
+    id,
+    ariaLabel,
+    ariaLabelledby,
+    ariaDescribedby,
+  }: Props = $props()
 
   function select(): void {
     if (disabled || checked) return
@@ -27,9 +39,15 @@
   class:cursor-default={disabled}
   class:opacity-40={disabled}
   class:hover:border-accent={!disabled && !checked}
+  {id}
+  type="button"
   role="radio"
   aria-checked={checked}
   aria-disabled={disabled}
+  aria-label={ariaLabel}
+  aria-labelledby={ariaLabelledby}
+  aria-describedby={ariaDescribedby}
+  {disabled}
   onclick={select}
   onkeydown={handleKeydown}
 >

--- a/src/renderer/src/components/sidebar/CollapsibleSection.svelte
+++ b/src/renderer/src/components/sidebar/CollapsibleSection.svelte
@@ -28,20 +28,20 @@
 </script>
 
 <section class="py-3" class:border-t={borderTop} class:border-border-subtle={borderTop}>
-  <div class="flex items-center justify-between px-3 h-5 mb-2">
+  <div class="flex items-center justify-between px-3 h-7 mb-1">
     <button
       class="flex items-center gap-1 flex-1 min-w-0 bg-transparent border-0 py-1 -my-1 cursor-pointer text-inherit group"
       onclick={toggle}
       aria-expanded={!collapsed}
     >
       <span
-        class="flex items-center text-text-faint transition-transform duration-base ease-std"
+        class="flex items-center text-text-faint group-hover:text-text-muted transition-transform duration-base ease-std"
         class:rotate-90={!collapsed}
       >
         <ChevronRight size={12} />
       </span>
       <h3
-        class="text-2xs font-semibold tracking-caps uppercase text-text-muted group-hover:text-text-secondary"
+        class="text-2xs font-semibold tracking-caps-looser uppercase text-text-faint group-hover:text-text-muted leading-tight"
       >
         {title}
       </h3>

--- a/src/renderer/src/components/sidebar/FileTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/FileTreeSection.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import { match } from 'ts-pattern'
-  import { ChevronRight, Folder, FolderOpen, File, RotateCw } from '@lucide/svelte'
+  import { ChevronRight, Folder, FolderOpen, RotateCw, Plus } from '@lucide/svelte'
   import CollapsibleSection from './CollapsibleSection.svelte'
+  import FileTypeIcon from './_partials/FileTypeIcon.svelte'
   import { fileTree } from '../../lib/stores/fileTree.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import { openFile } from '../../lib/stores/tabs.svelte'
   import { fileManagerLabel } from '../../lib/platform'
+  import { prompt, confirm } from '../../lib/stores/dialogs.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
 
   let refreshing = $state(false)
 
@@ -58,23 +61,55 @@
   $effect(() => {
     const wt = workspaceState.selectedWorktreePath
     if (!wt) return
+    let statusTimer: ReturnType<typeof setTimeout> | null = null
     const unsub = window.api.onFilesChanged((payload) => {
       if (payload.repoRoot !== wt) return
       fileTree.applyFileEvents(payload.events)
+      const repoRoot = workspaceState.repoRoot
+      if (!repoRoot) return
+      if (statusTimer) clearTimeout(statusTimer)
+      statusTimer = setTimeout(() => {
+        statusTimer = null
+        fileTree.refreshGitStatus(repoRoot)
+      }, 150)
     })
-    return unsub
+    return () => {
+      if (statusTimer) clearTimeout(statusTimer)
+      unsub()
+    }
   })
 
-  function getStatusColor(relativePath: string): string | null {
-    const status = fileTree.gitFileStatus.get(relativePath)
-    if (!status) return null
+  function getStatus(relativePath: string): string | null {
+    return fileTree.gitFileStatus.get(relativePath) ?? null
+  }
+
+  function statusLetter(status: string): string {
     return match(status)
-      .with('M', () => 'var(--color-warning-text)')
-      .with('A', () => 'var(--color-success)')
-      .with('D', () => 'var(--color-danger-text)')
-      .with('?', () => 'var(--color-text-faint)')
-      .with('R', () => 'var(--color-accent-text)')
-      .otherwise(() => 'var(--color-warning-text)')
+      .with('?', () => 'U')
+      .otherwise((s) => s.toUpperCase())
+  }
+
+  function statusTone(status: string): string {
+    return match(status)
+      .with('M', () => 'text-warning-text')
+      .with('A', () => 'text-success-text')
+      .with('D', () => 'text-danger-text')
+      .with('R', () => 'text-warning-text')
+      .with('?', () => 'text-accent-text')
+      .otherwise(() => 'text-warning-text')
+  }
+
+  function folderHasChanges(relPath: string): boolean {
+    if (!relPath) return fileTree.gitFileStatus.size > 0
+    const prefix = relPath + '/'
+    for (const key of fileTree.gitFileStatus.keys()) {
+      if (key.startsWith(prefix)) return true
+    }
+    return false
+  }
+
+  function isIgnored(status: string | null): boolean {
+    return status === '!'
   }
 
   function getRelativePath(absPath: string): string {
@@ -126,21 +161,108 @@
       closeContextMenu()
     }
   }
+
+  function validateNewName(value: string): string | null {
+    const trimmed = value.trim()
+    if (!trimmed) return 'Name is required'
+    if (trimmed.startsWith('/')) return 'Use a relative path'
+    if (trimmed.includes('..')) return 'Path cannot contain ".."'
+    return null
+  }
+
+  async function createInDir(dirAbsPath: string): Promise<void> {
+    const dirLabel =
+      dirAbsPath === fileTree.rootPath
+        ? '/'
+        : dirAbsPath.replace((fileTree.rootPath ?? '') + '/', '')
+    const result = await prompt({
+      title: `New file or folder in ${dirLabel}`,
+      placeholder: 'name.ts  or  folder/',
+      submitLabel: 'Create',
+      validate: validateNewName,
+    })
+    if (!result) return
+
+    const name = result.value.trim()
+    const isFolder = name.endsWith('/')
+    const cleaned = isFolder ? name.replace(/\/+$/, '') : name
+    const target = `${dirAbsPath}/${cleaned}`
+
+    try {
+      if (isFolder) {
+        await window.api.mkdir(target)
+      } else {
+        await window.api.createFile(target)
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.includes('EEXIST')) {
+        await confirm({
+          title: 'Already exists',
+          message: `"${cleaned}" already exists in this folder.`,
+          confirmLabel: 'OK',
+        })
+      } else {
+        addToast(`Create failed: ${msg}`)
+      }
+      return
+    }
+
+    // Make sure the parent (and any intermediate dirs) are expanded so the
+    // new entry is visible without the user having to click around.
+    const segments = cleaned.split('/').slice(0, -1)
+    let walked = dirAbsPath
+    await fileTree.expandDir(walked)
+    for (const segment of segments) {
+      walked = `${walked}/${segment}`
+      await fileTree.expandDir(walked)
+    }
+
+    if (!isFolder) {
+      const wt = workspaceState.selectedWorktreePath
+      if (wt) openFile(target, wt)
+    }
+  }
+
+  async function handleCreateRoot(e: MouseEvent): Promise<void> {
+    e.stopPropagation()
+    if (!fileTree.rootPath) return
+    await createInDir(fileTree.rootPath)
+  }
+
+  async function handleCreateInRow(e: MouseEvent, dirAbsPath: string): Promise<void> {
+    e.stopPropagation()
+    await createInDir(dirAbsPath)
+  }
 </script>
 
-{#snippet headerRefreshButton()}
-  <button
-    class="flex items-center justify-center w-6 h-6 -my-1 bg-transparent border-0 rounded-md text-text-faint cursor-pointer transition-colors duration-fast enabled:hover:bg-hover enabled:hover:text-text-secondary disabled:opacity-40 disabled:cursor-default"
-    onclick={handleRefresh}
-    disabled={refreshing || !fileTree.rootPath}
-    title="Refresh file list"
-    aria-label="Refresh file list"
-  >
-    <RotateCw size={14} class={refreshing ? 'animate-spin-slow motion-reduce:animate-none' : ''} />
-  </button>
+{#snippet headerActions()}
+  <span class="inline-flex items-center gap-0.5 -my-1">
+    <button
+      class="inline-flex items-center justify-center size-5 bg-transparent border-0 rounded-sm text-text-faint cursor-pointer transition-colors duration-fast enabled:hover:bg-hover enabled:hover:text-text disabled:opacity-40 disabled:cursor-default"
+      onclick={handleCreateRoot}
+      disabled={!fileTree.rootPath}
+      title="New file or folder"
+      aria-label="New file or folder"
+    >
+      <Plus size={12} />
+    </button>
+    <button
+      class="inline-flex items-center justify-center size-5 bg-transparent border-0 rounded-sm text-text-faint cursor-pointer transition-colors duration-fast enabled:hover:bg-hover enabled:hover:text-text disabled:opacity-40 disabled:cursor-default"
+      onclick={handleRefresh}
+      disabled={refreshing || !fileTree.rootPath}
+      title="Refresh file list"
+      aria-label="Refresh file list"
+    >
+      <RotateCw
+        size={12}
+        class={refreshing ? 'animate-spin-slow motion-reduce:animate-none' : ''}
+      />
+    </button>
+  </span>
 {/snippet}
 
-<CollapsibleSection title="FILES" sectionKey="files" borderTop headerExtra={headerRefreshButton}>
+<CollapsibleSection title="FILES" sectionKey="files" borderTop headerExtra={headerActions}>
   {#if fileTree.rootPath && fileTree.expandedDirs[fileTree.rootPath]}
     <div class="flex flex-col">
       {#snippet renderEntries(entries: DirEntry[], parentPath: string, depth: number)}
@@ -148,48 +270,84 @@
           {@const absPath = parentPath + '/' + entry.name}
           {@const isExpanded = !!fileTree.expandedDirs[absPath]}
           {@const relPath = getRelativePath(absPath)}
-          {@const statusColor = getStatusColor(relPath)}
+          {@const status = getStatus(relPath)}
+          {@const ignored = isIgnored(status)}
           {@const isSelected = fileTree.selectedFilePath === absPath}
           {#if entry.isDirectory}
-            <button
-              class="flex items-center gap-1 py-0.5 pr-2 h-6 bg-transparent border-0 cursor-pointer text-text-secondary text-sm text-left w-full hover:bg-hover"
-              class:bg-hover-strong={isSelected}
-              style:padding-left="{8 + depth * 16}px"
-              onclick={() => fileTree.toggleDir(absPath)}
-              oncontextmenu={(e) => handleContextMenu(e, absPath)}
+            {@const hasChanges = folderHasChanges(relPath)}
+            <div
+              class="group relative flex items-center w-full transition-colors duration-fast hover:bg-hover"
+              class:bg-active={isSelected}
+              class:text-text-faint={ignored}
+              class:italic={ignored}
             >
-              <span
-                class="flex items-center flex-shrink-0 text-text-faint transition-transform duration-fast ease-std"
-                class:rotate-90={isExpanded}
+              <button
+                class="flex-1 min-w-0 flex items-center gap-2 pr-1 h-7 bg-transparent border-0 cursor-pointer text-sm text-left transition-colors duration-fast"
+                class:text-text={!ignored}
+                style:padding-left="{12 + depth * 12}px"
+                onclick={() => fileTree.toggleDir(absPath)}
+                oncontextmenu={(e) => handleContextMenu(e, absPath)}
               >
-                <ChevronRight size={12} />
-              </span>
-              {#if isExpanded}
-                <FolderOpen size={14} class="flex-shrink-0 text-folder-icon" />
-              {:else}
-                <Folder size={14} class="flex-shrink-0 text-folder-icon" />
-              {/if}
-              <span
-                class="overflow-hidden text-ellipsis whitespace-nowrap text-text"
-                style:color={statusColor}>{entry.name}</span
+                <span
+                  class="inline-flex items-center justify-center size-3 flex-shrink-0 text-text-faint transition-transform duration-fast ease-std"
+                  class:rotate-90={isExpanded}
+                >
+                  <ChevronRight size={12} />
+                </span>
+                {#if isExpanded}
+                  <FolderOpen size={14} class="flex-shrink-0 text-text-muted" />
+                {:else}
+                  <Folder size={14} class="flex-shrink-0 text-text-muted" />
+                {/if}
+                <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                  {entry.name}
+                </span>
+                {#if hasChanges && !ignored}
+                  <span
+                    class="ml-auto size-1.5 rounded-full bg-accent-text/70 flex-shrink-0"
+                    aria-hidden="true"
+                    title="Contains changes"
+                  ></span>
+                {/if}
+              </button>
+              <button
+                class="inline-flex items-center justify-center size-5 mr-3 ml-1 bg-transparent border-0 rounded-sm text-text-faint cursor-pointer flex-shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-fast hover:text-text hover:bg-hover-strong"
+                onclick={(e) => handleCreateInRow(e, absPath)}
+                title={`New file or folder in ${entry.name}`}
+                aria-label={`New file or folder in ${entry.name}`}
               >
-            </button>
+                <Plus size={11} />
+              </button>
+            </div>
             {#if isExpanded && fileTree.expandedDirs[absPath]}
               {@render renderEntries(fileTree.expandedDirs[absPath], absPath, depth + 1)}
             {/if}
           {:else}
             <button
-              class="flex items-center gap-1 py-0.5 pr-2 h-6 bg-transparent border-0 cursor-pointer text-text-secondary text-sm text-left w-full hover:bg-hover"
-              class:bg-hover-strong={isSelected}
-              style:padding-left="{8 + depth * 16 + 16}px"
+              class="group flex items-center gap-2 pr-3 h-7 bg-transparent border-0 cursor-pointer text-sm text-left w-full transition-colors duration-fast hover:bg-hover"
+              class:bg-active={isSelected}
+              class:text-text={!ignored}
+              class:text-text-faint={ignored}
+              class:italic={ignored}
+              style:padding-left="{12 + depth * 12 + 12}px"
               onclick={() => handleFileClick(absPath)}
               oncontextmenu={(e) => handleContextMenu(e, absPath)}
             >
-              <File size={13} class="flex-shrink-0 text-text-muted" />
-              <span
-                class="overflow-hidden text-ellipsis whitespace-nowrap text-text"
-                style:color={statusColor}>{entry.name}</span
-              >
+              <FileTypeIcon name={entry.name} size={13} />
+              <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                {entry.name}
+              </span>
+              {#if status && status !== '!'}
+                <span
+                  class="ml-auto text-2xs font-mono font-semibold leading-none flex-shrink-0 {statusTone(
+                    status,
+                  )}"
+                  aria-hidden="true"
+                  title={`Git status: ${status}`}
+                >
+                  {statusLetter(status)}
+                </span>
+              {/if}
             </button>
           {/if}
         {/each}
@@ -213,14 +371,14 @@
   >
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
-      class="fixed min-w-45 bg-bg-overlay border border-border rounded-lg p-1 shadow-menu backdrop-blur-md z-popover"
+      class="fixed min-w-45 bg-bg-overlay border border-border rounded-md p-1 shadow-menu backdrop-blur-md z-popover"
       role="menu"
       style="left: {contextMenu.x}px; top: {contextMenu.y}px"
       onclick={(e) => e.stopPropagation()}
     >
       <!-- eslint-disable-next-line svelte/no-autofocus -->
       <button
-        class="block w-full px-2.5 py-1.5 text-sm text-text bg-transparent border-0 rounded-md cursor-pointer text-left font-inherit hover:bg-hover-strong"
+        class="block w-full px-2.5 py-1.5 text-sm text-text bg-transparent border-0 rounded-sm cursor-pointer text-left font-inherit transition-colors duration-fast hover:bg-hover"
         role="menuitem"
         autofocus
         onclick={contextRevealInFileManager}
@@ -228,12 +386,12 @@
         {fileManagerLabel()}
       </button>
       <button
-        class="block w-full px-2.5 py-1.5 text-sm text-text bg-transparent border-0 rounded-md cursor-pointer text-left font-inherit hover:bg-hover-strong"
+        class="block w-full px-2.5 py-1.5 text-sm text-text bg-transparent border-0 rounded-sm cursor-pointer text-left font-inherit transition-colors duration-fast hover:bg-hover"
         role="menuitem"
         onclick={contextCopyPath}>Copy path</button
       >
       <button
-        class="block w-full px-2.5 py-1.5 text-sm text-text bg-transparent border-0 rounded-md cursor-pointer text-left font-inherit hover:bg-hover-strong"
+        class="block w-full px-2.5 py-1.5 text-sm text-text bg-transparent border-0 rounded-sm cursor-pointer text-left font-inherit transition-colors duration-fast hover:bg-hover"
         role="menuitem"
         onclick={contextCopyName}>Copy name</button
       >

--- a/src/renderer/src/components/sidebar/FileTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/FileTreeSection.svelte
@@ -166,7 +166,7 @@
     const trimmed = value.trim()
     if (!trimmed) return 'Name is required'
     if (trimmed.startsWith('/')) return 'Use a relative path'
-    if (trimmed.includes('..')) return 'Path cannot contain ".."'
+    if (trimmed.split('/').includes('..')) return 'Path cannot contain ".."'
     return null
   }
 

--- a/src/renderer/src/components/sidebar/GitSection.svelte
+++ b/src/renderer/src/components/sidebar/GitSection.svelte
@@ -1,4 +1,14 @@
 <script lang="ts">
+  import {
+    GitCommitVertical,
+    ArrowUpFromLine,
+    ArrowDownToLine,
+    RefreshCw,
+    Archive,
+    ArchiveRestore,
+    GitPullRequest,
+    Loader2,
+  } from '@lucide/svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import { confirm, prompt, showCreateGitHubPR } from '../../lib/stores/dialogs.svelte'
   import CollapsibleSection from './CollapsibleSection.svelte'
@@ -123,7 +133,7 @@
 <CollapsibleSection title="GIT" sectionKey="git" borderTop>
   {#snippet headerExtra()}
     <span class="flex items-center gap-1 overflow-hidden">
-      <span class="text-2xs text-text-secondary truncate max-w-30"
+      <span class="text-2xs font-mono text-text-faint truncate max-w-30"
         >{workspaceState.branch ?? ''}</span
       >
       {#if workspaceState.isDirty}
@@ -138,71 +148,148 @@
   {/snippet}
   <div class="flex flex-col">
     <button
-      class="flex items-center gap-2 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
+      class="group flex items-center gap-2.5 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
       disabled={!workspaceState.isDirty || loading === 'commit'}
       onclick={doCommit}
       title={workspaceState.isDirty ? 'Commit staged changes' : 'Nothing to commit'}
     >
+      {#if loading === 'commit'}
+        <Loader2 size={13} class="text-text-faint animate-spin-slow flex-shrink-0" />
+      {:else}
+        <GitCommitVertical
+          size={13}
+          class="text-text-faint group-enabled:group-hover:text-text-secondary flex-shrink-0"
+        />
+      {/if}
       <span class="flex-1">Commit</span>
     </button>
+
+    <div
+      class="h-px mx-3 my-1 bg-border-subtle"
+      role="separator"
+      aria-orientation="horizontal"
+    ></div>
+
     <button
-      class="flex items-center gap-2 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
+      class="group flex items-center gap-2.5 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
       disabled={loading === 'push'}
       onclick={doPush}
       title="Push to remote"
     >
+      {#if loading === 'push'}
+        <Loader2 size={13} class="text-text-faint animate-spin-slow flex-shrink-0" />
+      {:else}
+        <ArrowUpFromLine
+          size={13}
+          class="text-text-faint group-enabled:group-hover:text-text-secondary flex-shrink-0"
+        />
+      {/if}
       <span class="flex-1">Push</span>
       {#if ahead > 0}
         <span
-          class="flex items-center justify-center min-w-4 h-4 px-1 rounded-2xl bg-border text-text text-2xs font-semibold flex-shrink-0"
+          class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
           >{ahead}</span
         >
       {/if}
     </button>
     <button
-      class="flex items-center gap-2 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
+      class="group flex items-center gap-2.5 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
       disabled={loading === 'pull'}
       onclick={doPull}
       title="Pull from remote"
     >
+      {#if loading === 'pull'}
+        <Loader2 size={13} class="text-text-faint animate-spin-slow flex-shrink-0" />
+      {:else}
+        <ArrowDownToLine
+          size={13}
+          class="text-text-faint group-enabled:group-hover:text-text-secondary flex-shrink-0"
+        />
+      {/if}
       <span class="flex-1">Pull</span>
       {#if behind > 0}
         <span
-          class="flex items-center justify-center min-w-4 h-4 px-1 rounded-2xl bg-border text-text text-2xs font-semibold flex-shrink-0"
+          class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
           >{behind}</span
         >
       {/if}
     </button>
     <button
-      class="flex items-center gap-2 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
+      class="group flex items-center gap-2.5 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
       disabled={loading === 'fetch'}
       onclick={doFetch}
       title="Fetch from remote"
     >
+      {#if loading === 'fetch'}
+        <Loader2 size={13} class="text-text-faint animate-spin-slow flex-shrink-0" />
+      {:else}
+        <RefreshCw
+          size={13}
+          class="text-text-faint group-enabled:group-hover:text-text-secondary flex-shrink-0"
+        />
+      {/if}
       <span class="flex-1">Fetch</span>
     </button>
+
+    <div
+      class="h-px mx-3 my-1 bg-border-subtle"
+      role="separator"
+      aria-orientation="horizontal"
+    ></div>
+
     <button
-      class="flex items-center gap-2 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
+      class="group flex items-center gap-2.5 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
       disabled={!workspaceState.isDirty || loading === 'stash'}
       onclick={doStash}
       title={workspaceState.isDirty ? 'Stash changes' : 'Nothing to stash'}
     >
+      {#if loading === 'stash'}
+        <Loader2 size={13} class="text-text-faint animate-spin-slow flex-shrink-0" />
+      {:else}
+        <Archive
+          size={13}
+          class="text-text-faint group-enabled:group-hover:text-text-secondary flex-shrink-0"
+        />
+      {/if}
       <span class="flex-1">Stash</span>
     </button>
     <button
-      class="flex items-center gap-2 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
+      class="group flex items-center gap-2.5 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
       disabled={loading === 'stashPop'}
       onclick={doStashPop}
       title="Pop stashed changes"
     >
+      {#if loading === 'stashPop'}
+        <Loader2 size={13} class="text-text-faint animate-spin-slow flex-shrink-0" />
+      {:else}
+        <ArchiveRestore
+          size={13}
+          class="text-text-faint group-enabled:group-hover:text-text-secondary flex-shrink-0"
+        />
+      {/if}
       <span class="flex-1">Stash Pop</span>
     </button>
+
+    <div
+      class="h-px mx-3 my-1 bg-border-subtle"
+      role="separator"
+      aria-orientation="horizontal"
+    ></div>
+
     <button
-      class="flex items-center gap-2 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
+      class="group flex items-center gap-2.5 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
       disabled={!workspaceState.branch || loading === 'pr'}
       onclick={doCreatePR}
       title="Create pull request"
     >
+      {#if loading === 'pr'}
+        <Loader2 size={13} class="text-text-faint animate-spin-slow flex-shrink-0" />
+      {:else}
+        <GitPullRequest
+          size={13}
+          class="text-text-faint group-enabled:group-hover:text-accent-text flex-shrink-0"
+        />
+      {/if}
       <span class="flex-1">Create PR</span>
     </button>
   </div>

--- a/src/renderer/src/components/sidebar/GitSection.svelte
+++ b/src/renderer/src/components/sidebar/GitSection.svelte
@@ -187,7 +187,7 @@
       <span class="flex-1">Push</span>
       {#if ahead > 0}
         <span
-          class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
+          class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-sm bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
           >{ahead}</span
         >
       {/if}
@@ -209,7 +209,7 @@
       <span class="flex-1">Pull</span>
       {#if behind > 0}
         <span
-          class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
+          class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-sm bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
           >{behind}</span
         >
       {/if}

--- a/src/renderer/src/components/sidebar/ProjectSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectSection.svelte
@@ -61,7 +61,7 @@
 <CollapsibleSection title="PROJECTS" sectionKey="projects">
   {#snippet headerExtra()}
     <button
-      class="text-2xs font-medium font-inherit text-text-muted bg-transparent border-0 px-1.5 py-px rounded-md cursor-pointer transition-colors duration-fast hover:text-text hover:bg-active"
+      class="inline-flex items-center h-5 px-1.5 rounded-sm font-inherit text-2xs font-medium text-text-faint bg-transparent border-0 cursor-pointer transition-colors duration-fast hover:text-text hover:bg-hover"
       onclick={handleOpenFolder}
       title="Open folder">+ open</button
     >
@@ -72,8 +72,8 @@
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div
-          class="group flex items-center gap-1.5 w-full px-3 py-1 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left hover:bg-hover"
-          class:bg-hover-strong={ws.path === workspaceState.workspace?.path}
+          class="group flex items-center gap-2 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left hover:bg-hover"
+          class:bg-active={ws.path === workspaceState.workspace?.path}
           onclick={() => switchProject(ws.path)}
           title={ws.path}
         >
@@ -95,14 +95,14 @@
             class="flex items-center gap-0.5 ml-auto opacity-0 group-hover:opacity-100 transition-opacity duration-fast flex-shrink-0"
           >
             <button
-              class="flex items-center justify-center w-4.5 h-4.5 border-0 bg-transparent text-text-muted rounded-sm cursor-pointer p-0 hover:text-text hover:bg-hover-strong"
+              class="inline-flex items-center justify-center size-5 border-0 bg-transparent text-text-faint rounded-sm cursor-pointer p-0 transition-colors duration-fast hover:text-text hover:bg-hover"
               onclick={(e) => handlePin(e, ws.id)}
               title="Unpin"
             >
               <PinOff size={11} />
             </button>
             <button
-              class="flex items-center justify-center w-4.5 h-4.5 border-0 bg-transparent text-text-muted rounded-sm cursor-pointer p-0 hover:text-text hover:bg-hover-strong"
+              class="inline-flex items-center justify-center size-5 border-0 bg-transparent text-text-faint rounded-sm cursor-pointer p-0 transition-colors duration-fast hover:text-text hover:bg-hover"
               onclick={(e) => handleRemove(e, ws.id, ws.name)}
               title="Remove"
             >
@@ -120,8 +120,8 @@
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div
-          class="group flex items-center gap-1.5 w-full px-3 py-1 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left hover:bg-hover"
-          class:bg-hover-strong={ws.path === workspaceState.workspace?.path}
+          class="group flex items-center gap-2 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left hover:bg-hover"
+          class:bg-active={ws.path === workspaceState.workspace?.path}
           onclick={() => switchProject(ws.path)}
           title={ws.path}
         >
@@ -143,14 +143,14 @@
             class="flex items-center gap-0.5 ml-auto opacity-0 group-hover:opacity-100 transition-opacity duration-fast flex-shrink-0"
           >
             <button
-              class="flex items-center justify-center w-4.5 h-4.5 border-0 bg-transparent text-text-muted rounded-sm cursor-pointer p-0 hover:text-text hover:bg-hover-strong"
+              class="inline-flex items-center justify-center size-5 border-0 bg-transparent text-text-faint rounded-sm cursor-pointer p-0 transition-colors duration-fast hover:text-text hover:bg-hover"
               onclick={(e) => handlePin(e, ws.id)}
               title="Pin"
             >
               <Pin size={11} />
             </button>
             <button
-              class="flex items-center justify-center w-4.5 h-4.5 border-0 bg-transparent text-text-muted rounded-sm cursor-pointer p-0 hover:text-text hover:bg-hover-strong"
+              class="inline-flex items-center justify-center size-5 border-0 bg-transparent text-text-faint rounded-sm cursor-pointer p-0 transition-colors duration-fast hover:text-text hover:bg-hover"
               onclick={(e) => handleRemove(e, ws.id, ws.name)}
               title="Remove"
             >

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -375,7 +375,7 @@
     {@const collapsed = collapseState[project.workspace.path] ?? false}
     {@const merged = getMerged(project)}
     <div class="mb-0.5">
-      <div class="flex items-center justify-between pl-3 pr-2">
+      <div class="flex items-center justify-between pl-3 pr-3">
         <button
           class="group flex items-center gap-1 flex-1 min-w-0 bg-transparent border-0 py-1 cursor-pointer text-inherit rounded-sm"
           class:bg-active={!project.isGitRepo &&
@@ -457,7 +457,7 @@
               class:pointer-events-none={isRemoving}
             >
               <button
-                class="flex items-center gap-1.5 flex-1 min-w-0 py-1 pr-2 pl-6 border-0 bg-transparent text-text-secondary text-sm font-inherit cursor-pointer text-left rounded-sm mx-1 hover:bg-hover hover:text-text"
+                class="flex items-center gap-1.5 flex-1 min-w-0 h-7 pr-2 pl-6 border-0 bg-transparent text-text-secondary text-sm font-inherit cursor-pointer text-left rounded-sm mx-1 hover:bg-hover hover:text-text"
                 class:bg-active={wt.path === workspaceState.selectedWorktreePath}
                 class:text-text={wt.path === workspaceState.selectedWorktreePath}
                 onclick={() => selectWorktree(wt.path)}
@@ -530,20 +530,20 @@
                   <span
                     role="button"
                     tabindex="-1"
-                    class="inline-flex items-center justify-center w-4 h-4 p-0 border-0 bg-transparent text-warning-text cursor-pointer flex-shrink-0 rounded-sm transition-colors duration-fast hover:text-danger hover:bg-danger-bg"
+                    class="inline-flex items-center justify-center size-5 p-0 border-0 bg-transparent text-danger-text cursor-pointer flex-shrink-0 rounded-sm transition-colors duration-fast hover:bg-danger-bg"
                     title="Stop all terminals in this worktree"
                     onclick={(e) => {
                       e.stopPropagation()
                       stopWorktree(e, wt.path)
                     }}
                   >
-                    <Square size={8} />
+                    <Square size={10} fill="currentColor" />
                   </span>
                 {/if}
               </button>
               {#if !wtActive && !wt.isMain && merged.has(wt.branch) && !isRemoving}
                 <button
-                  class="flex items-center justify-center w-6 h-6 p-0 border-0 bg-transparent text-text-faint cursor-pointer flex-shrink-0 rounded-md mr-1 transition-colors duration-fast hover:text-danger hover:bg-danger-bg"
+                  class="inline-flex items-center justify-center size-5 p-0 border-0 bg-transparent text-text-faint cursor-pointer flex-shrink-0 rounded-sm mr-3 transition-colors duration-fast hover:text-danger-text hover:bg-danger-bg"
                   title="Remove worktree and delete branch"
                   aria-label="Remove worktree and delete branch"
                   onclick={(e) => removeWorktree(e, project, wt)}

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -315,40 +315,40 @@
 {#if ctxMenu}
   <div class="fixed inset-0 z-overlay" use:portal onclick={closeCtxMenu}>
     <div
-      class="fixed min-w-45 bg-bg-overlay border border-border rounded-xl shadow-ctx p-1 z-popover"
+      class="fixed min-w-45 bg-bg-overlay border border-border rounded-md shadow-ctx p-1 z-popover"
       style="left: {ctxMenu.x}px; top: {ctxMenu.y}px"
       onclick={(e) => e.stopPropagation()}
     >
       <button
-        class="block w-full px-2.5 py-1.5 border-0 rounded-md bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-active"
+        class="block w-full px-2.5 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
         onclick={ctxRevealInFileManager}>{fileManagerLabel()}</button
       >
       <button
-        class="block w-full px-2.5 py-1.5 border-0 rounded-md bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-active"
+        class="block w-full px-2.5 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
         onclick={ctxCopyPath}>Copy Path</button
       >
       {#if ctxMenu.wt.branch !== '(detached)'}
         <button
-          class="block w-full px-2.5 py-1.5 border-0 rounded-md bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-active"
+          class="block w-full px-2.5 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
           onclick={ctxCopyBranch}>Copy Branch Name</button
         >
         <div class="h-px mx-2 my-1 bg-border-subtle"></div>
         <button
-          class="block w-full px-2.5 py-1.5 border-0 rounded-md bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-active"
+          class="block w-full px-2.5 py-1.5 border-0 rounded-sm bg-transparent text-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
           onclick={ctxNewWorktree}>New Worktree from Branch</button
         >
       {/if}
       {#if isWorktreeActive(ctxMenu.wt.path)}
         <div class="h-px mx-2 my-1 bg-border-subtle"></div>
         <button
-          class="block w-full px-2.5 py-1.5 border-0 rounded-md bg-transparent text-danger-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-active"
+          class="block w-full px-2.5 py-1.5 border-0 rounded-sm bg-transparent text-danger-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
           onclick={ctxStopAll}>Stop All Terminals</button
         >
       {/if}
       {#if !ctxMenu.wt.isMain}
         <div class="h-px mx-2 my-1 bg-border-subtle"></div>
         <button
-          class="block w-full px-2.5 py-1.5 border-0 rounded-md bg-transparent text-danger-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-active"
+          class="block w-full px-2.5 py-1.5 border-0 rounded-sm bg-transparent text-danger-text text-md font-inherit cursor-pointer text-left transition-colors duration-fast hover:bg-hover"
           onclick={ctxRemoveWorktree}>Remove Worktree</button
         >
       {/if}
@@ -357,10 +357,12 @@
 {/if}
 
 <section class="py-3">
-  <div class="flex items-center justify-between px-3 pb-2">
-    <h3 class="text-2xs font-semibold tracking-caps uppercase text-text-muted">PROJECTS</h3>
+  <div class="flex items-center justify-between px-3 h-7 mb-1">
+    <h3 class="text-2xs font-semibold tracking-caps-looser uppercase text-text-faint leading-tight">
+      PROJECTS
+    </h3>
     <button
-      class="font-inherit text-2xs font-medium text-text-secondary bg-transparent border-0 p-0 cursor-pointer transition-colors duration-fast hover:text-accent-text"
+      class="inline-flex items-center h-5 px-1.5 rounded-sm font-inherit text-2xs font-medium text-text-faint bg-transparent border-0 cursor-pointer transition-colors duration-fast hover:text-text hover:bg-hover"
       onclick={handleAttachProject}
       title="Attach a project folder"
       aria-label="Attach a project folder"
@@ -375,10 +377,8 @@
     <div class="mb-0.5">
       <div class="flex items-center justify-between pl-3 pr-2">
         <button
-          class="group flex items-center gap-1 flex-1 min-w-0 bg-transparent border-0 py-1 cursor-pointer text-inherit"
-          class:bg-hover-strong={!project.isGitRepo &&
-            workspaceState.selectedWorktreePath === project.workspace.path}
-          class:rounded-md={!project.isGitRepo &&
+          class="group flex items-center gap-1 flex-1 min-w-0 bg-transparent border-0 py-1 cursor-pointer text-inherit rounded-sm"
+          class:bg-active={!project.isGitRepo &&
             workspaceState.selectedWorktreePath === project.workspace.path}
           onclick={() => {
             if (project.isGitRepo) {
@@ -422,19 +422,19 @@
         <div class="flex items-center gap-0.5 flex-shrink-0">
           {#if project.isGitRepo}
             <button
-              class="font-mono text-2xs font-medium text-accent-text bg-transparent border-0 px-1.5 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:text-accent hover:bg-accent-bg"
+              class="inline-flex items-center h-5 px-1.5 rounded-sm font-inherit text-2xs font-medium text-text-faint bg-transparent border-0 cursor-pointer transition-colors duration-fast hover:text-accent-text hover:bg-accent-bg"
               onclick={(e) => handleNewWorktree(e, project)}
               title="Create worktree">+ new</button
             >
           {:else}
             <button
-              class="font-mono text-2xs font-medium text-accent-text bg-transparent border-0 px-1.5 py-0.5 rounded-sm cursor-pointer transition-colors duration-fast hover:text-accent hover:bg-accent-bg"
+              class="inline-flex items-center h-5 px-1.5 rounded-sm font-inherit text-2xs font-medium text-text-faint bg-transparent border-0 cursor-pointer transition-colors duration-fast hover:text-accent-text hover:bg-accent-bg"
               onclick={(e) => handleInitGit(e, project)}
               title="Initialize git repository">init</button
             >
           {/if}
           <button
-            class="flex items-center justify-center w-4.5 h-4.5 p-0 border-0 bg-transparent text-text-faint cursor-pointer rounded-sm transition-colors duration-fast hover:text-text-secondary hover:bg-hover"
+            class="inline-flex items-center justify-center size-5 p-0 border-0 bg-transparent text-text-faint cursor-pointer rounded-sm transition-colors duration-fast hover:text-text hover:bg-hover"
             onclick={(e) => handleDetach(e, project)}
             title="Detach project from window"
             aria-label="Detach project from window"
@@ -497,17 +497,18 @@
                 >
                 {#if isRemoving}
                   <span
-                    class="text-micro font-medium text-warning-text flex-shrink-0 animate-badge-pulse motion-reduce:animate-none"
-                    >removing...</span
+                    class="inline-flex items-center h-4 px-1.5 rounded-md text-2xs font-semibold uppercase tracking-caps-tight bg-warning-bg text-warning-text leading-tight flex-shrink-0 animate-badge-pulse motion-reduce:animate-none"
+                    >removing</span
                   >
                 {:else if wt.branch === '(detached)'}
                   <span
-                    class="text-micro font-medium font-mono text-warning-text flex-shrink-0"
+                    class="inline-flex items-center h-4 px-1.5 rounded-md text-2xs font-semibold font-mono tracking-caps-tight bg-border-subtle text-warning-text leading-tight flex-shrink-0"
                     title={wt.head}>{wt.head.slice(0, 7)}</span
                   >
                 {:else if merged.has(wt.branch)}
-                  <span class="text-micro font-medium text-success flex-shrink-0" title="Merged"
-                    >merged</span
+                  <span
+                    class="inline-flex items-center h-4 px-1.5 rounded-md text-2xs font-semibold uppercase tracking-caps-tight bg-border-subtle text-success-text leading-tight flex-shrink-0"
+                    title="Merged">merged</span
                   >
                 {/if}
                 {#if prMap[wt.branch]}

--- a/src/renderer/src/components/sidebar/RunConfigSection.svelte
+++ b/src/renderer/src/components/sidebar/RunConfigSection.svelte
@@ -73,7 +73,7 @@
 <CollapsibleSection title="RUN" sectionKey="runConfigs" borderTop>
   {#snippet headerExtra()}
     <button
-      class="flex items-center justify-center w-6 h-6 -my-1 border-0 bg-transparent text-text-muted cursor-pointer rounded-md transition-colors duration-fast hover:bg-hover hover:text-text"
+      class="inline-flex items-center justify-center size-5 -my-1 border-0 bg-transparent text-text-faint cursor-pointer rounded-sm transition-colors duration-fast hover:bg-hover hover:text-text"
       title="Add configuration"
       onclick={() => showRunConfigManager()}
     >
@@ -85,7 +85,7 @@
     {#each [...grouped.entries()] as [relativePath, group] (relativePath)}
       {#if relativePath !== '.'}
         <li
-          class="px-3 pt-1 pb-0.5 text-2xs font-semibold text-text-muted uppercase tracking-caps-tight"
+          class="px-3 pt-1 pb-0.5 text-2xs font-semibold text-text-faint uppercase tracking-caps-looser leading-tight"
         >
           {relativePath}
         </li>
@@ -100,11 +100,11 @@
           >
             {config.name}
           </button>
-          <div class="flex gap-px flex-shrink-0 opacity-0 group-hover:opacity-100">
+          <div class="flex gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100">
             {#if runningCount > 0}
               <Tooltip text={runningCount > 1 ? `Stop all (${runningCount})` : 'Stop'}>
                 <button
-                  class="relative flex items-center justify-center w-5.5 h-5.5 border-0 bg-transparent text-danger-text cursor-pointer rounded-md flex-shrink-0 hover:bg-hover-strong"
+                  class="relative inline-flex items-center justify-center size-6 border-0 bg-transparent text-danger-text cursor-pointer rounded-sm flex-shrink-0 transition-colors duration-fast hover:bg-hover-strong"
                   aria-label={runningCount > 1
                     ? `Stop all ${runningCount} sessions for ${config.name}`
                     : `Stop ${config.name}`}
@@ -113,7 +113,7 @@
                   <Square size={12} />
                   {#if runningCount > 1}
                     <span
-                      class="absolute -top-0.5 -right-0.5 min-w-3.5 h-3.5 px-px rounded-2xl bg-accent-bg text-accent-text text-micro font-bold leading-3.5 text-center"
+                      class="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center min-w-3.5 h-3.5 px-px rounded-md bg-accent-bg text-accent-text text-micro font-bold leading-tight"
                       >{runningCount}</span
                     >
                   {/if}
@@ -122,7 +122,7 @@
             {:else}
               <Tooltip text="Run">
                 <button
-                  class="flex items-center justify-center w-5.5 h-5.5 border-0 bg-transparent text-success-text cursor-pointer rounded-md flex-shrink-0 hover:bg-hover-strong"
+                  class="inline-flex items-center justify-center size-6 border-0 bg-transparent text-success-text cursor-pointer rounded-sm flex-shrink-0 transition-colors duration-fast hover:bg-hover-strong"
                   aria-label={`Run ${config.name}`}
                   onclick={() => handlePlay(group.configDir, config.name)}
                 >
@@ -132,7 +132,7 @@
             {/if}
             <Tooltip text="Delete">
               <button
-                class="flex items-center justify-center w-5.5 h-5.5 border-0 bg-transparent text-text-muted cursor-pointer rounded-md flex-shrink-0 hover:bg-hover-strong hover:text-danger-text"
+                class="inline-flex items-center justify-center size-6 border-0 bg-transparent text-text-muted cursor-pointer rounded-sm flex-shrink-0 transition-colors duration-fast hover:bg-hover-strong hover:text-danger-text"
                 aria-label={`Delete ${config.name}`}
                 onclick={() => handleDelete(group.configDir, config.name)}
               >

--- a/src/renderer/src/components/sidebar/Sidebar.svelte
+++ b/src/renderer/src/components/sidebar/Sidebar.svelte
@@ -35,7 +35,7 @@
   class="flex-shrink-0 h-full bg-bg-glass backdrop-blur-xl border-r border-border-subtle flex flex-col overflow-hidden"
   style="width: {width}px; min-width: {width}px"
 >
-  <div class="flex-1 min-h-0 overflow-y-auto flex flex-col">
+  <div class="flex-1 min-h-0 overflow-y-auto flex flex-col [scrollbar-gutter:stable]">
     {#each sections as section (section.id)}
       {#if section.visible}
         {#if section.id === 'projects'}
@@ -56,9 +56,11 @@
       {/if}
     {/each}
   </div>
-  <div class="flex-shrink-0 px-3 py-2 border-t border-border-subtle">
+  <div class="flex-shrink-0 px-3 h-7 border-t border-border-subtle flex items-center">
     {#if version}
-      <span class="text-xs text-text-faint select-none">v{version}</span>
+      <span class="text-2xs text-text-faint tracking-caps-tight uppercase select-none"
+        >v{version}</span
+      >
     {/if}
   </div>
 </aside>

--- a/src/renderer/src/components/sidebar/TaskTrackerSection.svelte
+++ b/src/renderer/src/components/sidebar/TaskTrackerSection.svelte
@@ -155,7 +155,8 @@
               title={tracker.baseUrl || 'Not configured'}
               >{tracker.baseUrl || 'Not configured'}</span
             >
-            <span class="text-2xs text-text-faint flex-shrink-0"
+            <span
+              class="inline-flex items-center h-4 px-1.5 rounded-md text-2xs font-semibold uppercase tracking-caps-tight bg-border-subtle text-text-muted leading-tight flex-shrink-0"
               >{providerLabel(tracker.provider)}</span
             >
             {#if hasCreds}
@@ -167,7 +168,9 @@
     </ul>
 
     {#if activeTask}
-      <div class="flex items-center gap-2 px-3 py-1.5 border-t border-border-subtle">
+      <div
+        class="flex items-center gap-2 mx-2 mt-1 px-3 py-1.5 rounded-md bg-bg-elevated border border-border-subtle"
+      >
         <span class="text-xs font-semibold text-accent-text flex-shrink-0"
           >{activeTask.taskKey}</span
         >

--- a/src/renderer/src/components/sidebar/ToolSection.svelte
+++ b/src/renderer/src/components/sidebar/ToolSection.svelte
@@ -61,7 +61,7 @@
             <span class="overflow-hidden text-ellipsis whitespace-nowrap flex-1">{tool.name}</span>
             {#if count > 0}
               <span
-                class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
+                class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-sm bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
                 >{count}</span
               >
             {/if}
@@ -83,12 +83,12 @@
             <span class="overflow-hidden text-ellipsis whitespace-nowrap flex-1">{tool.name}</span>
             {#if count > 0}
               <span
-                class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
+                class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-sm bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
                 >{count}</span
               >
             {:else}
               <span
-                class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-border-subtle text-text-muted text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
+                class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-sm bg-border-subtle text-text-muted text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
                 >{profiles.length}</span
               >
             {/if}
@@ -126,7 +126,7 @@
           <span class="overflow-hidden text-ellipsis whitespace-nowrap flex-1">{tool.name}</span>
           {#if count > 0}
             <span
-              class="flex items-center justify-center min-w-4 h-4 px-1 rounded-2xl bg-border text-text text-2xs font-semibold flex-shrink-0"
+              class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-sm bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
               >{count}</span
             >
           {/if}

--- a/src/renderer/src/components/sidebar/ToolSection.svelte
+++ b/src/renderer/src/components/sidebar/ToolSection.svelte
@@ -61,7 +61,7 @@
             <span class="overflow-hidden text-ellipsis whitespace-nowrap flex-1">{tool.name}</span>
             {#if count > 0}
               <span
-                class="flex items-center justify-center min-w-4 h-4 px-1 rounded-2xl bg-border text-text text-2xs font-semibold flex-shrink-0"
+                class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
                 >{count}</span
               >
             {/if}
@@ -83,12 +83,12 @@
             <span class="overflow-hidden text-ellipsis whitespace-nowrap flex-1">{tool.name}</span>
             {#if count > 0}
               <span
-                class="flex items-center justify-center min-w-4 h-4 px-1 rounded-2xl bg-border text-text text-2xs font-semibold flex-shrink-0"
+                class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-accent-bg text-accent-text text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
                 >{count}</span
               >
             {:else}
               <span
-                class="flex items-center justify-center min-w-4 h-4 px-1 rounded-2xl bg-transparent text-text-faint text-2xs font-medium flex-shrink-0"
+                class="inline-flex items-center justify-center min-w-4 h-4 px-1.5 rounded-md bg-border-subtle text-text-muted text-2xs font-semibold tracking-caps-tight leading-tight flex-shrink-0"
                 >{profiles.length}</span
               >
             {/if}

--- a/src/renderer/src/components/sidebar/WorktreeSection.svelte
+++ b/src/renderer/src/components/sidebar/WorktreeSection.svelte
@@ -102,7 +102,7 @@
 <CollapsibleSection title="WORKTREES" sectionKey="worktrees">
   {#snippet headerExtra()}
     <button
-      class="text-2xs font-medium font-inherit text-text-muted bg-transparent border-0 px-1.5 py-px rounded-md cursor-pointer transition-colors duration-fast hover:text-text hover:bg-active"
+      class="inline-flex items-center h-5 px-1.5 rounded-sm font-inherit text-2xs font-medium text-text-faint bg-transparent border-0 cursor-pointer transition-colors duration-fast hover:text-text hover:bg-hover"
       onclick={showCreateWorktree}
       title="Create worktree">+ new</button
     >
@@ -111,8 +111,8 @@
     {#each workspaceState.worktrees as wt (wt.path)}
       <li class="flex items-center">
         <button
-          class="flex items-center gap-1 flex-1 min-w-0 px-3 py-1 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left hover:bg-hover"
-          class:bg-hover-strong={wt.path === workspaceState.selectedWorktreePath}
+          class="flex items-center gap-2 flex-1 min-w-0 h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left hover:bg-hover"
+          class:bg-active={wt.path === workspaceState.selectedWorktreePath}
           onclick={() => selectWorktree(wt.path)}
         >
           <span class="font-mono text-xs text-text-secondary w-2.5 flex-shrink-0"
@@ -123,12 +123,13 @@
           >
           {#if wt.branch === '(detached)'}
             <span
-              class="text-2xs font-medium font-mono text-warning-text flex-shrink-0 ml-auto"
+              class="ml-auto inline-flex items-center h-4 px-1.5 rounded-md text-2xs font-semibold font-mono tracking-caps-tight bg-border-subtle text-warning-text leading-tight flex-shrink-0"
               title={wt.head}>{wt.head.slice(0, 7)}</span
             >
           {:else if mergedBranches.has(wt.branch)}
-            <span class="text-2xs font-medium text-success flex-shrink-0 ml-auto" title="Merged"
-              >merged</span
+            <span
+              class="ml-auto inline-flex items-center h-4 px-1.5 rounded-md text-2xs font-semibold uppercase tracking-caps-tight bg-border-subtle text-success-text leading-tight flex-shrink-0"
+              title="Merged">merged</span
             >
           {/if}
           {#if prMap[wt.branch]}
@@ -148,7 +149,7 @@
         </button>
         {#if !wt.isMain && mergedBranches.has(wt.branch)}
           <button
-            class="flex items-center justify-center w-6 h-6 p-0 border-0 bg-transparent text-text-faint cursor-pointer flex-shrink-0 rounded-md mr-1 transition-colors duration-fast hover:text-danger hover:bg-danger-bg"
+            class="inline-flex items-center justify-center size-6 p-0 border-0 bg-transparent text-text-faint cursor-pointer flex-shrink-0 rounded-md mr-1 transition-colors duration-fast hover:text-danger-text hover:bg-danger-bg"
             title="Remove worktree and delete branch"
             aria-label="Remove worktree and delete branch"
             onclick={(e) => removeWorktree(e, wt)}

--- a/src/renderer/src/components/sidebar/_partials/FileTypeIcon.svelte
+++ b/src/renderer/src/components/sidebar/_partials/FileTypeIcon.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import {
+    File,
+    FileCode,
+    FileJson,
+    FileText,
+    FileType,
+    FileCog,
+    BookOpen,
+    Package,
+    Diamond,
+  } from '@lucide/svelte'
+
+  let { name, size = 13 }: { name: string; size?: number } = $props()
+
+  type IconDef = {
+    Icon: typeof File
+    tone: string
+  }
+
+  function resolve(filename: string): IconDef {
+    const lower = filename.toLowerCase()
+
+    if (lower === 'package.json' || lower === 'package-lock.json' || lower === 'bun.lockb') {
+      return { Icon: Package, tone: 'text-warning-text' }
+    }
+    if (lower.startsWith('readme')) {
+      return { Icon: BookOpen, tone: 'text-success-text' }
+    }
+    if (lower === '.gitignore' || lower === '.gitattributes' || lower === '.gitmodules') {
+      return { Icon: Diamond, tone: 'text-danger-text' }
+    }
+    if (lower === '.editorconfig' || lower.endsWith('.config.js') || lower.endsWith('.config.ts')) {
+      return { Icon: FileCog, tone: 'text-text-muted' }
+    }
+
+    const ext = lower.includes('.') ? lower.slice(lower.lastIndexOf('.') + 1) : ''
+    switch (ext) {
+      case 'ts':
+      case 'tsx':
+      case 'cts':
+      case 'mts':
+        return { Icon: FileCode, tone: 'text-accent-text' }
+      case 'js':
+      case 'jsx':
+      case 'cjs':
+      case 'mjs':
+        return { Icon: FileCode, tone: 'text-warning-text' }
+      case 'svelte':
+      case 'vue':
+        return { Icon: FileCode, tone: 'text-danger-text' }
+      case 'json':
+      case 'jsonc':
+        return { Icon: FileJson, tone: 'text-warning-text' }
+      case 'yaml':
+      case 'yml':
+      case 'toml':
+        return { Icon: FileCog, tone: 'text-text-muted' }
+      case 'css':
+      case 'scss':
+      case 'sass':
+      case 'less':
+        return { Icon: FileType, tone: 'text-accent-text' }
+      case 'md':
+      case 'mdx':
+        return { Icon: FileText, tone: 'text-success-text' }
+      case 'txt':
+      case 'log':
+        return { Icon: FileText, tone: 'text-text-muted' }
+      case 'rs':
+      case 'go':
+      case 'py':
+      case 'rb':
+      case 'sh':
+      case 'fish':
+      case 'zsh':
+      case 'bash':
+        return { Icon: FileCode, tone: 'text-text-muted' }
+      default:
+        return { Icon: File, tone: 'text-text-muted' }
+    }
+  }
+
+  let resolved = $derived(resolve(name))
+  let Icon = $derived(resolved.Icon)
+</script>
+
+<Icon {size} class="flex-shrink-0 {resolved.tone}" />

--- a/src/renderer/src/lib/onboarding/steps.ts
+++ b/src/renderer/src/lib/onboarding/steps.ts
@@ -170,6 +170,30 @@ export const onboardingSteps: OnboardingStep[] = [
     introducedIn: '0.12.0',
     category: 'feature',
   },
+  {
+    id: 'file-tree-create',
+    title: 'Create files and folders from the sidebar',
+    description:
+      'The Files section now has a + button at the top of the tree, and each directory reveals a + button on hover. Click either one and type a name (or a nested path like "subdir/newfile.ts") to create a file or folder in place. Missing parent directories are created automatically.',
+    introducedIn: '0.13.0',
+    category: 'feature',
+  },
+  {
+    id: 'welcome-filter',
+    title: 'Filter recents on the welcome dashboard',
+    description:
+      'When you have more than four recent workspaces, the welcome dashboard shows a filter input. Press / to focus it, ↑/↓ to move between rows, Enter to open, and Cmd/Ctrl+Backspace to remove a workspace from the list.',
+    introducedIn: '0.13.0',
+    category: 'feature',
+  },
+  {
+    id: 'settings-backup',
+    title: 'Backup and restore settings',
+    description:
+      'The Settings dialog footer now has Export and Import buttons. Export writes a JSON snapshot of preferences, tracker configs, and skill settings; Import merges or replaces the current settings from a snapshot. Useful for syncing across machines or recovering after a reset.',
+    introducedIn: '0.13.0',
+    category: 'feature',
+  },
 ]
 
 export function getFirstLaunchSteps(): OnboardingStep[] {

--- a/src/renderer/src/lib/stores/workspace.svelte.ts
+++ b/src/renderer/src/lib/stores/workspace.svelte.ts
@@ -1,4 +1,4 @@
-import { restoreLayout, closeAllTabsForWorktree } from './tabs.svelte'
+import { restoreLayout, closeAllTabsForWorktree, killAllTabs, tabsByWorktree } from './tabs.svelte'
 import {
   loadRepoConfig,
   getRepoConfig,
@@ -354,11 +354,25 @@ export async function detachProject(path: string): Promise<void> {
   const project = projects[idx]
   console.warn(`[workspace] detaching "${project.workspace.name}" (${path})`)
 
-  // Close tabs for all worktrees of this project (kills PTY sessions)
-  const worktreePaths = project.isGitRepo
-    ? project.worktrees.map((wt) => wt.path)
-    : [project.workspace.path]
-  for (const wtPath of worktreePaths) {
+  // Close tabs for every path owned by this project (kills PTY sessions).
+  // Includes workspace path, repoRoot, all worktree paths, plus any
+  // tabsByWorktree key under the repo root — so nothing lingers under a
+  // stale or symlink-normalized key.
+  const ownedPaths: string[] = []
+  const addPath = (p: string | null | undefined): void => {
+    if (p && !ownedPaths.includes(p)) ownedPaths.push(p)
+  }
+  addPath(project.workspace.path)
+  addPath(project.repoRoot)
+  for (const wt of project.worktrees) addPath(wt.path)
+  if (project.repoRoot) {
+    const normalize = (s: string): string => s.replace(/\\/g, '/')
+    const rootNorm = normalize(project.repoRoot) + '/'
+    for (const key of Object.keys(tabsByWorktree)) {
+      if (normalize(key).startsWith(rootNorm)) addPath(key)
+    }
+  }
+  for (const wtPath of ownedPaths) {
     await closeAllTabsForWorktree(wtPath)
   }
 
@@ -399,6 +413,12 @@ export async function detachProject(path: string): Promise<void> {
       // No projects left — stop the file tree watcher
       await window.api.unwatchFiles()
     }
+  }
+
+  // Safety net: if no projects remain, kill any remaining PTYs/tabs that
+  // might have been registered under stale keys, so the dashboard can render.
+  if (projects.length === 0 && Object.keys(tabsByWorktree).length > 0) {
+    await killAllTabs()
   }
 }
 


### PR DESCRIPTION
## What

Reskins almost every surface of the renderer to a single design dialect: `text-text-faint` baseline, `tracking-caps-looser` uppercase section labels, `bg-bg-overlay` popovers, squared `rounded-sm` chips and badges, `size-5` icon buttons, and **fixed-height rows everywhere** to prevent layout shift on hover. Touched surfaces include preferences, sidebar (file tree, git, projects/worktrees), dashboard, status bar, right inspector, diff panel, file editor, and the `Cmd+K` command palette. The branch also closes a long list of accessibility and privacy gaps surfaced by self-review.

## Why

Different surfaces had drifted into different dialects (mixed paddings, mixed badge radii, mixed text-muted vs text-faint baselines), and several high-traffic UIs had cosmetic glitches: layout shifts when hover-revealed actions appeared, summary bars that didn't fill their tracks, alignment mismatches between right-side action columns, and a margin-reset rule in `tokens.css` that silently clobbered every Tailwind margin utility. Bringing the surfaces into one dialect makes the app feel coherent and made it possible to fix the cosmetic issues with shared patterns rather than per-surface bandaids.

The accessibility/privacy track (real `<form>`/`<input>` elements, focus traps, masked secrets, env-shape validation, slugified IDs, focus-visible affordances) was driven by a self-review pass — most of the items there are small targeted fixes rather than redesigns.

## Highlights

- **Visual:** unified section labels, fixed-height rows, squared chips, accent-tint selection (replacing heavy gray flashes), per-category icons in command palette section headers, file-type icons in the sidebar tree, full-bleed active band, hover-revealed inline actions that don't shift the layout.
- **Functional:** new file/folder create from sidebar tree (`fs:createFile` / `fs:mkdir` IPC, walked-up parent validation), git-aware file tree with status letters, welcome dashboard filter + roving keyboard nav, settings export/import surfaced from the prefs sidebar footer.
- **Bugs:** universal margin reset wrapped in `@layer base` so utilities can override it; diff summary bar fills its track; per-row hover doesn't change row height in changes panel and editor toolbar; status-bar buttons don't shift when toggled active.
- **A11y:** real form elements in skill/tool forms, keyboard nav and focus restoration in welcome context menu and `SeparatorPopover`, Tab trapping in Settings dialog with Cmd/Ctrl+K gated to OS, named controls in PrefsRow, focus-revealed profile delete button.
- **Privacy:** SavedPasswords reveal window extended; new env vars masked by default; env JSON shape validated with warnings on secret-named vars; SavedPasswords storage description honest about what's persisted where.
- **Refactor hygiene:** `if/else` chains over discriminated unions replaced with `ts-pattern` (TrackerEditForm); unused styles dropped; large preferences panels split into `_partials/`.

## How to test

1. `npm install && npm run dev`
2. **Unified dialect** — open the app and skim:
   - Sidebar section labels (`PROJECTS`, `WORKTREES`, `GIT`, `FILES`, `TOOLS`) all read at `text-text-faint` with the loose tracking.
   - Right-inspector tabs, dashboard rows, command palette section headers all share the dialect.
3. **Command palette (`Cmd+K`)** — modal radius is `rounded-lg`; magnifier icon in the input; section headers have a leading icon (Wrench / GitCommit / Branch / Panel / Sliders); selected row uses the accent tint, not heavy gray; "Not found in PATH" renders as a squared chip; shortcuts are squared mono chips.
4. **File tree create** — hover a directory → `+` icon appears in the right gutter at a stable column → click → enter `subdir/newfile.ts` → file (and any missing parents) is created. Repeat with the top-level `+` button. Verify "Access denied" never fires for valid in-workspace paths (was broken before this branch).
5. **Layout-shift checks** — hover diff file rows, sidebar rows with action buttons, editor sub-tabs, status bar buttons. Toggle status-bar active states. None should change row height.
6. **Welcome dashboard** — recent-workspace context menu opens with focus on first item; arrow keys cycle; Escape closes and restores focus.
7. **Preferences** — open with `Cmd+,`; Tab cycles only inside the dialog; `Cmd+K` is forwarded to the OS, not captured. Trigger skill install error to verify toast surfaces it.
8. **Privacy** — add a `SECRET=foo` env var → masked by default with a reveal toggle. Paste invalid env JSON → warning surfaces. Open SavedPasswords → reveal countdown is 15s.
9. `npm run typecheck`, `npm run svelte-check`, `npm run lint` — all pass on this branch.

## Screenshots

(omitted from PR body — visual changes are pervasive; reviewers should run the branch.)

## Checklist

- [x] Conventional commit messages
- [x] `typecheck` passes
- [x] `svelte-check` passes
- [x] `lint` passes (only pre-existing warnings in unrelated files)
- [x] Docs updated where user-visible behavior changed (`docs/features/file-editor.md`, `docs/features/settings-export.md`)
- [x] No new tokens added — all changes use existing `tokens.css` vars
- [ ] Tests — no automated UI tests in this repo; manual verification only
- [ ] Screenshots — see commits 7f921b9, 609ddea, 14164f0 etc. for the relevant areas