### PR TITLE
fix: limit tab status dots to agents

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -299,21 +299,6 @@ export function registerIpcHandlers(
     return ptyManager.hasChildProcess(payload.sessionId)
   })
 
-  ipcMain.handle(
-    'pty:hasChildProcesses',
-    (_event, payload: { sessionIds: string[] }): Record<string, boolean> => {
-      const result: Record<string, boolean> = {}
-      for (const sid of payload.sessionIds) {
-        try {
-          result[sid] = ptyManager.hasChildProcess(sid)
-        } catch {
-          result[sid] = false
-        }
-      }
-      return result
-    },
-  )
-
   ipcMain.handle('pty:getDimensions', (_event, payload: { sessionId: string }) => {
     return ptyManager.getDimensions(payload.sessionId)
   })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -262,7 +262,6 @@ interface CanopyAPI {
   killPty: (sessionId: string, killTmux?: boolean) => Promise<void>
   writePty: (sessionId: string, data: string) => Promise<void>
   hasChildProcess: (sessionId: string) => Promise<boolean>
-  hasChildProcesses: (sessionIds: string[]) => Promise<Record<string, boolean>>
   getPtyDimensions: (sessionId: string) => Promise<{ cols: number; rows: number } | null>
 
   // Tmux

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,8 +17,6 @@ const api = {
     ipcRenderer.invoke('pty:write', { sessionId, data }),
   hasChildProcess: (sessionId: string) =>
     ipcRenderer.invoke('pty:hasChildProcess', { sessionId }) as Promise<boolean>,
-  hasChildProcesses: (sessionIds: string[]) =>
-    ipcRenderer.invoke('pty:hasChildProcesses', { sessionIds }) as Promise<Record<string, boolean>>,
   getPtyDimensions: (sessionId: string) =>
     ipcRenderer.invoke('pty:getDimensions', { sessionId }) as Promise<{
       cols: number

--- a/src/renderer/src/components/terminal/TabBar.svelte
+++ b/src/renderer/src/components/terminal/TabBar.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
   import {
     tabsByWorktree,
     activeTabId,
@@ -25,37 +24,11 @@
     connectionStatus,
     type ConnectionStatus,
   } from '../../lib/terminal/connectionState.svelte'
-  onMount(() => {
-    async function pollShellBusy(): Promise<void> {
-      const sessionIds = tabs
-        .flatMap((tab) => allPanes(tab.rootSplit))
-        .filter((p) => !agentSessions[p.sessionId] && p.isRunning)
-        .map((p) => p.sessionId)
-
-      if (sessionIds.length === 0) {
-        shellBusyState = {}
-        return
-      }
-
-      try {
-        shellBusyState = await window.api.hasChildProcesses(sessionIds)
-      } catch {
-        shellBusyState = {}
-      }
-    }
-
-    void pollShellBusy()
-    shellPollTimer = setInterval(() => void pollShellBusy(), 2000)
-  })
-
-  // Cleanup returned from an async onMount is silently dropped by Svelte,
-  // so register the drag listener teardown via $effect instead. If the
-  // tab bar unmounts mid-drag (window close, workspace switch), this runs
-  // and detaches the window-level pointermove/pointerup handlers that
-  // would otherwise leak with their closures.
+  // If the tab bar unmounts mid-drag (window close, workspace switch),
+  // detach the window-level pointermove/pointerup handlers that would
+  // otherwise leak with their closures.
   $effect(() => {
     return () => {
-      clearInterval(shellPollTimer)
       window.removeEventListener('pointermove', handleDragMove)
       window.removeEventListener('pointerup', handleDragEnd)
     }
@@ -86,37 +59,25 @@
     if (badge === 'unread')
       return { color: 'var(--color-accent)', pulse: true, label: 'Unread activity' }
 
-    const panes = allPanes(tab.rootSplit)
-
-    // If every pane has exited, surface that instead of falling through to an
-    // "idle" state — keeps the dot in sync with the `.tab.exited` text color.
-    if (panes.length > 0 && panes.every((p) => !p.isRunning)) {
-      return { color: 'var(--color-blazing)', pulse: false, label: 'Exited' }
-    }
-
     let priority = 0
 
-    for (const p of panes) {
+    for (const p of allPanes(tab.rootSplit)) {
       if (!p.isRunning) continue
       const session = agentSessions[p.sessionId]
-      if (session) {
-        const t = session.status.type
-        if (t === 'waitingPermission')
-          return { color: 'var(--color-warning)', pulse: true, label: 'Permission required' }
-        if (t === 'error') priority = Math.max(priority, 5)
-        else if (t === 'thinking' || t === 'toolCalling' || t === 'compacting' || t === 'starting')
-          priority = Math.max(priority, 4)
-        else if (t === 'idle' || t === 'ended') priority = Math.max(priority, 3)
-      } else {
-        priority = Math.max(priority, shellBusyState[p.sessionId] ? 2 : 1)
-      }
+      if (!session) continue
+
+      const t = session.status.type
+      if (t === 'waitingPermission')
+        return { color: 'var(--color-warning)', pulse: true, label: 'Permission required' }
+      if (t === 'error') priority = Math.max(priority, 5)
+      else if (t === 'thinking' || t === 'toolCalling' || t === 'compacting' || t === 'starting')
+        priority = Math.max(priority, 4)
+      else if (t === 'idle' || t === 'ended') priority = Math.max(priority, 3)
     }
 
     if (priority === 5) return { color: 'var(--color-danger)', pulse: false, label: 'Agent error' }
     if (priority === 4) return { color: 'var(--color-accent)', pulse: true, label: 'Agent working' }
     if (priority === 3) return { color: 'var(--color-success)', pulse: false, label: 'Agent idle' }
-    if (priority === 2) return { color: 'var(--color-accent)', pulse: true, label: 'Shell running' }
-    if (priority === 1) return { color: 'var(--color-success)', pulse: false, label: 'Shell idle' }
     return null
   }
 
@@ -134,8 +95,6 @@
 
   let tabs = $derived(tabsByWorktree[worktreePath] ?? [])
 
-  let shellBusyState: Record<string, boolean> = $state({})
-  let shellPollTimer: ReturnType<typeof setInterval> | undefined
   let currentActiveId = $derived(activeTabId[worktreePath])
 
   let showOverflow = $state(false)
@@ -346,6 +305,7 @@
       {#each visibleTabs as tab (tab.id)}
         {@const connState = getConnectionState(tab)}
         {@const favicon = getTabFavicon(tab)}
+        {@const statusDot = getTabStatusDot(tab)}
         {@const isActiveTab = tab.id === currentActiveId}
         {@const isExited = !tab.suspended && allPanes(tab.rootSplit).some((p) => !p.isRunning)}
         {@const isDragging = dragActive && dragTabId === tab.id}
@@ -379,15 +339,14 @@
         >
           {#if favicon}
             <img class="flex-shrink-0 rounded-xs" src={favicon} alt="" width="12" height="12" />
-          {:else}
-            {@const dot = getTabStatusDot(tab)}
+          {:else if statusDot}
             <span
               class="w-2 h-2 rounded-full flex-shrink-0 motion-reduce:animate-none"
-              class:animate-badge-pulse={dot?.pulse ?? false}
-              style:background={dot?.color ?? 'var(--color-text-faint)'}
-              role={dot ? 'status' : undefined}
-              aria-label={dot?.label ?? undefined}
-              title={dot?.label ?? undefined}
+              class:animate-badge-pulse={statusDot.pulse}
+              style:background={statusDot.color}
+              role="status"
+              aria-label={statusDot.label}
+              title={statusDot.label}
             ></span>
           {/if}
           {#if isTabDirty(tab)}


### PR DESCRIPTION
## What
- Remove shell/non-agent status-dot polling from the terminal tab bar.
- Render tab status dots only when the tab has agent status or notification state.
- Remove the now-unused plural `hasChildProcesses` IPC/preload API so the WMIC-heavy batch polling path is gone.
- Keep connection-state dots wired for all terminal sessions so disconnected/reconnecting shell tabs still surface bridge state.

## Why
Non-agent tabs do not need the idle/running status dot, and polling every shell tab for child processes can be expensive on Windows because it hits the WMIC process lookup path. Agent tabs keep their useful status signal; shell tabs avoid unnecessary recurring work.

## Checklist
- [x] Status dots remain for agent states: permission, error, working, idle.
- [x] Notification badges still render as status dots when no favicon is present.
- [x] Shell/non-agent tabs no longer trigger plural child-process polling for tab dots.
- [x] Connection-state indicators still work for all terminal sessions.
- [x] Removed unused `hasChildProcesses` IPC/preload surface.

## Test Plan
- [x] `npm run typecheck`
- [x] `npm run lint` (passes; existing prettier warnings outside this change remain)
- [x] `npm run build`
