### PR TITLE
feat(remote): allow manual selection of LAN network interface

### DIFF
--- a/docs/features/remote-control.md
+++ b/docs/features/remote-control.md
@@ -41,9 +41,9 @@ Listen mode keeps the signaling server bound on `0.0.0.0` in the background for 
 
 1. Open the command palette and select "Remote Connection."
 2. Canopy calls `remote:start`, which triggers `RemoteSessionService.start()`. The session transitions to `starting`.
-3. The service detects a usable LAN IPv4 interface by enumerating non-virtual network adapters. On macOS, interfaces named `en0`/`en1` (WiFi) are preferred. Virtual adapters (docker, vmnet, tailscale, utun, awdl, bridge, etc.) are filtered out.
+3. The service detects a usable LAN IPv4 interface. When `remote.selectedInterface` is set, the named interface is used as-is (including normally-filtered virtual adapters like Tailscale — the user opted in explicitly); if that interface is no longer present, the service returns `NoNetworkInterface`. When the preference is empty, the service auto-detects by enumerating non-virtual adapters; on macOS, interfaces named `en0`/`en1` (WiFi) are preferred, and virtual adapters (docker, vmnet, tailscale, utun, awdl, bridge, etc.) are filtered out.
 4. A 32-byte random hex token is generated.
-5. The `SignalingServer` starts an HTTP server bound on `0.0.0.0` with a preferred port (persisted in `remote.lastPort` preference). If the preferred port is taken, it falls back to an ephemeral port. Reusing the same port keeps the peer-client origin stable so that the peer's localStorage (device ID, trust flag) survives Canopy restarts.
+5. The `SignalingServer` starts an HTTP server with a preferred port (persisted in `remote.lastPort` preference). The bind host depends on `remote.selectedInterface`: empty / auto → bound on `0.0.0.0` (all interfaces); set → bound only on the selected interface's IPv4 address. If the preferred port is taken, it falls back to an ephemeral port. Reusing the same port keeps the peer-client origin stable so that the peer's localStorage (device ID, trust flag) survives Canopy restarts.
 6. The pairing URL is built as `http://<lan-ip>:<port>/remote/?v=<cache-buster>#t=<token>&h=<hostname>`.
 7. The session transitions to `waiting` state with a 10-minute expiry. The QR code is displayed in the connection modal.
 8. If no device connects within 10 minutes, the session auto-stops and returns to `idle`.
@@ -94,11 +94,12 @@ On touch devices (detected via `pointer: coarse` media query), the remote termin
 
 ## Configuration
 
-| Preference key          | Values                | Default   | Notes                                                                     |
-| ----------------------- | --------------------- | --------- | ------------------------------------------------------------------------- |
-| `remote.enabled`        | `"true"` / `"false"`  | `"false"` | Must be `true` for the command palette entry to appear                    |
-| `remote.lastPort`       | port number as string | none      | Persisted automatically after first bind; keeps peer-client origin stable |
-| `remote.trustedDevices` | JSON array            | `[]`      | Managed by TrustedDeviceStore; not user-editable                          |
+| Preference key             | Values                 | Default   | Notes                                                                                                                                                |
+| -------------------------- | ---------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `remote.enabled`           | `"true"` / `"false"`   | `"false"` | Must be `true` for the command palette entry to appear                                                                                               |
+| `remote.lastPort`          | port number as string  | none      | Persisted automatically after first bind; keeps peer-client origin stable                                                                            |
+| `remote.selectedInterface` | interface name or `""` | `""`      | Empty = auto-detect. Otherwise the signaling server binds only on the named interface's IPv4 address; missing interface yields `NoNetworkInterface`. |
+| `remote.trustedDevices`    | JSON array             | `[]`      | Managed by TrustedDeviceStore; not user-editable                                                                                                     |
 
 Trusted devices can be viewed and removed in Settings. Each entry stores `deviceId`, `name`, `addedAt`, and `lastSeen`.
 
