### PR TITLE
fix(remote): enable text selection on mobile terminals

### DIFF
--- a/docs/features/remote-control.md
+++ b/docs/features/remote-control.md
@@ -88,6 +88,10 @@ Listen mode keeps the signaling server bound on `0.0.0.0` in the background for 
 
 While paired, an idle timer of 15 minutes runs. Each signaling message (SDP, ICE, or data-channel relay) resets the timer. If no activity occurs for 15 minutes, the same listen-mode calculus from the disconnect reaper applies: when eligible, the session drops back to `listening` and keeps the port bound for trusted reconnects; otherwise it fully tears down to `idle`. QR expiry (the 10-minute `waiting` deadline) follows the same rule — it drops back to `listening` when eligible.
 
+### Mobile terminal text selection
+
+On touch devices (detected via `pointer: coarse` media query), the remote terminal enables xterm's `screenReaderMode` to create a DOM-based accessibility tree overlay. This overlay has `pointer-events: auto`, allowing native long-press → drag → copy text selection. Short taps (< 400 ms) still focus the hidden textarea to open the soft keyboard. Both `pointerup` and `pointercancel` are handled via a shared `AbortController` to avoid listener accumulation during long-press gestures.
+
 ## Configuration
 
 | Preference key          | Values                | Default   | Notes                                                                     |

--- a/src/renderer-shared/styles/globals.css
+++ b/src/renderer-shared/styles/globals.css
@@ -130,6 +130,11 @@
 .terminal-wrap .xterm-screen {
   width: fit-content;
 }
+@media (pointer: coarse) {
+  .terminal-wrap .xterm-accessibility {
+    pointer-events: auto;
+  }
+}
 
 /* ============ CodeMirror — CodeMirrorEditor ============ */
 .cm-root .cm-editor {

--- a/src/renderer/src/remote/components/RemoteTerminalView.svelte
+++ b/src/renderer/src/remote/components/RemoteTerminalView.svelte
@@ -292,13 +292,15 @@
       if (a11y) {
         a11y.addEventListener('pointerdown', () => {
           const start = Date.now()
-          const onUp = (): void => {
-            a11y.removeEventListener('pointerup', onUp)
-            if (Date.now() - start < 400) {
+          const ac = new AbortController()
+          const onEnd = (e: PointerEvent): void => {
+            ac.abort()
+            if (e.type === 'pointerup' && Date.now() - start < 400) {
               term?.textarea?.focus()
             }
           }
-          a11y.addEventListener('pointerup', onUp, { once: true })
+          a11y.addEventListener('pointerup', onEnd, { signal: ac.signal })
+          a11y.addEventListener('pointercancel', onEnd, { signal: ac.signal })
         })
       }
     }

--- a/src/renderer/src/remote/components/RemoteTerminalView.svelte
+++ b/src/renderer/src/remote/components/RemoteTerminalView.svelte
@@ -272,6 +272,8 @@
     }
 
     const { fontSize, lineHeight } = resolveMobileFontSize()
+    const isCoarsePointer =
+      typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches
 
     term = new Terminal({
       cols,
@@ -280,15 +282,26 @@
       lineHeight,
       cursorBlink: true,
       scrollback: 5000,
-      // Disable line wrap at the xterm level — the PTY already lays out
-      // content for `cols` characters and any additional wrap here would
-      // just undo that layout. If the host writes a 120-char line and the
-      // viewer's xterm is also 120 cols, no wrap is needed.
-      // (xterm.js doesn't have an explicit "no wrap" option; keeping cols
-      // in sync with the host is the right fix.)
+      screenReaderMode: isCoarsePointer,
       theme: resolveXtermTheme(),
     })
     term.open(containerEl)
+
+    if (isCoarsePointer) {
+      const a11y = containerEl.querySelector<HTMLElement>('.xterm-accessibility')
+      if (a11y) {
+        a11y.addEventListener('pointerdown', () => {
+          const start = Date.now()
+          const onUp = (): void => {
+            a11y.removeEventListener('pointerup', onUp)
+            if (Date.now() - start < 400) {
+              term?.textarea?.focus()
+            }
+          }
+          a11y.addEventListener('pointerup', onUp, { once: true })
+        })
+      }
+    }
 
     // Measure the real character width once xterm has painted its first
     // frame — before that, `scrollWidth` is 0 and our auto-follow math


### PR DESCRIPTION
## What
Enable native text selection (long-press → drag → copy) in Canopy Remote terminal views on mobile devices.

## Why
xterm.js selection relies on mouse events which don't fire on touch devices. Users on mobile could only get single-word selection or nothing — no way to select arbitrary text ranges.

## How it works
On touch devices (`@media (pointer: coarse)`), the xterm accessibility tree overlay gets `pointer-events: auto`. This tree is a hidden DOM layer with real terminal text and `user-select: text` — enabling pointer events lets the browser's native long-press selection mechanism work through it. Desktop is unaffected.

## How to test
1. Open Canopy Remote on a phone (or Chrome DevTools with touch emulation)
2. Long-press on text in a terminal session
3. Native selection handles should appear — drag to select multiple characters/lines
4. Copy the selected text
5. Verify desktop terminal selection still works normally (mouse-based)

## Checklist
- [x] Targets correct base branch (`next`)
- [x] Title follows conventional commits
- [ ] Tests added / updated
- [x] No secrets or local config committed
- [x] Self-reviewed