### PR TITLE
feat: move mobile terminal actions into keyboard toolbar

### DIFF
--- a/docs/features/remote-control.md
+++ b/docs/features/remote-control.md
@@ -92,6 +92,12 @@ While paired, an idle timer of 15 minutes runs. Each signaling message (SDP, ICE
 
 The native mobile app (`mobile/src/components/terminal/terminal-view.tsx`) enables xterm's `screenReaderMode`, which creates a DOM-based accessibility tree with selectable text overlaying the canvas. The overlay has `pointer-events: auto` so touch events reach it. The gesture detector distinguishes three interactions: short tap (< 500 ms) focuses the terminal and opens the soft keyboard, swipe scrolls the terminal buffer, and long-press (> 400 ms stationary) yields to the browser's native text selection flow. Selection-edge auto-scroll keeps extending the selection when the drag handle reaches the top or bottom of the terminal viewport.
 
+### Mobile terminal keyboard toolbar
+
+When the mobile soft keyboard is open, the terminal renders its action toolbar inside the WebView instead of using a separate native action bar. Keeping the toolbar in the WebView preserves xterm focus and selected terminal text while the user taps toolbar controls. The toolbar includes Hide, Copy, Paste, Esc, Tab, Shift+Tab, Ctrl, Alt, Left, Right, Up, Down, Home, End, and Enter.
+
+Hide blurs xterm's hidden textarea to dismiss the soft keyboard. Copy sends only the current DOM terminal selection to the native app for clipboard writing; if there is no selection, the terminal shows a short transient notice and does not change the clipboard. Paste reads text from the native clipboard, sanitizes it with the mobile PTY paste wrapper, wraps it in bracketed-paste markers, and writes it to the active PTY without submitting Enter. The old native paste action bar below the terminal tabs is no longer shown.
+
 ## Configuration
 
 | Preference key             | Values                 | Default   | Notes                                                                                                                                                |

--- a/mobile/src/app/terminal.tsx
+++ b/mobile/src/app/terminal.tsx
@@ -3,7 +3,7 @@ import { useKeepAwake } from 'expo-keep-awake'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { SymbolView } from 'expo-symbols'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Alert, Keyboard, Pressable, StyleSheet, View } from 'react-native'
+import { Alert, Pressable, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { TerminalTabBar } from '@/components/terminal/tab-bar'
@@ -247,7 +247,23 @@ export default function TerminalScreen(): React.ReactElement {
     }
   }, [handleWriteError])
 