@@ -118,7 +119,7 @@ Trusted devices can be viewed and removed in Settings. Each entry stores `device
 
 ## Security and privacy
 
-The signaling server binds on `0.0.0.0`, making it reachable from any device on the local network. It shuts down when the session is explicitly stopped or when the reaper / idle / expiry paths tear the session down. With **listen mode** (feature enabled and ≥1 trusted device), the server also comes up automatically at app launch and stays bound in the background so trusted devices can reconnect without the user opening a modal first — see "Listen mode" under Behavior. In this mode the server accepts only trusted `deviceId`s; any other pair attempt is rejected before reaching the accept prompt.
+The signaling server binds on `0.0.0.0` by default, making it reachable from any device on the local network. When the user picks a specific interface in Settings → Remote Control (`remote.selectedInterface`), the server binds only on that interface's IPv4 address — narrowing the LAN exposure to one adapter. It shuts down when the session is explicitly stopped or when the reaper / idle / expiry paths tear the session down. Changing `remote.selectedInterface` stops any in-flight session so the new bind takes effect on the next pairing or trusted reconnect. With **listen mode** (feature enabled and ≥1 trusted device), the server also comes up automatically at app launch and stays bound in the background so trusted devices can reconnect without the user opening a modal first — see "Listen mode" under Behavior. In this mode the server accepts only trusted `deviceId`s; any other pair attempt is rejected before reaching the accept prompt.
 
 Pairing tokens are 32 random bytes (hex-encoded, 64 characters). Token comparison uses Node.js `timingSafeEqual` to prevent timing attacks. Tokens are single-use per session.
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -72,6 +72,7 @@ import type { GitHubService } from '../github/GitHubService'
 import { gitHubErrorMessage } from '../github/errors'
 import type { RemoteSessionService } from '../remote/RemoteSessionService'
 import { remoteServerErrorMessage } from '../remote/errors'
+import { listAllInterfaces } from '../remote/discovery'
 import type { RunConfigManager } from '../runConfig/RunConfigManager'
 import { runConfigErrorMessage } from '../runConfig/errors'
 import type { SkillRegistry } from '../skills/SkillRegistry'
@@ -577,6 +578,12 @@ export function registerIpcHandlers(
   ipcMain.handle('db:prefs:set', (_event, payload: { key: string; value: string }) => {
     preferencesStore.set(payload.key, payload.value)
     if (payload.key === 'remote.enabled' && payload.value === 'false') {
+      void remoteSessionService.stop()
+    }
+    // Changing the bound interface requires rebinding the signaling server.
+    // Stop the current session; the next ensureListening() / start() picks
+    // up the new pref. Mirrors the enabled=false teardown above.
+    if (payload.key === 'remote.selectedInterface') {
       void remoteSessionService.stop()
     }
   })
@@ -2815,6 +2822,10 @@ export function registerIpcHandlers(
 
   ipcMain.handle('remote:listTrustedDevices', () => {
     return remoteSessionService.listTrustedDevices()
+  })
+
+  ipcMain.handle('remote:listNetworkInterfaces', () => {
+    return listAllInterfaces()
   })
 
   ipcMain.handle('remote:removeTrustedDevice', (_event, payload: { deviceId: string }) => {

--- a/src/main/remote/RemoteSessionService.ts
+++ b/src/main/remote/RemoteSessionService.ts
@@ -175,7 +175,10 @@ export class RemoteSessionService {
       .start({
         bundleRoot,
         preferredPort: savedPort,
-        bindHost: iface.address,
+        // Auto-detect keeps the historical 0.0.0.0 bind so any LAN
+        // interface can reach the server; only an explicit user choice
+        // narrows the bind to one adapter.
+        bindHost: preferredIfaceName ? iface.address : '0.0.0.0',
         handlers: {
           onPairAttempt: (msg) => this.handlePairAttempt(msg),
           onPeerSignal: (msg) => this.handlePeerSignal(msg),
@@ -257,7 +260,8 @@ export class RemoteSessionService {
       .start({
         bundleRoot,
         preferredPort: savedPort,
-        bindHost: iface.address,
+        // See start() — auto stays on 0.0.0.0, explicit pick narrows.
+        bindHost: preferredIfaceName ? iface.address : '0.0.0.0',
         handlers: {
           onPairAttempt: (msg) => this.handlePairAttempt(msg),
           onPeerSignal: (msg) => this.handlePeerSignal(msg),

--- a/src/main/remote/RemoteSessionService.ts
+++ b/src/main/remote/RemoteSessionService.ts
@@ -41,6 +41,17 @@ const REMOTE_SIGNAL_CHANNEL = 'remote:signal'
 const LAST_PORT_PREF_KEY = 'remote.lastPort'
 
 /**
+ * Preference key holding the user's chosen LAN interface name (e.g. `Wi-Fi`
+ * on Windows, `en0` on macOS). Empty / unset means "auto-detect" — the
+ * service falls back to the historical `selectPrimaryInterface()` heuristic.
+ * When set, the named interface is used as-is (no virtual filter — the user
+ * may deliberately pick Tailscale/WireGuard), and the signaling server binds
+ * only on that interface's IPv4 address. A named interface that is no longer
+ * present yields `NoNetworkInterface` rather than silently falling back.
+ */
+const SELECTED_INTERFACE_PREF_KEY = 'remote.selectedInterface'
+
+/**
  * State machine + lifecycle owner for the WebRTC remote-control feature.
  *
  * Responsibilities:
@@ -141,7 +152,8 @@ export class RemoteSessionService {
       return errAsync({ _tag: 'AlreadyRunning' })
     }
 
-    const iface = selectPrimaryInterface()
+    const preferredIfaceName = this.preferencesStore.get(SELECTED_INTERFACE_PREF_KEY) || undefined
+    const iface = selectPrimaryInterface(preferredIfaceName)
     if (!iface) {
       const err: RemoteServerError = { _tag: 'NoNetworkInterface' }
       this.setStatus({ kind: 'error', message: 'No usable network interface found' })
@@ -163,6 +175,7 @@ export class RemoteSessionService {
       .start({
         bundleRoot,
         preferredPort: savedPort,
+        bindHost: iface.address,
         handlers: {
           onPairAttempt: (msg) => this.handlePairAttempt(msg),
           onPeerSignal: (msg) => this.handlePeerSignal(msg),
@@ -227,7 +240,12 @@ export class RemoteSessionService {
     if (!this.isEnabledInPreferences()) return okAsync(undefined)
     if (this.trustedDevices.list().length === 0) return okAsync(undefined)
 
-    const iface = selectPrimaryInterface()
+    const preferredIfaceName = this.preferencesStore.get(SELECTED_INTERFACE_PREF_KEY) || undefined
+    const iface = selectPrimaryInterface(preferredIfaceName)
+    // Silent no-op for listen mode: any failure (no interface at all, or
+    // the user-named interface currently unavailable) leaves the session
+    // idle. Listen mode never surfaces errors to the user — the next manual
+    // `start()` will return NoNetworkInterface with a visible message.
     if (!iface) return okAsync(undefined)
 
     this.hostWcId = hostWcId
@@ -239,6 +257,7 @@ export class RemoteSessionService {
       .start({
         bundleRoot,
         preferredPort: savedPort,
+        bindHost: iface.address,
         handlers: {
           onPairAttempt: (msg) => this.handlePairAttempt(msg),
           onPeerSignal: (msg) => this.handlePeerSignal(msg),

--- a/src/main/remote/SignalingServer.ts
+++ b/src/main/remote/SignalingServer.ts
@@ -81,10 +81,12 @@ export type PairResponse =
  *      pairing + WebRTC SDP/ICE messages to the orchestrator
  *
  * **Bind address.** Unlike `WsBridge` and `AgentHookServer` (both `127.0.0.1`),
- * this server binds on `0.0.0.0` so a phone on the same WiFi can reach it via
- * the host's LAN address. This is an *intentional* widening of the listening
- * surface — the server is only started while the user explicitly has a remote
- * session open, and only accepts WS peers that present a valid one-shot token.
+ * this server binds on `0.0.0.0` (default) so a phone on the same WiFi can
+ * reach it via the host's LAN address. This is an *intentional* widening of
+ * the listening surface — the server is only started while the user explicitly
+ * has a remote session open, and only accepts WS peers that present a valid
+ * one-shot token. Users may further narrow the bind to a single interface IP
+ * by selecting a network interface in Settings → Remote Control.
  *
  * Lazy lifecycle: nothing is bound until {@link start} is called, and
  * {@link stop} releases the port. Re-using a single instance across multiple
@@ -94,6 +96,7 @@ export class SignalingServer {
   private server: http.Server | null = null
   private wss: WebSocketServer | null = null
   private port = 0
+  private boundHost = '0.0.0.0'
   private bundleHost: RemoteClientHost | null = null
   private activePeer: WsWebSocket | null = null
   private handlers: SignalingServerHandlers | null = null
@@ -104,6 +107,10 @@ export class SignalingServer {
 
   get listeningPort(): number {
     return this.port
+  }
+
+  get listeningHost(): string {
+    return this.boundHost
   }
 
   start(opts: {
@@ -118,6 +125,13 @@ export class SignalingServer {
      * the peer origin (`http://ip:PORT`) stays the same.
      */
     preferredPort?: number
