### PR TITLE
fix(terminal): hide cursor during conpty redraws on windows

### DIFF
--- a/docs/core/terminal.md
+++ b/docs/core/terminal.md
@@ -48,6 +48,16 @@ The WsBridge maintains a circular buffer of up to 1 MB of PTY output per session
 4. The resize callback calls `window.api.resizePty(sessionId, cols, rows)` which forwards to `PtyManager.resize()`.
 5. When the user clicks back into a terminal after a remote peer resized the PTY, the component always sends `resizePty` on `pointerdown`/`focus` to reclaim the desktop dimensions.
 
+### Cursor handling on Windows (ConPTY)
+
+ConPTY repaints arrive as a stream of CUP+char runs, so without intervention the xterm cursor visibly traces the path of every redraw. To suppress this on Windows only:
+
+1. Each output burst is bracketed with DECTCEM hide (`\x1b[?25l`) before the data and a debounced restore (`\x1b[?25h`) 80ms after the last burst.
+2. The burst data is scanned for the last `\x1b[?25[lh]` sequence the TUI emitted; if the TUI ended with the cursor explicitly hidden (e.g. `claude` while thinking, `vim` during paste), the restore timer is skipped so the TUI's intent is honored.
+3. On disposal, any pending restore timer is cleared and the cursor is re-shown so no hidden-cursor state leaks across tab close.
+
+macOS and Linux are unaffected — `writeBurst` falls through to a plain scroll-preserving write without DECTCEM bracketing.
+
 ### Pane tab strip controls
 
 In split layouts, each pane shows a strip above the pane body with the pane title and actions:

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -56,6 +56,13 @@
   let pendingData = ''
   let writeScheduled = false
   let writeRafId: number | null = null
+  let cursorHiddenForBurst = false
+  let cursorRestoreTimer: ReturnType<typeof setTimeout> | null = null
+  const isWindows = window.api.platform === 'win32'
+  // ConPTY repaints arrive as a stream of CUP+char runs, so the cursor visibly
+  // traces the path of every redraw. Bracket each batch with DECTCEM hide/show
+  // and debounce restoration so it reappears once output settles.
+  const CURSOR_RESTORE_MS = 80
   let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null
   let receivedChars = 0
   let startTerminal: (() => void) | null = null
@@ -164,6 +171,34 @@
     }
   }
 
+  function writeBurst(term: Terminal, data: string): void {
+    if (!isWindows) {
+      scrollPreservingWrite(term, data)
+      return
+    }
+    const prefixed = cursorHiddenForBurst ? data : '\x1b[?25l' + data
+    cursorHiddenForBurst = true
+    scrollPreservingWrite(term, prefixed)
+    if (cursorRestoreTimer !== null) clearTimeout(cursorRestoreTimer)
+    cursorRestoreTimer = setTimeout(() => {
+      cursorRestoreTimer = null
+      if (!cursorHiddenForBurst) return
+      cursorHiddenForBurst = false
+      if (termRef) termRef.write('\x1b[?25h')
+    }, CURSOR_RESTORE_MS)
+  }
+
+  function restoreCursorImmediately(): void {
+    if (cursorRestoreTimer !== null) {
+      clearTimeout(cursorRestoreTimer)
+      cursorRestoreTimer = null
+    }
+    if (cursorHiddenForBurst) {
+      cursorHiddenForBurst = false
+      if (termRef) termRef.write('\x1b[?25h')
+    }
+  }
+
   function disconnectWs(options: { suppressStatus?: boolean } = {}): void {
     if (reconnectTimer) {
       clearTimeout(reconnectTimer)
@@ -261,7 +296,7 @@
           const frameData = pendingData
           pendingData = ''
           writeScheduled = false
-          scrollPreservingWrite(term, frameData)
+          writeBurst(term, frameData)
         })
       }
     }
@@ -376,10 +411,11 @@
       const term = new Terminal({
         fontSize: currentFontSize,
         fontFamily: currentFontFamily,
-        cursorBlink: true,
+        cursorBlink: !isWindows,
         allowProposedApi: true,
         theme: currentTheme,
         scrollback: 5000,
+        ...(isWindows ? { windowsPty: { backend: 'conpty' as const } } : {}),
       })
 
       const fitAddon = new FitAddon()