-  const pasteDisabled = !api || !sessionId
+  const handleCopySelection = useCallback(async (text: string) => {
+    if (!text) {
+      setStreamError('No terminal selection to copy')
+      return
+    }
+    try {
+      await Clipboard.setStringAsync(text)
+      setStreamError(null)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setStreamError(`Could not copy selection: ${msg}`)
+    }
+  }, [])
+
+  const handleToolbarNotice = useCallback(async (message: string) => {
+    setStreamError(message)
+  }, [])
 
   const handleTabSelect = useCallback(
     (tabId: string) => {
@@ -305,34 +321,10 @@ export default function TerminalScreen(): React.ReactElement {
     [api, tabs],
   )
 
-  // Dismiss the soft keyboard when the user taps anywhere in the header
-  // (back button area, title, or empty space around them). We try two
-  // paths: Keyboard.dismiss() resigns the native WKWebView's first
-  // responder, and the DOM handle's blur() unfocuses xterm's textarea
-  // from inside the webview. Either one alone is usually enough, but
-  // combining them is resilient to iOS quirks where the webview keeps
-  // the keyboard up until both sides agree focus is gone.
-  const dismissKeyboard = useCallback((): void => {
-    Keyboard.dismiss()
-    const blur = terminalRef.current?.blur
-    if (typeof blur === 'function') blur()
-  }, [])
-
   return (
     <ThemedView style={styles.container}>
       <SafeAreaView edges={['top']} style={styles.safeArea}>
-        <View
-          style={styles.header}
-          // Observe touches without stealing the responder from the back
-          // button. Returning false keeps children (the Pressable) eligible
-          // to claim the gesture, but the capture callback still runs —
-          // which is where we dismiss the keyboard on every tap inside the
-          // header strip (back button, title area, or the gap between).
-          onStartShouldSetResponderCapture={(): boolean => {
-            dismissKeyboard()
-            return false
-          }}
-        >
+        <View style={styles.header}>
           <Pressable
             onPress={() => router.back()}
             style={({ pressed }) => [styles.iconBack, pressed && styles.pressed]}
@@ -363,34 +355,6 @@ export default function TerminalScreen(): React.ReactElement {
           onLongPress={api ? handleTabLongPress : undefined}
           onNewTab={api ? () => setPickerVisible(true) : undefined}
         />
-        <View style={[styles.actionBar, { borderTopColor: theme.backgroundElement }]}>
-          <Pressable
-            onPress={handlePaste}
-            disabled={pasteDisabled}
-            style={({ pressed }) => [
-              styles.actionButton,
-              { backgroundColor: theme.backgroundElement },
-              pressed && styles.pressed,
-              pasteDisabled && styles.actionButtonDisabled,
-            ]}
-            accessibilityRole="button"
-            accessibilityLabel="Paste from clipboard"
-          >
-            <SymbolView
-              name={{
-                ios: 'doc.on.clipboard',
-                android: 'content_paste',
-                web: 'content_paste',
-              }}
-              size={14}
-              weight="semibold"
-              tintColor={theme.textSecondary}
-            />
-            <ThemedText type="small" themeColor="textSecondary">
-              Paste
-            </ThemedText>
-          </Pressable>
-        </View>
         {streamError ? (
           <View style={styles.banner}>
             <ThemedText type="small" themeColor="textSecondary">
@@ -423,6 +387,9 @@ export default function TerminalScreen(): React.ReactElement {
           terminalThemeId={terminalThemeId}
           onInput={onInput}
           onResize={onResize}
+          onCopyRequest={handleCopySelection}
+          onPasteRequest={handlePaste}
+          onToolbarNotice={handleToolbarNotice}
           dom={{
             style: { flex: 1 },
             matchContents: false,
@@ -510,25 +477,6 @@ const styles = StyleSheet.create({
   },
   pressed: {
     opacity: 0.6,
-  },
-  actionBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.two,
-    paddingHorizontal: Spacing.three,
-    paddingVertical: Spacing.two,
-    borderTopWidth: StyleSheet.hairlineWidth,
-  },
-  actionButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.two,
-    paddingHorizontal: Spacing.three,
-    paddingVertical: Spacing.two,
-    borderRadius: Spacing.three,
-  },
-  actionButtonDisabled: {
-    opacity: 0.4,
   },
   banner: {
     paddingHorizontal: Spacing.four,

--- a/mobile/src/app/terminal.tsx
+++ b/mobile/src/app/terminal.tsx
@@ -72,6 +72,7 @@ export default function TerminalScreen(): React.ReactElement {
   const writeQueueRef = useRef<string[]>([])
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [streamError, setStreamError] = useState<string | null>(null)
+  const [toolbarNotice, setToolbarNotice] = useState<string | null>(null)
 
   // Mirror latest api/sessionId into refs so the onInput/onResize callbacks
   // passed to the DOM component can stay referentially stable forever. If
@@ -182,6 +183,12 @@ export default function TerminalScreen(): React.ReactElement {
     }
   }, [api, sessionId, scheduleFlush])
 
+  useEffect(() => {
+    if (!toolbarNotice) return
+    const timer = setTimeout(() => setToolbarNotice(null), 2500)
+    return () => clearTimeout(timer)
+  }, [toolbarNotice])
+
   // Translate a thrown api.pty.write error into a user-facing banner.
   // Keyboard strokes, paste, and any future write path (drag-and-drop,
   // shortcut macros) funnel through here so the brittle regex-against-
@@ -248,21 +255,17 @@ export default function TerminalScreen(): React.ReactElement {
   }, [handleWriteError])
 
   const handleCopySelection = useCallback(async (text: string) => {
-    if (!text) {
-      setStreamError('No terminal selection to copy')
-      return
-    }
     try {
       await Clipboard.setStringAsync(text)
-      setStreamError(null)
+      setToolbarNotice(null)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       setStreamError(`Could not copy selection: ${msg}`)
     }
   }, [])
 
-  const handleToolbarNotice = useCallback(async (message: string) => {
-    setStreamError(message)
+  const handleToolbarNotice = useCallback((message: string) => {
+    setToolbarNotice(message)
   }, [])
 
   const handleTabSelect = useCallback(
@@ -355,10 +358,10 @@ export default function TerminalScreen(): React.ReactElement {
           onLongPress={api ? handleTabLongPress : undefined}
           onNewTab={api ? () => setPickerVisible(true) : undefined}
         />
-        {streamError ? (
+        {streamError || toolbarNotice ? (
           <View style={styles.banner}>
             <ThemedText type="small" themeColor="textSecondary">
-              {streamError}
+              {streamError ?? toolbarNotice}
             </ThemedText>
           </View>
         ) : null}

--- a/mobile/src/components/terminal/terminal-view.tsx
+++ b/mobile/src/components/terminal/terminal-view.tsx
@@ -63,6 +63,9 @@ type Props = {
   terminalThemeId: TerminalThemeId
   onInput: (data: string) => Promise<void>
   onResize: (cols: number, rows: number) => Promise<void>
+  onCopyRequest: (text: string) => Promise<void>
+  onPasteRequest: () => Promise<void>
+  onToolbarNotice: (message: string) => Promise<void>
   /**
    * `ref` is intentionally part of Props rather than a `forwardRef` argument:
    * Expo DOM components auto-generate a wrapper on the native side that
@@ -79,6 +82,9 @@ export default function TerminalView({
   terminalThemeId,
   onInput,
   onResize,
+  onCopyRequest,
+  onPasteRequest,
+  onToolbarNotice,
 }: Props): React.ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
   const hostRef = useRef<HTMLDivElement>(null)
@@ -117,6 +123,12 @@ export default function TerminalView({
   onInputRef.current = onInput
   const onResizeRef = useRef(onResize)
   onResizeRef.current = onResize
+  const onCopyRequestRef = useRef(onCopyRequest)
+  onCopyRequestRef.current = onCopyRequest
+  const onPasteRequestRef = useRef(onPasteRequest)
+  onPasteRequestRef.current = onPasteRequest
+  const onToolbarNoticeRef = useRef(onToolbarNotice)
+  onToolbarNoticeRef.current = onToolbarNotice
 
   // `tryFit` is defined inside the init effect so it closes over the local
   // `fit`/`term`. Stash it in a ref so the imperative `refit()` method can
@@ -124,6 +136,23 @@ export default function TerminalView({
   // tab switches when the visible host height (e.g. keyboard-adjusted) is
   // unchanged but the xterm was clobbered by a pty.resized replay event.
   const tryFitRef = useRef<(() => void) | null>(null)
+
+  const blurTerminal = useCallback((): void => {
+    try {
+      termRef.current?.blur()
+      termRef.current?.textarea?.blur()
+    } catch {
+      /* ignore — xterm might already be disposed */
+    }
+    try {
+      if (typeof document !== 'undefined') {
+        const active = document.activeElement as HTMLElement | null
+        active?.blur?.()
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [])
 
   // Expo's DOM-component-aware variant of useImperativeHandle. Methods must
   // be serializable (JSON args, void return) because they cross the native
@@ -147,30 +176,12 @@ export default function TerminalView({
       focus: () => {
         termRef.current?.focus()
       },
-      blur: () => {
-        // xterm's own blur unfocuses its internal textarea. We also blur
-        // whatever document.activeElement currently is as a belt-and-braces
-        // measure: iOS WKWebView dismisses the soft keyboard when no
-        // element inside the document holds focus.
-        try {
-          termRef.current?.blur()
-        } catch {
-          /* ignore — xterm might already be disposed */
-        }
-        try {
-          if (typeof document !== 'undefined') {
-            const active = document.activeElement as HTMLElement | null
-            active?.blur?.()
-          }
-        } catch {
-          /* ignore */
-        }
-      },
+      blur: blurTerminal,
       refit: () => {
         tryFitRef.current?.()
       },
     }),
-    [],
+    [blurTerminal],
   )
 
   useEffect(() => {
@@ -614,6 +625,19 @@ export default function TerminalView({
     void onInputRef.current(seq)
   }, [])
 
+  const pasteFromClipboard = useCallback((): void => {
+    void onPasteRequestRef.current()
+  }, [])
+
+  const copySelection = useCallback((): void => {
+    const selectedText = document.getSelection()?.toString() ?? ''
+    if (!selectedText) {
+      void onToolbarNoticeRef.current('No terminal selection to copy')
+      return
+    }
+    void onCopyRequestRef.current(selectedText)
+  }, [])
+
   const toggleCtrl = useCallback((): void => {
     const next = !ctrlArmedRef.current
     ctrlArmedRef.current = next
@@ -658,15 +682,21 @@ export default function TerminalView({
         // otherwise the iOS soft keyboard dismisses on every tap gap.
         onMouseDown={(e): void => e.preventDefault()}
       >
+        <ToolbarKey label="Hide" onPress={blurTerminal} palette={palette} />
+        <ToolbarKey label="Copy" onPress={copySelection} palette={palette} />
+        <ToolbarKey label="Paste" onPress={pasteFromClipboard} palette={palette} />
         <ToolbarKey label="Esc" onPress={(): void => emit('\x1b')} palette={palette} />
         <ToolbarKey label="Tab" onPress={(): void => emit('\t')} palette={palette} />
-        <ToolbarKey label="⇧Tab" onPress={(): void => emit('\x1b[Z')} palette={palette} />
+        <ToolbarKey label="Shift+Tab" onPress={(): void => emit('\x1b[Z')} palette={palette} />
         <ToolbarKey label="Ctrl" onPress={toggleCtrl} palette={palette} active={ctrlArmed} />
         <ToolbarKey label="Alt" onPress={toggleAlt} palette={palette} active={altArmed} />
-        <ToolbarKey label="←" onPress={(): void => emit('\x1b[D')} palette={palette} />
-        <ToolbarKey label="→" onPress={(): void => emit('\x1b[C')} palette={palette} />
-        <ToolbarKey label="↑" onPress={(): void => emit('\x1b[A')} palette={palette} />
-        <ToolbarKey label="↓" onPress={(): void => emit('\x1b[B')} palette={palette} />
+        <ToolbarKey label="Left" onPress={(): void => emit('\x1b[D')} palette={palette} />
+        <ToolbarKey label="Right" onPress={(): void => emit('\x1b[C')} palette={palette} />
+        <ToolbarKey label="Up" onPress={(): void => emit('\x1b[A')} palette={palette} />
+        <ToolbarKey label="Down" onPress={(): void => emit('\x1b[B')} palette={palette} />
+        <ToolbarKey label="Home" onPress={(): void => emit('\x1b[H')} palette={palette} />
+        <ToolbarKey label="End" onPress={(): void => emit('\x1b[F')} palette={palette} />
+        <ToolbarKey label="Enter" onPress={(): void => emit('\r')} palette={palette} />
       </div>
     </div>
   )

--- a/mobile/src/components/terminal/terminal-view.tsx
+++ b/mobile/src/components/terminal/terminal-view.tsx
@@ -65,7 +65,7 @@ type Props = {
   onResize: (cols: number, rows: number) => Promise<void>
   onCopyRequest: (text: string) => Promise<void>
   onPasteRequest: () => Promise<void>
-  onToolbarNotice: (message: string) => Promise<void>
+  onToolbarNotice: (message: string) => void
   /**
    * `ref` is intentionally part of Props rather than a `forwardRef` argument:
    * Expo DOM components auto-generate a wrapper on the native side that


### PR DESCRIPTION
## What

Moves mobile terminal actions into the in-WebView keyboard toolbar and removes the native paste action bar.

Adds toolbar actions for Hide, Copy, Paste, Home, End, and Enter while preserving existing terminal keys and one-shot Ctrl/Alt behavior.

## Why

Mobile terminal users need copy, paste, and keyboard dismissal controls without leaving the WebView toolbar, so toolbar taps preserve terminal focus and selection better on soft keyboards.

## How to test

- \\`cd mobile && npm run lint\\`
- \\`cd mobile && npm run typecheck\\`
- \\`cd mobile && npm run build\\`
- On a simulator or device, connect to a desktop Canopy remote session.
- Open a terminal, focus it, and verify the WebView keyboard toolbar appears.
- Verify the native paste action bar is gone.
- Select terminal output and tap Copy; paste into another text field to confirm selected text copied.
- Tap Copy with no selection and verify the terminal banner reports no selection.
- Put text on the device clipboard, tap Paste, and verify it inserts without submitting.
- Verify Hide dismisses the keyboard.
- Verify Esc, Tab, Shift+Tab, Ctrl, Alt, arrows, Home, End, and Enter work in the terminal.

## Screenshots / recordings

Not included. This changes the mobile keyboard toolbar and should be verified on device or simulator.

## Checklist

- [x] Code follows existing project patterns
- [x] Lint passes
- [x] Typecheck passes
- [x] Build passes
- [ ] Device/simulator QA completed