+    /**
+     * Host/IP to bind to. Defaults to `0.0.0.0` (all interfaces). When the
+     * user picks a specific network interface in Settings, the caller passes
+     * that interface's IPv4 address here so the server is only reachable on
+     * that one adapter — narrowing the LAN exposure surface.
+     */
+    bindHost?: string
   }): ResultAsync<{ port: number }, RemoteServerError> {
     if (this.server) {
       return errAsync({ _tag: 'AlreadyRunning' })
@@ -126,6 +140,7 @@ export class SignalingServer {
     this.bundleHost = new RemoteClientHost(opts.bundleRoot)
     this.handlers = opts.handlers
     const preferredPort = opts.preferredPort && opts.preferredPort > 0 ? opts.preferredPort : 0
+    const bindHost = opts.bindHost ?? '0.0.0.0'
 
     return fromExternalCall(
       (async () => {
@@ -137,7 +152,7 @@ export class SignalingServer {
         // shutdown. A fresh instance per attempt is the only thing we've
         // found to always work.
         try {
-          return await this.attemptListen(preferredPort)
+          return await this.attemptListen(preferredPort, bindHost)
         } catch (e) {
           const isAddrInUse =
             typeof e === 'object' &&
@@ -151,7 +166,7 @@ export class SignalingServer {
           // Give the kernel a tick to release any half-closed state, then
           // retry on an ephemeral port with a brand-new server instance.
           await new Promise((resolve) => setTimeout(resolve, 50))
-          return await this.attemptListen(0)
+          return await this.attemptListen(0, bindHost)
         }
       })(),
       (e): RemoteServerError => ({ _tag: 'PortBindFailed', message: errorMessage(e) }),
@@ -159,6 +174,7 @@ export class SignalingServer {
       this.server = server
       this.wss = wss
       this.port = port
+      this.boundHost = bindHost
       return { port }
     })
   }
@@ -175,6 +191,7 @@ export class SignalingServer {
    */
   private attemptListen(
     port: number,
+    bindHost: string,
   ): Promise<{ server: http.Server; wss: WebSocketServer; port: number }> {
     return new Promise((resolve, reject) => {
       const server = http.createServer((req, res) => this.handleHttpRequest(req, res))
@@ -211,11 +228,13 @@ export class SignalingServer {
       }
       server.once('error', onError)
       server.once('listening', onListening)
-      // INTENTIONAL: bind on 0.0.0.0 so LAN peers can reach this. Other
-      // local servers in this codebase (WsBridge, AgentHookServer) bind
-      // on 127.0.0.1; this one is different on purpose. Only listens
-      // while a remote session is active.
-      server.listen(port, '0.0.0.0')
+      // Bind host comes from the caller. Default is 0.0.0.0 so LAN peers
+      // on any interface can reach this; other local servers in this
+      // codebase (WsBridge, AgentHookServer) bind on 127.0.0.1 — this one
+      // is different on purpose. When the user picks a specific interface
+      // in Settings, the caller passes that interface's IPv4 so the bind
+      // is narrowed to one adapter.
+      server.listen(port, bindHost)
     })
   }
 

--- a/src/main/remote/discovery.ts
+++ b/src/main/remote/discovery.ts
@@ -14,27 +14,39 @@ import { networkInterfaces } from 'node:os'
 export interface NetworkInterfaceInfo {
   name: string
   address: string
+  virtual: boolean
 }
 
 const VIRTUAL_INTERFACE_PATTERN =
   /^(vboxnet|vmnet|docker|br-|lo|utun|tun|tap|tailscale|zerotier|wg|cni|virbr|awdl|llw|anpi|bridge)/i
 
-export function listLanInterfaces(): NetworkInterfaceInfo[] {
+export function listAllInterfaces(): NetworkInterfaceInfo[] {
   const ifaces = networkInterfaces()
   const result: NetworkInterfaceInfo[] = []
   for (const [name, addrs] of Object.entries(ifaces)) {
     if (!addrs) continue
-    if (VIRTUAL_INTERFACE_PATTERN.test(name)) continue
+    const virtual = VIRTUAL_INTERFACE_PATTERN.test(name)
     for (const addr of addrs) {
       if (addr.family === 'IPv4' && !addr.internal) {
-        result.push({ name, address: addr.address })
+        result.push({ name, address: addr.address, virtual })
       }
     }
   }
   return result
 }
 
-export function selectPrimaryInterface(): NetworkInterfaceInfo | null {
+export function listLanInterfaces(): NetworkInterfaceInfo[] {
+  return listAllInterfaces().filter((i) => !i.virtual)
+}
+
+export function selectPrimaryInterface(preferredName?: string): NetworkInterfaceInfo | null {
+  // Explicit user choice: match by interface name across ALL interfaces
+  // (including virtual ones like Tailscale/WireGuard — the user opted in).
+  // No match means the named interface is gone (DHCP renew, adapter unplug,
+  // VPN down). Caller treats null as NoNetworkInterface — no silent fallback.
+  if (preferredName) {
+    return listAllInterfaces().find((i) => i.name === preferredName) ?? null
+  }
   const ifaces = listLanInterfaces()
   // Prefer interfaces named like WiFi on macOS (`en0`, `en1`) since that's
   // usually where a phone will be. Ethernet has higher numeric priority

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -847,6 +847,12 @@ interface RemoteTrustedDevice {
   publicKeyJwk: unknown
 }
 
+interface RemoteNetworkInterface {
+  name: string
+  address: string
+  virtual: boolean
+}
+
 interface RemoteAPI {
   start: () => Promise<{ pairingUrl: string }>
   ensureListening: () => Promise<void>
@@ -857,6 +863,7 @@ interface RemoteAPI {
   sendSignal: (msg: unknown) => Promise<void>
   listTrustedDevices: () => Promise<RemoteTrustedDevice[]>
   removeTrustedDevice: (deviceId: string) => Promise<void>
+  listNetworkInterfaces: () => Promise<RemoteNetworkInterface[]>
   onStatusChange: (callback: (status: RemoteSessionStatus) => void) => () => void
   onSignal: (callback: (msg: unknown) => void) => () => void
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -933,6 +933,10 @@ const api = {
       >,
     removeTrustedDevice: (deviceId: string) =>
       ipcRenderer.invoke('remote:removeTrustedDevice', { deviceId }) as Promise<void>,
+    listNetworkInterfaces: () =>
+      ipcRenderer.invoke('remote:listNetworkInterfaces') as Promise<
+        Array<{ name: string; address: string; virtual: boolean }>
+      >,
     onStatusChange: (callback: (status: RemoteSessionStatus) => void) => {
       const handler = (_event: IpcRendererEvent, status: RemoteSessionStatus): void =>
         callback(status)

--- a/src/renderer/src/components/preferences/RemoteControlPrefs.svelte
+++ b/src/renderer/src/components/preferences/RemoteControlPrefs.svelte
@@ -5,6 +5,7 @@
   import { confirm } from '../../lib/stores/dialogs.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
   import CustomRadio from '../shared/CustomRadio.svelte'
+  import CustomSelect from '../shared/CustomSelect.svelte'
   import PrefsSection from './_partials/PrefsSection.svelte'
   import PrefsRow from './_partials/PrefsRow.svelte'
 
@@ -14,6 +15,7 @@
   let guardProfile: GuardProfile = $derived(
     (prefs['remote.actionGuard'] as GuardProfile) ?? 'destructive',
   )
+  let selectedInterface = $derived(prefs['remote.selectedInterface'] ?? '')
 
   type TrustedDevice = {
     deviceId: string
@@ -23,8 +25,36 @@
     publicKeyJwk: unknown
   }
 
+  type NetworkInterface = { name: string; address: string; virtual: boolean }
+
   let trustedDevices = $state<TrustedDevice[]>([])
   let loading = $state(false)
+  let interfaces = $state<NetworkInterface[]>([])
+
+  const interfaceGroups = $derived.by(() => {
+    const auto = [{ value: '', label: 'Auto (detect at start)' }]
+    const physical = interfaces
+      .filter((i) => !i.virtual)
+      .map((i) => ({ value: i.name, label: `${i.name} (${i.address})` }))
+    const virtual = interfaces
+      .filter((i) => i.virtual)
+      .map((i) => ({ value: i.name, label: `${i.name} (${i.address}) — virtual` }))
+    const groups: Array<{ label: string; options: typeof auto }> = [
+      { label: 'Auto', options: auto },
+    ]
+    if (physical.length) groups.push({ label: 'Physical', options: physical })
+    if (virtual.length) groups.push({ label: 'Virtual', options: virtual })
+    // If the user previously picked an interface that is no longer present,
+    // surface it so they can see what's selected (and switch away) instead
+    // of the dropdown silently snapping back to "Auto".
+    if (selectedInterface && !interfaces.some((i) => i.name === selectedInterface)) {
+      groups.push({
+        label: 'Unavailable',
+        options: [{ value: selectedInterface, label: `${selectedInterface} (not found)` }],
+      })
+    }
+    return groups
+  })
 
   function toggleEnabled(): void {
     setPref('remote.enabled', enabled ? 'false' : 'true')
@@ -34,6 +64,10 @@
     setPref('remote.actionGuard', profile)
   }
 
+  function setInterface(name: string): void {
+    setPref('remote.selectedInterface', name)
+  }
+
   async function loadTrustedDevices(): Promise<void> {
     loading = true
     try {
@@ -41,6 +75,10 @@
     } finally {
       loading = false
     }
+  }
+
+  async function loadInterfaces(): Promise<void> {
+    interfaces = await window.api.remote.listNetworkInterfaces()
   }
 
   async function removeDevice(deviceId: string, name: string): Promise<void> {
@@ -74,6 +112,7 @@
 
   onMount(() => {
     void loadTrustedDevices()
+    void loadInterfaces()
   })
 </script>
 
@@ -109,6 +148,18 @@
       badge={{ text: 'Beta', tone: 'warning' }}
     >
       <CustomCheckbox checked={enabled} onchange={toggleEnabled} />
+    </PrefsRow>
+    <PrefsRow
+      label="Network interface"
+      help="Which LAN interface the signaling server binds to. The QR code uses this interface's IPv4 address, and the server only listens on that one adapter. 'Auto' picks the first physical Wi-Fi/Ethernet adapter at start. Changing this stops any active session — the next pairing or trusted reconnect picks up the new interface."
+      search="remote interface network adapter wifi ethernet bind ip"
+    >
+      <CustomSelect
+        value={selectedInterface}
+        groups={interfaceGroups}
+        onchange={setInterface}
+        maxWidth="280px"
+      />
     </PrefsRow>
   </PrefsSection>
 


### PR DESCRIPTION
## What

Adds a "Network interface" picker in Settings → Remote Control. When set, the Remote Control signaling server binds only on the chosen interface's IPv4 address (instead of `0.0.0.0`) and the QR pairing URL advertises that same address. "Auto" preserves the previous heuristic (`en0`/`en1` preferred on macOS; first non-virtual adapter elsewhere).

The dropdown groups interfaces as **Auto / Physical / Virtual**. Tunnel/VPN adapters (Tailscale, WireGuard, utun, docker, etc.) — normally filtered out of auto-detect — are listed under "Virtual" so a power user can opt in. A previously-selected interface that has disappeared is shown under "Unavailable" so the user can see what's broken instead of silently snapping back to Auto.

## Why

Auto-detection picks one adapter for the whole machine. On laptops with Wi-Fi + Ethernet, dock-attached NICs, or VPN/tailnet setups, that's often the wrong one — the phone scans the QR, fails to reach the host, and there's no way to override. This makes the binding explicit and works on both Windows and macOS (interface names like `Wi-Fi`/`Ethernet` vs `en0`/`en1` are surfaced verbatim).

When the named interface is no longer present, `start()` returns `NoNetworkInterface` (existing user-facing error); listen mode silently no-ops, matching the existing pattern. Changing the preference while a session is running stops it so the next pairing or trusted reconnect picks up the new bind — mirrors the existing `remote.enabled=false` teardown.

## How to test

1. Open Settings → Remote Control. Pick `Wi-Fi` (Windows) / `en0` (macOS) from the new "Network interface" dropdown.
2. Open the command palette → "Remote Connection". Confirm the QR URL contains the IP of the chosen adapter.
3. On Windows: `netstat -an | findstr <port>` shows LISTENING only on the picked IP, not `0.0.0.0`. On macOS: `lsof -iTCP -sTCP:LISTEN -P` confirms the same.
4. Switch the dropdown to a different physical adapter while the modal is open — session stops, reopen modal and verify new IP in the QR.
5. Select a virtual interface (e.g. Tailscale) — bind happens on its IP; peer from the same tailnet can pair.
6. Set the preference to a name that doesn't exist (via DevTools / preferences edit) — `start()` returns `NoNetworkInterface` with "No usable network interface found on the LAN".
7. Regression: leave the dropdown on "Auto (detect at start)" — pairing works exactly as before.

## Screenshots / recordings

_To be added during review (Windows + macOS Settings screenshots)._

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [x] Non-core feature is behind a feature flag (off by default) — the existing `remote.enabled` gate still applies; this is a sub-setting of an already opt-in feature
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands — interface names come from `os.networkInterfaces()` directly
- [x] Keyboard accessible (all interactive elements reachable via keyboard) — reuses existing `CustomSelect` which supports full keyboard nav
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle` — new `remote:listNetworkInterfaces`
- [x] Renderer code does not import Node.js modules directly — interface enumeration runs in main, exposed via preload
- [x] Feature docs in `docs/` updated — `docs/features/remote-control.md` (configuration table, behavior step 3+5, security section)