@@ -625,6 +661,7 @@
       cleanupSession(sessionId)
       cleanupKeystrokeSession(sessionId)
       if (keystrokeHandler) containerEl.removeEventListener('keydown', keystrokeHandler, true)
+      restoreCursorImmediately()
       disconnectWs({ suppressStatus: true })
       if (dataDisposable) dataDisposable.dispose()
       const term = termRef

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -247,7 +247,7 @@
       const frameData = pendingData
       pendingData = ''
       writeScheduled = false
-      scrollPreservingWrite(term, frameData)
+      writeBurst(term, frameData)
     })
   }
 

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -176,10 +176,17 @@
       scrollPreservingWrite(term, data)
       return
     }
+    // Honor the TUI's last DECTCEM intent: if the burst itself ended with
+    // `\x1b[?25l`, the TUI wants the cursor hidden (e.g. claude while
+    // thinking, vim during paste). Restoring would override that intent
+    // and leave a stray xterm caret.
+    const lastDectcem = data.match(/\x1b\[\?25[lh](?!.*\x1b\[\?25[lh])/s)
+    const tuiWantsHidden = lastDectcem?.[0].endsWith('l') ?? false
     const prefixed = cursorHiddenForBurst ? data : '\x1b[?25l' + data
     cursorHiddenForBurst = true
     scrollPreservingWrite(term, prefixed)
     if (cursorRestoreTimer !== null) clearTimeout(cursorRestoreTimer)
+    if (tuiWantsHidden) return
     cursorRestoreTimer = setTimeout(() => {
       cursorRestoreTimer = null
       if (!cursorHiddenForBurst) return
@@ -411,7 +418,7 @@
       const term = new Terminal({
         fontSize: currentFontSize,
         fontFamily: currentFontFamily,
-        cursorBlink: !isWindows,
+        cursorBlink: true,
         allowProposedApi: true,
         theme: currentTheme,
         scrollback: 5000,

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -180,6 +180,7 @@
     // `\x1b[?25l`, the TUI wants the cursor hidden (e.g. claude while
     // thinking, vim during paste). Restoring would override that intent
     // and leave a stray xterm caret.
+    // eslint-disable-next-line no-control-regex
     const lastDectcem = data.match(/\x1b\[\?25[lh](?!.*\x1b\[\?25[lh])/s)
     const tuiWantsHidden = lastDectcem?.[0].endsWith('l') ?? false
     const prefixed = cursorHiddenForBurst ? data : '\x1b[?25l' + data


### PR DESCRIPTION
## What
On Windows, hide the xterm.js cursor during burst writes from ConPTY and re-show it 80ms after output settles, so TUI redraws (claude code, codex, vim) look atomic instead of tracing the cursor across the screen. Also pass `windowsPty: { backend: 'conpty' }` and disable `cursorBlink` on Windows.

## Why
ConPTY scrapes the underlying console buffer and re-emits the screen as a stream of CUP (cursor position) + character runs cell by cell, instead of forwarding the TUI's own escape sequences as Unix PTYs do. xterm renders each CUP synchronously, so users see the caret fly across the screen on every redraw. macOS/Linux are unaffected — the new helper is a passthrough off-Windows.

## How to test
- **macOS/Linux**: `npm run dev`, open a terminal tab, run `vim` / `htop` / `claude`. Behaviour must be identical to today.
- **Windows**: `npm run dev`, run `claude` or `codex`, trigger a full redraw (resize pane, scroll, switch TUI screens). Cursor stays parked during the redraw and reappears once output settles.
- **Windows regression**: type at the PowerShell prompt — cursor still appears normally between keystrokes (80ms debounce releases well within human reaction time).
- **Edge**: Ctrl-C a TUI mid-redraw — cursor reappears within ~80ms even if no further data arrives.

## Checklist
- [x] Typecheck passes (`npm run typecheck`)
- [x] No changes to non-Windows code paths
- [ ] Manually verified on Windows
- [ ] Manually verified on macOS/Linux