### PR TITLE
refactor: move renderer mutations into main commands

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,14 @@ The preload exposes dedicated typed functions per domain, not a generic `invoke(
 
 IPC handlers validate input from the renderer (the renderer is untrusted). Write operations unwrap Results with `unwrapOrThrow()`. Read operations use `.unwrapOr(defaultValue)` for safe fallbacks.
 
+Renderer code should prefer main-owned command IPC for domain mutations. Low-level IPC primitives
+are reserved for UI-native operations or command-service internals; renderer stores should not
+compose privileged primitives into workspace, session, layout, agent, or run-config workflows.
+Layout persistence uses main-owned save/delete commands that derive workspace identity from the
+sender's attached workspace state. Full saved-layout interpretation is still renderer-assisted:
+the renderer parses the persisted split tree and requests main-owned pane/tmux commands for each
+session. Moving full layout hydration into main is a follow-up boundary-tightening step.
+
 ## Error handling
 
 Business logic uses `neverthrow` (`Result<T, E>`, `ResultAsync<T, E>`) instead of `try/catch`. Each domain defines a typed error union with `_tag` discriminants in a dedicated `errors.ts` file (e.g., `src/main/git/errors.ts`, `src/main/taskTracker/errors.ts`).

--- a/docs/core/terminal.md
+++ b/docs/core/terminal.md
@@ -21,8 +21,9 @@ Tmux integration (dev builds only) allows creating new tmux sessions or attachin
 ### Opening a new shell tab
 
 1. User presses the new-tab shortcut or clicks the add button.
-2. Renderer calls `window.api.spawnPty({ cols, rows, cwd })`.
-3. Main process spawns a PTY via `PtyManager.spawn()`, assigns a UUID session ID.
+2. Renderer asks the main-owned tab command API to open the shell for the selected worktree.
+3. Main process validates the sender owns that worktree, then spawns a PTY via `PtyManager.spawn()`
+   and assigns a UUID session ID.
 4. `WsBridge.create()` attaches to the PTY data stream and returns a `ws://` URL.
 5. Renderer receives `{ sessionId, wsUrl }` and creates a `TerminalInstance` component.
 6. `TerminalInstance` waits for fonts to load, creates an xterm.js `Terminal`, then connects to the WebSocket URL.

--- a/docs/features/run-configurations.md
+++ b/docs/features/run-configurations.md
@@ -108,7 +108,7 @@ The file path is always `<dir>/.canopy/run.toml` and is not configurable. Discov
 
 ## Security and privacy
 
-Run configuration files can be committed with the repository, so their `env` table is treated as untrusted input. Before spawning `pre_run`, the main command, or `post_run`, Canopy filters environment overrides through the shared `BLOCKED_ENV_VARS` list. Blocked keys such as `PATH`, `HOME`, dynamic linker variables, `NODE_OPTIONS`, Git/SSH helpers, proxy/TLS variables, and compiler flags are ignored so a cloned `.canopy/run.toml` cannot hijack the child shell or runtime. Non-string TOML values are also ignored.
+Run configuration files can be committed with the repository, so their `env` table is treated as untrusted input. Before spawning `pre_run`, the main command, or `post_run`, Canopy filters environment overrides through the shared `BLOCKED_ENV_VARS` list. Blocked keys such as `PATH`, `HOME`, dynamic linker variables, runtime option hooks (`NODE_OPTIONS`, `JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`), Git/SSH helpers, proxy/TLS variables, and compiler flags are ignored so a cloned `.canopy/run.toml` cannot hijack the child shell or runtime. Non-string TOML values are also ignored.
 
 Filtered variables fall back to the inherited login environment used by `PtyManager.spawn`; the run does not fail just because a blocked override was present.
 

--- a/docs/integrations/agents.md
+++ b/docs/integrations/agents.md
@@ -50,12 +50,12 @@ Each agent emits events in its own protocol. Adapters map these to a common set 
 | `PermissionRequest`   | `PermissionRequest`  | -                  | `Notification(ToolPermission)` | `PermissionAsked`   |
 | `Idle`                | `Stop`               | `Stop`             | `AfterAgent`                   | `SessionStatusIdle` |
 | `IdleFailure`         | `StopFailure`        | -                  | -                              | `SessionError`      |
-| `BeforeCompact`       | `PreCompact`         | `PreCompact`      | `PreCompress`                  | `SessionCompacting` |
-| `AfterCompact`        | `PostCompact`        | `PostCompact`     | -                              | `SessionCompacted`  |
+| `BeforeCompact`       | `PreCompact`         | `PreCompact`       | `PreCompress`                  | `SessionCompacting` |
+| `AfterCompact`        | `PostCompact`        | `PostCompact`      | -                              | `SessionCompacted`  |
 | `Notification`        | `Notification`       | -                  | `Notification`                 | `TodoUpdated`       |
 | `AfterToolUseFailure` | `PostToolUseFailure` | -                  | -                              | -                   |
 | `SubagentStart`       | `SubagentStart`      | -                  | -                              | -                   |
-| `SubagentStop`        | `SubagentStop`       | `SubagentStop`    | -                              | -                   |
+| `SubagentStop`        | `SubagentStop`       | `SubagentStop`     | -                              | -                   |
 | `TaskCompleted`       | `TaskCompleted`      | -                  | -                              | -                   |
 | `TeammateIdle`        | `TeammateIdle`       | -                  | -                              | -                   |
 
@@ -115,9 +115,9 @@ On session destroy, the adapter's `cleanup()` function removes temporary setting
 
 Each agent can have multiple named **profiles**, each holding a complete configuration snapshot (model, API key, base URL, provider, env vars, settings JSON override). Profiles let users switch between providers — e.g. a `Default` profile using Anthropic, an `Ollama` profile pointing at a local endpoint, a `GLM` or `MinMax` profile targeting alternative gateways — without rewriting global preferences each time.
 
-**Launching a profile.** The Tools sidebar renders each AI agent as a collapsible group when it has two or more profiles. Expanding the group lists the profiles; clicking one spawns the agent using that profile's configuration. When an agent has only a single profile (typically the `Default`), it renders as a flat launcher with no chevron — one click launches directly. If `profileId` is omitted from the `tool:spawn` payload, the spawn handler falls back to reading global preferences (legacy behaviour).
+**Launching a profile.** The Tools sidebar renders each AI agent as a collapsible group when it has two or more profiles. Expanding the group lists the profiles; clicking one spawns the agent using that profile's configuration. When an agent has only a single profile (typically the `Default`), it renders as a flat launcher with no chevron — one click launches directly. If `profileId` is omitted from the tab command payload, the spawn handler falls back to reading global preferences (legacy behaviour).
 
-**Profile → adapter seam.** Adapters are profile-agnostic: they take a `PreferencesReader` interface (`{ get(key): string | null }`). When `tool:spawn` receives a `profileId`, it wraps the profile in a `profileToReader()` shim that returns the profile's values for `${agentType}.*` keys and delegates all other keys to the global `preferencesStore`. This means adding profile support required zero changes to `AgentSessionManager` or any of the four adapter files. All three reader call sites in `tool:spawn` (settingsJson parsing, `getCliArgs`, `getEnvVars`) swap to the shim together.
+**Profile -> adapter seam.** Adapters are profile-agnostic: they take a `PreferencesReader` interface (`{ get(key): string | null }`). When the tab command spawn path receives a `profileId`, it wraps the profile in a `profileToReader()` shim that returns the profile's values for `${agentType}.*` keys and delegates all other keys to the global `preferencesStore`. This means adding profile support required zero changes to `AgentSessionManager` or any of the four adapter files. All three reader call sites in the spawn path (settingsJson parsing, `getCliArgs`, `getEnvVars`) swap to the shim together.
 
 **Storage.** Profiles live in the `agent_profiles` SQLite table with columns `id`, `agent_type`, `name`, `is_default`, `sort_index`, `prefs_json`, `api_key_enc`, `created_at`, `updated_at`. `api_key_enc` is encrypted with Electron's `safeStorage` (identical pattern to `CredentialStore`; falls back to plain base64 on Linux without a keyring). The name is unique per agent type. Only a single profile per agent type may be deleted down to — the store returns `ProfileLastDeletion` if the user tries to remove the last profile.
 
@@ -133,36 +133,36 @@ Preferences for each agent are organized into **profiles** (see the Profiles sec
 
 The fields below describe the keys stored inside each profile's `prefs_json` (non-secret) and the separately encrypted `api_key_enc` column. Adapters read them via `${agentType}.<field>` lookups on the `PreferencesReader` shim.
 
-| Profile field          | Agent    | Purpose                                           |
-| ---------------------- | -------- | ------------------------------------------------- |
-| `model`                | Claude   | `--model` argument                                |
-| `permissionMode`       | Claude   | `--permission-mode` argument                      |
-| `effortLevel`          | Claude   | `--effort` argument                               |
-| `appendSystemPrompt`   | Claude   | `--append-system-prompt` argument                 |
-| `apiKey` _(encrypted)_ | Claude   | `ANTHROPIC_API_KEY` env var                       |
-| `baseUrl`              | Claude   | `ANTHROPIC_BASE_URL` env var                      |
-| `provider`             | Claude   | Sets `CLAUDE_CODE_USE_BEDROCK`/`VERTEX`/`FOUNDRY` |
-| `customEnv`            | Claude   | JSON object of additional env vars                |
-| `settingsJson`         | Claude   | Merged into per-session `settings.json`           |
-| `model`                | Codex    | `--model` argument                                |
-| `approvalMode`         | Codex    | `--ask-for-approval` argument                     |
-| `sandbox`              | Codex    | `--sandbox` argument                              |
-| `fullAuto`             | Codex    | `--full-auto` flag (when `"true"`)                |
+| Profile field                          | Agent    | Purpose                                                                                                        |
+| -------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `model`                                | Claude   | `--model` argument                                                                                             |
+| `permissionMode`                       | Claude   | `--permission-mode` argument                                                                                   |
+| `effortLevel`                          | Claude   | `--effort` argument                                                                                            |
+| `appendSystemPrompt`                   | Claude   | `--append-system-prompt` argument                                                                              |
+| `apiKey` _(encrypted)_                 | Claude   | `ANTHROPIC_API_KEY` env var                                                                                    |
+| `baseUrl`                              | Claude   | `ANTHROPIC_BASE_URL` env var                                                                                   |
+| `provider`                             | Claude   | Sets `CLAUDE_CODE_USE_BEDROCK`/`VERTEX`/`FOUNDRY`                                                              |
+| `customEnv`                            | Claude   | JSON object of additional env vars                                                                             |
+| `settingsJson`                         | Claude   | Merged into per-session `settings.json`                                                                        |
+| `model`                                | Codex    | `--model` argument                                                                                             |
+| `approvalMode`                         | Codex    | `--ask-for-approval` argument                                                                                  |
+| `sandbox`                              | Codex    | `--sandbox` argument                                                                                           |
+| `fullAuto`                             | Codex    | `--full-auto` flag (when `"true"`)                                                                             |
 | `dangerouslyBypassApprovalsAndSandbox` | Codex    | `--dangerously-bypass-approvals-and-sandbox` flag; takes precedence over approval mode, sandbox, and full auto |
-| `profile`              | Codex    | `--profile` argument                              |
-| `apiKey` _(encrypted)_ | Codex    | `OPENAI_API_KEY` env var                          |
-| `baseUrl`              | Codex    | `OPENAI_BASE_URL` env var                         |
-| `customEnv`            | Codex    | JSON object of additional env vars                |
-| `settingsJson`         | Codex    | Merged into per-session `.codex/hooks.json`       |
-| `model`                | Gemini   | `--model` argument                                |
-| `approvalMode`         | Gemini   | `--approval-mode` argument                        |
-| `apiKey` _(encrypted)_ | Gemini   | `GEMINI_API_KEY` env var                          |
-| `customEnv`            | Gemini   | JSON object of additional env vars                |
-| `settingsJson`         | Gemini   | Merged into per-session `.gemini/settings.json`   |
-| `model`                | OpenCode | `--model` argument                                |
-| `apiKey` _(encrypted)_ | OpenCode | `ANTHROPIC_API_KEY` env var                       |
-| `settingsJson`         | OpenCode | `OPENCODE_CONFIG_CONTENT` env var                 |
-| `customEnv`            | OpenCode | JSON object of additional env vars                |
+| `profile`                              | Codex    | `--profile` argument                                                                                           |
+| `apiKey` _(encrypted)_                 | Codex    | `OPENAI_API_KEY` env var                                                                                       |
+| `baseUrl`                              | Codex    | `OPENAI_BASE_URL` env var                                                                                      |
+| `customEnv`                            | Codex    | JSON object of additional env vars                                                                             |
+| `settingsJson`                         | Codex    | Merged into per-session `.codex/hooks.json`                                                                    |
+| `model`                                | Gemini   | `--model` argument                                                                                             |
+| `approvalMode`                         | Gemini   | `--approval-mode` argument                                                                                     |
+| `apiKey` _(encrypted)_                 | Gemini   | `GEMINI_API_KEY` env var                                                                                       |
+| `customEnv`                            | Gemini   | JSON object of additional env vars                                                                             |
+| `settingsJson`                         | Gemini   | Merged into per-session `.gemini/settings.json`                                                                |
+| `model`                                | OpenCode | `--model` argument                                                                                             |
+| `apiKey` _(encrypted)_                 | OpenCode | `ANTHROPIC_API_KEY` env var                                                                                    |
+| `settingsJson`                         | OpenCode | `OPENCODE_CONFIG_CONTENT` env var                                                                              |
+| `customEnv`                            | OpenCode | JSON object of additional env vars                                                                             |
 
 Custom env vars are filtered against a blocklist (`BLOCKED_ENV_VARS` from `security/envBlocklist`) and internal vars (`CANOPY_HOOK_PORT`, `CANOPY_HOOK_TOKEN`, `ELECTRON_RUN_AS_NODE`).
 

--- a/perf/cpu-profile.ts
+++ b/perf/cpu-profile.ts
@@ -80,9 +80,12 @@ test('CPU profile: project open', async ({ cdp, electronApp, page, testProjectPa
   expect(profile).toBeTruthy()
 })
 
-test('CPU profile: terminal activity', async ({ cdp, page }) => {
-  const result = await page.evaluate(() =>
-    (window as unknown as BrowserApi).api.spawnPty({ cols: 80, rows: 24 }),
+test('CPU profile: terminal activity', async ({ cdp, electronApp, page, testProjectPath }) => {
+  await openProject(electronApp, page, testProjectPath)
+
+  const result = await page.evaluate(
+    (worktreePath) => (window as unknown as BrowserApi).api.tabSpawnPane('shell', worktreePath),
+    testProjectPath,
   )
   await new Promise((r) => setTimeout(r, 1000))
 

--- a/perf/fixtures.ts
+++ b/perf/fixtures.ts
@@ -175,10 +175,11 @@ export interface BrowserApi {
     getPref: (k: string) => Promise<string | null>
     perfDiagnostics: () => Promise<PerfDiagnostics | null>
     perfIpcLog: () => Promise<Array<{ channel: string; size: number; ts: number; dir: string }>>
-    spawnPty: (o: { cols: number; rows: number }) => Promise<{ sessionId: string }>
+    perfOpenProject?: (path: string) => Promise<void>
+    tabSpawnPane: (toolId: string, worktreePath: string) => Promise<{ sessionId: string }>
     writePty: (sid: string, data: string) => Promise<void>
     killPty: (sid: string) => Promise<void>
-    detachProject: (path: string) => Promise<void>
+    workspaceDetachProject: (path: string) => Promise<void>
   }
 }
 
@@ -193,10 +194,10 @@ export async function openProject(
       !!(window as unknown as BrowserApi).api &&
       typeof (window as unknown as BrowserApi).api.getPref === 'function',
   )
-  await electronApp.evaluate(({ BrowserWindow }, path) => {
-    const win = BrowserWindow.getAllWindows()[0]
-    win.webContents.send('url:action', { action: 'open', path })
-  }, projectPath)
+  await page.evaluate(
+    (path) => (window as unknown as BrowserApi).api.perfOpenProject?.(path),
+    projectPath,
+  )
   // Wait for workspace to load
   await page.waitForTimeout(2000)
 }

--- a/perf/ipc-monitor.ts
+++ b/perf/ipc-monitor.ts
@@ -117,8 +117,9 @@ test('capture IPC traffic with project open', async ({ electronApp, page, testPr
 
   console.log(`\n--- IPC Traffic Capture (${CAPTURE_MS / 1000}s with project) ---`)
 
-  const ptyResult = await page.evaluate(() =>
-    (window as unknown as BrowserApi).api.spawnPty({ cols: 80, rows: 24 }),
+  const ptyResult = await page.evaluate(
+    (worktreePath) => (window as unknown as BrowserApi).api.tabSpawnPane('shell', worktreePath),
+    testProjectPath,
   )
 
   await page.waitForTimeout(1000)

--- a/perf/memory-leak.ts
+++ b/perf/memory-leak.ts
@@ -18,9 +18,14 @@ import {
 } from './fixtures'
 import type { BrowserApi } from './fixtures'
 
-test('terminal open/close should not leak PTY sessions', async ({ page }) => {
+test('terminal open/close should not leak PTY sessions', async ({
+  electronApp,
+  page,
+  testProjectPath,
+}) => {
   const CYCLES = 8
 
+  await openProject(electronApp, page, testProjectPath)
   await forceGC(await page.context().newCDPSession(page))
   const baseline = await getDiagnostics(page)
   expect(baseline).toBeTruthy()
@@ -32,8 +37,9 @@ test('terminal open/close should not leak PTY sessions', async ({ page }) => {
   console.log(`Baseline PTY: ${baselinePty}, WS bridges: ${baselineBridge}`)
 
   for (let i = 0; i < CYCLES; i++) {
-    const result = await page.evaluate(() =>
-      (window as unknown as BrowserApi).api.spawnPty({ cols: 80, rows: 24 }),
+    const result = await page.evaluate(
+      (worktreePath) => (window as unknown as BrowserApi).api.tabSpawnPane('shell', worktreePath),
+      testProjectPath,
     )
 
     expect(result).toBeTruthy()
@@ -89,7 +95,7 @@ test('workspace open should not leak git watchers', async ({
     }
 
     await page.evaluate(
-      (path) => (window as unknown as BrowserApi).api.detachProject(path),
+      (path) => (window as unknown as BrowserApi).api.workspaceDetachProject(path),
       testProjectPath,
     )
 
@@ -118,8 +124,9 @@ test('heap snapshot comparison', async ({ page, electronApp, testProjectPath, cd
   await page.waitForTimeout(2000)
 
   for (let i = 0; i < 3; i++) {
-    const result = await page.evaluate(() =>
-      (window as unknown as BrowserApi).api.spawnPty({ cols: 80, rows: 24 }),
+    const result = await page.evaluate(
+      (worktreePath) => (window as unknown as BrowserApi).api.tabSpawnPane('shell', worktreePath),
+      testProjectPath,
     )
     await page.waitForTimeout(300)
     await page.evaluate(
@@ -129,7 +136,7 @@ test('heap snapshot comparison', async ({ page, electronApp, testProjectPath, cd
   }
 
   await page.evaluate(
-    (path) => (window as unknown as BrowserApi).api.detachProject(path),
+    (path) => (window as unknown as BrowserApi).api.workspaceDetachProject(path),
     testProjectPath,
   )
 

--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -256,6 +256,10 @@ export class WindowManager {
     if (set) set.delete(sessionId)
   }
 
+  ownsPtySession(wcId: number, sessionId: string): boolean {
+    return this.ptySessions.get(wcId)?.has(sessionId) ?? false
+  }
+
   setGitWatcher(wcId: number, repoRoot: string, watcher: GitWatcher): void {
     let watchers = this.gitWatchers.get(wcId)
     if (!watchers) {

--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -174,7 +174,7 @@ export class WindowManager {
 
   getWindowForPath(path: string): BrowserWindow | null {
     for (const [wcId, paths] of this.workspacePaths) {
-      if (paths.has(path)) {
+      if (paths.has(path) || this.activeWorktreePaths.get(wcId) === path) {
         const win = this.windows.get(wcId)
         if (win && !win.isDestroyed()) return win
       }
@@ -198,6 +198,10 @@ export class WindowManager {
 
   setActiveWorktree(wcId: number, path: string): void {
     this.activeWorktreePaths.set(wcId, path)
+  }
+
+  clearActiveWorktree(wcId: number): void {
+    this.activeWorktreePaths.delete(wcId)
   }
 
   setFocusedAgentSession(wcId: number, ptySessionId: string | null): void {

--- a/src/main/commands/agentCommands.ts
+++ b/src/main/commands/agentCommands.ts
@@ -1,0 +1,77 @@
+import type { WebContents } from 'electron'
+import type { AgentSessionManager } from '../agents/AgentSessionManager'
+import type { PtyManager } from '../pty/PtyManager'
+import type { WindowManager } from '../WindowManager'
+import type { AgentCommandResult } from './types'
+
+interface AgentCommandServiceDeps {
+  ptyManager: PtyManager
+  agentSessionManager: AgentSessionManager
+  windowManager: WindowManager
+}
+
+export interface AgentContextPayload {
+  text: string
+  worktreePath?: string
+  sessionId?: string
+}
+
+export interface AgentDrawingPayload {
+  pngBase64?: string
+  worktreePath?: string
+  sessionId?: string
+}
+
+export class AgentCommandService {
+  constructor(private deps: AgentCommandServiceDeps) {}
+
+  sendTaskContext(sender: WebContents, payload: AgentContextPayload): AgentCommandResult {
+    const sessionId = this.resolveTargetSession(sender, payload.sessionId)
+    this.writeBracketedPaste(sessionId, this.contextText(payload))
+    return { sessionId }
+  }
+
+  sendReviewContext(sender: WebContents, payload: AgentContextPayload): AgentCommandResult {
+    const sessionId = this.resolveTargetSession(sender, payload.sessionId)
+    this.writeBracketedPaste(sessionId, this.contextText(payload))
+    return { sessionId }
+  }
+
+  sendDrawing(sender: WebContents, payload: AgentDrawingPayload): AgentCommandResult {
+    const sessionId = this.resolveTargetSession(sender, payload.sessionId)
+    this.deps.ptyManager.write(sessionId, '\x16')
+    return { sessionId }
+  }
+
+  private resolveTargetSession(sender: WebContents, explicitSessionId?: string): string {
+    if (explicitSessionId) {
+      if (!this.isValidTarget(sender.id, explicitSessionId)) {
+        throw new Error('Agent session is not available')
+      }
+      return explicitSessionId
+    }
+
+    const focusedSessionId = this.deps.windowManager.getFocusedAgentSession(sender.id)
+    if (focusedSessionId && this.isValidTarget(sender.id, focusedSessionId)) {
+      return focusedSessionId
+    }
+
+    throw new Error('No active agent session')
+  }
+
+  private isValidTarget(webContentsId: number, sessionId: string): boolean {
+    return (
+      this.deps.windowManager.ownsPtySession(webContentsId, sessionId) &&
+      this.deps.agentSessionManager.isAgentSession(sessionId)
+    )
+  }
+
+  private writeBracketedPaste(sessionId: string, text: string): void {
+    this.deps.ptyManager.write(sessionId, `\x1b[200~${text}\x1b[201~\r`)
+  }
+
+  private contextText(payload: AgentContextPayload): string {
+    if (typeof payload.text !== 'string') throw new Error('Invalid agent context payload')
+    return payload.text
+  }
+}

--- a/src/main/commands/agentCommands.ts
+++ b/src/main/commands/agentCommands.ts
@@ -17,7 +17,6 @@ export interface AgentContextPayload {
 }
 
 export interface AgentDrawingPayload {
-  pngBase64?: string
   worktreePath?: string
   sessionId?: string
 }

--- a/src/main/commands/runConfigCommands.ts
+++ b/src/main/commands/runConfigCommands.ts
@@ -1,0 +1,229 @@
+import type { WebContents } from 'electron'
+import os from 'os'
+import path from 'path'
+import type { PtyManager } from '../pty/PtyManager'
+import { resolveShell } from '../pty/PtyManager'
+import type { WsBridge } from '../pty/WsBridge'
+import type { WindowManager } from '../WindowManager'
+import type { RunConfigManager } from '../runConfig/RunConfigManager'
+import { runConfigErrorMessage } from '../runConfig/errors'
+import type { RunConfigCommandResult, RunConfigProcessSnapshot } from './types'
+import type { Result } from 'neverthrow'
+
+interface RunConfigCommandServiceDeps {
+  ptyManager: PtyManager
+  wsBridge: WsBridge
+  windowManager: WindowManager
+  runConfigManager: RunConfigManager
+  validatePathAccess: (webContentsId: number, targetPath: string) => Promise<string>
+}
+
+interface RunConfigExecutePayload {
+  configDir: string
+  name: string
+  cwd?: string
+}
+
+function unwrapOrThrow<T, E>(result: Result<T, E>, toMessage: (e: E) => string): T {
+  if (result.isErr()) throw new Error(toMessage(result.error))
+  return result.value
+}
+
+function shellExecArgs(command: string): { command: string; args: string[] } {
+  const shell = resolveShell()
+  const flag = os.platform() === 'win32' ? '-Command' : '-lc'
+  return { command: shell.command, args: [flag, command] }
+}
+
+export class RunConfigCommandService {
+  private runningProcesses = new Map<string, RunConfigProcessSnapshot>()
+  private runConfigInstances = new Map<string, number>()
+
+  constructor(private deps: RunConfigCommandServiceDeps) {}
+
+  async execute(
+    sender: WebContents,
+    payload: RunConfigExecutePayload,
+  ): Promise<RunConfigCommandResult> {
+    const resolvedConfigDir = await this.deps.validatePathAccess(sender.id, payload.configDir)
+    const fileResult = await this.deps.runConfigManager.loadFile(resolvedConfigDir)
+    const file = unwrapOrThrow(fileResult, runConfigErrorMessage)
+    const config = file.configurations.find((c) => c.name === payload.name)
+    if (!config) throw new Error(`Configuration "${payload.name}" not found`)
+
+    const instanceKey = this.instanceKey(resolvedConfigDir, payload.name)
+    let reserved = false
+    if (config.max_instances && config.max_instances > 0) {
+      const current = this.runConfigInstances.get(instanceKey) ?? 0
+      if (current >= config.max_instances) {
+        throw new Error(`"${payload.name}" is already running (max ${config.max_instances})`)
+      }
+    }
+    this.incrementInstance(instanceKey)
+    reserved = true
+
+    try {
+      if (!payload.cwd) throw new Error('No worktree selected')
+      const worktreeRoot = await this.deps.validatePathAccess(sender.id, payload.cwd)
+      const cwd = config.cwd ? path.resolve(worktreeRoot, config.cwd) : worktreeRoot
+      if (config.cwd && cwd !== worktreeRoot && !cwd.startsWith(worktreeRoot + path.sep)) {
+        throw new Error('config.cwd must not escape the worktree directory')
+      }
+      const env = config.env
+      const fullCommand = config.args ? `${config.command} ${config.args}` : config.command
+
+      // Pre-run hook (30s timeout)
+      if (config.pre_run) {
+        const PRE_RUN_TIMEOUT = 30_000
+        // Cap captured output so a noisy pre_run can't balloon main-process
+        // memory before the timer fires. We only surface the last ~5 lines on
+        // failure, so trimming the head is safe.
+        const PRE_RUN_OUTPUT_CAP = 32_768
+        const pre = shellExecArgs(config.pre_run)
+        const preSession = this.deps.ptyManager.spawn({
+          command: pre.command,
+          args: pre.args,
+          cwd,
+          env,
+        })
+        let preOutput = ''
+        preSession.pty.onData((data) => {
+          preOutput += data
+          if (preOutput.length > PRE_RUN_OUTPUT_CAP) {
+            preOutput = preOutput.slice(-PRE_RUN_OUTPUT_CAP / 2)
+          }
+        })
+        await new Promise<void>((resolve, reject) => {
+          let done = false
+          const timer = setTimeout(() => {
+            if (!done) {
+              done = true
+              this.deps.ptyManager.kill(preSession.id)
+              reject(new Error(`pre_run "${config.pre_run}" timed out after 30s`))
+            }
+          }, PRE_RUN_TIMEOUT)
+          preSession.pty.onExit(({ exitCode }) => {
+            if (done) return
+            done = true
+            clearTimeout(timer)
+            this.deps.ptyManager.kill(preSession.id)
+            if (exitCode !== 0) {
+              const lastLines = preOutput.trim().split('\n').slice(-5).join('\n')
+              reject(
+                new Error(`pre_run "${config.pre_run}" failed (exit ${exitCode}):\n${lastLines}`),
+              )
+            } else resolve()
+          })
+        })
+      }
+
+      // Run main command through shell so PATH is resolved
+      const main = shellExecArgs(fullCommand)
+      const session = this.deps.ptyManager.spawn({
+        command: main.command,
+        args: main.args,
+        cwd,
+        env,
+      })
+      const senderId = sender.id
+      let cleanedUp = false
+      const cleanup = (): void => {
+        if (cleanedUp) return
+        cleanedUp = true
+        this.deps.windowManager.untrackPtySession(senderId, session.id)
+        this.runningProcesses.delete(session.id)
+        this.decrementInstance(instanceKey)
+      }
+
+      session.pty.onExit(({ exitCode, signal }) => {
+        if (!sender.isDestroyed()) {
+          sender.send('pty:exit', { sessionId: session.id, exitCode, signal })
+        }
+        cleanup()
+
+        // Post-run hook
+        if (config.post_run) {
+          const postCmd = config.post_run
+          const post = shellExecArgs(postCmd)
+          const postSession = this.deps.ptyManager.spawn({
+            command: post.command,
+            args: post.args,
+            cwd,
+            env,
+          })
+          const POST_RUN_TIMEOUT = 30_000
+          let postDone = false
+          const postTimer = setTimeout(() => {
+            if (!postDone) {
+              postDone = true
+              this.deps.ptyManager.kill(postSession.id)
+              if (!sender.isDestroyed()) {
+                sender.send('runConfig:postRunResult', {
+                  success: false,
+                  command: postCmd,
+                  exitCode: -1,
+                })
+              }
+            }
+          }, POST_RUN_TIMEOUT)
+          postSession.pty.onExit(({ exitCode: postExit }) => {
+            if (postDone) return
+            postDone = true
+            clearTimeout(postTimer)
+            if (!sender.isDestroyed()) {
+              sender.send(
+                'runConfig:postRunResult',
+                postExit === 0
+                  ? { success: true, command: postCmd }
+                  : { success: false, command: postCmd, exitCode: postExit },
+              )
+            }
+            this.deps.ptyManager.kill(postSession.id)
+          })
+        }
+      })
+
+      this.deps.windowManager.trackPtySession(senderId, session.id)
+      this.runningProcesses.set(session.id, {
+        sessionId: session.id,
+        name: payload.name,
+        configDir: resolvedConfigDir,
+        worktreePath: worktreeRoot,
+      })
+      reserved = false
+
+      try {
+        const wsUrl = await this.deps.wsBridge.create(session.id, session.pty)
+        return { sessionId: session.id, wsUrl, running: this.listRunning(sender) }
+      } catch (error) {
+        cleanup()
+        this.deps.ptyManager.kill(session.id)
+        throw error
+      }
+    } finally {
+      if (reserved) this.decrementInstance(instanceKey)
+    }
+  }
+
+  listRunning(sender?: WebContents): RunConfigProcessSnapshot[] {
+    const snapshots = Array.from(this.runningProcesses.values())
+    if (!sender) return snapshots
+    return snapshots.filter((snapshot) =>
+      this.deps.windowManager.ownsPtySession(sender.id, snapshot.sessionId),
+    )
+  }
+
+  private instanceKey(configDir: string, name: string): string {
+    return `${configDir}::${name}`
+  }
+
+  private incrementInstance(instanceKey: string): void {
+    this.runConfigInstances.set(instanceKey, (this.runConfigInstances.get(instanceKey) ?? 0) + 1)
+  }
+
+  private decrementInstance(instanceKey: string): void {
+    const count = (this.runConfigInstances.get(instanceKey) ?? 1) - 1
+    if (count <= 0) this.runConfigInstances.delete(instanceKey)
+    else this.runConfigInstances.set(instanceKey, count)
+  }
+}

--- a/src/main/commands/tabCommands.ts
+++ b/src/main/commands/tabCommands.ts
@@ -1,7 +1,6 @@
 import { BrowserWindow, type WebContents } from 'electron'
-import os from 'os'
 import { randomUUID } from 'crypto'
-import type { PtyManager } from '../pty/PtyManager'
+import { resolveShell, type PtyManager } from '../pty/PtyManager'
 import type { WsBridge } from '../pty/WsBridge'
 import type { PreferencesStore } from '../db/PreferencesStore'
 import type { LayoutStore } from '../db/LayoutStore'
@@ -54,11 +53,6 @@ interface ToolSessionServiceDeps {
   resolveWorkspaceIdForWorktree: (webContentsId: number, worktreePath: string) => string | null
 }
 
-function resolveShellArgs(): string[] {
-  if (os.platform() === 'win32') return []
-  return ['--login']
-}
-
 function validateTmuxName(name: string): void {
   if (!/^[\w-]+$/.test(name)) {
     throw new Error('Invalid tmux session name: only letters, digits, underscores, and dashes')
@@ -80,7 +74,7 @@ export class ToolSessionService {
     let command = this.deps.toolRegistry.resolveCommand(tool)
     const isShell = tool.id === 'shell' || tool.command === 'shell'
     const isAgent = this.deps.agentSessionManager.isAgentTool(tool.id)
-    let args = isShell ? resolveShellArgs() : [...tool.args]
+    let args = isShell ? resolveShell().args : [...tool.args]
     let env: Record<string, string> | undefined
 
     let agentTempId: string | undefined
@@ -570,19 +564,6 @@ export class TabCommandService {
       console.error('Failed to delete layout:', error)
       throw error
     }
-  }
-
-  restoreLayout(
-    sender: WebContents,
-    payload: TabCommandPayloadBase & { layoutJson: string },
-  ): TabCommandResult {
-    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
-    try {
-      JSON.parse(payload.layoutJson)
-    } catch {
-      return emptyResult(payload.worktreePath, payload.tabs ?? [], payload.activeTabId ?? null)
-    }
-    return emptyResult(payload.worktreePath, payload.tabs ?? [], payload.activeTabId ?? null)
   }
 
   private assertSenderOwnsWorktree(sender: WebContents, worktreePath: string): string {

--- a/src/main/commands/tabCommands.ts
+++ b/src/main/commands/tabCommands.ts
@@ -3,7 +3,6 @@ import os from 'os'
 import { randomUUID } from 'crypto'
 import type { PtyManager } from '../pty/PtyManager'
 import type { WsBridge } from '../pty/WsBridge'
-import type { WorkspaceStore } from '../db/WorkspaceStore'
 import type { PreferencesStore } from '../db/PreferencesStore'
 import type { LayoutStore } from '../db/LayoutStore'
 import type { ToolRegistry } from '../tools/ToolRegistry'
@@ -46,13 +45,13 @@ interface TmuxAttachPayload {
 interface ToolSessionServiceDeps {
   ptyManager: PtyManager
   wsBridge: WsBridge
-  workspaceStore: WorkspaceStore
   preferencesStore: PreferencesStore
   toolRegistry: ToolRegistry
   agentSessionManager: AgentSessionManager
   windowManager: WindowManager
   tmuxManager: TmuxManager
   profileStore: ProfileStore
+  resolveWorkspaceIdForWorktree: (webContentsId: number, worktreePath: string) => string | null
 }
 
 function resolveShellArgs(): string[] {
@@ -70,6 +69,11 @@ export class ToolSessionService {
   constructor(private deps: ToolSessionServiceDeps) {}
 
   async spawnTool(sender: WebContents, payload: ToolSpawnPayload): Promise<ToolSpawnResult> {
+    const workspaceId = this.deps.resolveWorkspaceIdForWorktree(sender.id, payload.worktreePath)
+    if (!workspaceId) {
+      throw new Error(`Worktree is not attached to this window: ${payload.worktreePath}`)
+    }
+
     const tool = this.deps.toolRegistry.get(payload.toolId)
     if (!tool) throw new Error(`Unknown tool: ${payload.toolId}`)
 
@@ -103,7 +107,7 @@ export class ToolSessionService {
         try {
           settingsOverrides = JSON.parse(settingsJsonRaw) as Record<string, unknown>
         } catch {
-          // Invalid JSON is ignored, matching the legacy tool:spawn path.
+          // Invalid JSON is ignored, matching the previous spawn behavior.
         }
       }
 
@@ -133,9 +137,7 @@ export class ToolSessionService {
     let tmuxSessionName: string | undefined
     const tmuxEnabled = this.deps.preferencesStore.get('tmux.enabled') === 'true'
     if (tmuxEnabled && (await this.deps.tmuxManager.isAvailable())) {
-      const ws = this.deps.workspaceStore.getByPath(payload.worktreePath)
-      const wsId = ws?.id ?? 'default'
-      tmuxSessionName = TmuxManagerStatics.sessionName(wsId)
+      tmuxSessionName = TmuxManagerStatics.sessionName(workspaceId)
       const tmuxMouse = this.deps.preferencesStore.get('tmux.mouse') === 'true'
       await this.deps.tmuxManager.newSession({
         name: tmuxSessionName,
@@ -268,9 +270,9 @@ export class ToolSessionService {
 interface TabCommandServiceDeps {
   toolSessions: ToolSessionService
   layoutStore: LayoutStore
-  workspaceStore: WorkspaceStore
   browserManager: BrowserManager
   windowManager: WindowManager
+  resolveWorkspaceIdForWorktree: (webContentsId: number, worktreePath: string) => string | null
 }
 
 interface TabCommandPayloadBase {
@@ -302,10 +304,24 @@ interface CloseTabPayload extends TabCommandPayloadBase {
   tabId: string
 }
 
+interface SpawnPanePayload extends TabCommandPayloadBase {
+  toolId: string
+  options?: {
+    initialUrl?: string
+    profileId?: string
+    workspaceName?: string
+    branch?: string
+    resumeSessionId?: string
+  }
+}
+
 interface SaveLayoutPayload {
   worktreePath: string
   layoutJson: string
-  workspaceId?: string
+}
+
+interface DeleteLayoutPayload {
+  worktreePath: string
 }
 
 function allPaneSnapshots(split: SplitSnapshot): PaneSnapshot[] {
@@ -443,6 +459,7 @@ export class TabCommandService {
   constructor(private deps: TabCommandServiceDeps) {}
 
   async openTool(sender: WebContents, payload: OpenToolPayload): Promise<TabCommandResult> {
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
     const tabs = [...validateTabSnapshots(payload.tabs)]
     const pane = await this.createPane(sender, payload.toolId, payload.worktreePath, {
       ...payload.options,
@@ -474,6 +491,7 @@ export class TabCommandService {
   }
 
   async restartPane(sender: WebContents, payload: RestartPanePayload): Promise<TabCommandResult> {
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
     const tabs = [...validateTabSnapshots(payload.tabs)]
     const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
     if (tabIndex < 0) {
@@ -505,6 +523,7 @@ export class TabCommandService {
   }
 
   async closeTab(sender: WebContents, payload: CloseTabPayload): Promise<TabCommandResult> {
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
     const tabs = [...validateTabSnapshots(payload.tabs)]
     const idx = tabs.findIndex((tab) => tab.id === payload.tabId)
     if (idx < 0) return emptyResult(payload.worktreePath, tabs, payload.activeTabId ?? null)
@@ -525,10 +544,13 @@ export class TabCommandService {
     }
   }
 
-  saveLayout(payload: SaveLayoutPayload): void {
-    const workspaceId =
-      payload.workspaceId ?? this.deps.workspaceStore.getByPath(payload.worktreePath)?.id
-    if (!workspaceId) return
+  async spawnPane(sender: WebContents, payload: SpawnPanePayload): Promise<PaneSnapshot> {
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    return this.createPane(sender, payload.toolId, payload.worktreePath, payload.options)
+  }
+
+  saveLayout(sender: WebContents, payload: SaveLayoutPayload): void {
+    const workspaceId = this.assertSenderOwnsWorktree(sender, payload.worktreePath)
 
     try {
       this.deps.layoutStore.save(workspaceId, payload.worktreePath, payload.layoutJson)
@@ -538,13 +560,37 @@ export class TabCommandService {
     }
   }
 
-  restoreLayout(payload: TabCommandPayloadBase & { layoutJson: string }): TabCommandResult {
+  deleteLayout(sender: WebContents, payload: DeleteLayoutPayload): void {
+    const workspaceId = this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+
+    try {
+      this.deps.layoutStore.delete(workspaceId, payload.worktreePath)
+    } catch (error) {
+      if (this.deps.layoutStore.isClosed()) return
+      console.error('Failed to delete layout:', error)
+      throw error
+    }
+  }
+
+  restoreLayout(
+    sender: WebContents,
+    payload: TabCommandPayloadBase & { layoutJson: string },
+  ): TabCommandResult {
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
     try {
       JSON.parse(payload.layoutJson)
     } catch {
       return emptyResult(payload.worktreePath, payload.tabs ?? [], payload.activeTabId ?? null)
     }
     return emptyResult(payload.worktreePath, payload.tabs ?? [], payload.activeTabId ?? null)
+  }
+
+  private assertSenderOwnsWorktree(sender: WebContents, worktreePath: string): string {
+    const workspaceId = this.deps.resolveWorkspaceIdForWorktree(sender.id, worktreePath)
+    if (!workspaceId) {
+      throw new Error(`Worktree is not attached to this window: ${worktreePath}`)
+    }
+    return workspaceId
   }
 
   private async createPane(

--- a/src/main/commands/tabCommands.ts
+++ b/src/main/commands/tabCommands.ts
@@ -1,0 +1,747 @@
+import { BrowserWindow, type WebContents } from 'electron'
+import os from 'os'
+import { randomUUID } from 'crypto'
+import type { PtyManager } from '../pty/PtyManager'
+import type { WsBridge } from '../pty/WsBridge'
+import type { WorkspaceStore } from '../db/WorkspaceStore'
+import type { PreferencesStore } from '../db/PreferencesStore'
+import type { LayoutStore } from '../db/LayoutStore'
+import type { ToolRegistry } from '../tools/ToolRegistry'
+import type { AgentSessionManager } from '../agents/AgentSessionManager'
+import type { WindowManager } from '../WindowManager'
+import type { BrowserManager } from '../browser/BrowserManager'
+import type { TmuxManager } from '../pty/TmuxManager'
+import { TmuxManager as TmuxManagerStatics } from '../pty/TmuxManager'
+import type { ProfileStore } from '../profiles/ProfileStore'
+import { profileToReader } from '../profiles/ProfileStore'
+import { profileErrorMessage } from '../profiles/errors'
+import type { PreferencesReader } from '../agents/types'
+import type { PaneSnapshot, SplitSnapshot, TabCommandResult, TabSnapshot } from './types'
+
+export interface ToolSpawnPayload {
+  toolId: string
+  worktreePath: string
+  cols?: number
+  rows?: number
+  workspaceName?: string
+  branch?: string
+  resumeSessionId?: string
+  profileId?: string
+}
+
+export interface ToolSpawnResult {
+  sessionId: string
+  wsUrl: string
+  toolId: string
+  toolName: string
+  tmuxSessionName?: string
+}
+
+interface TmuxAttachPayload {
+  tmuxSessionName: string
+  cols?: number
+  rows?: number
+}
+
+interface ToolSessionServiceDeps {
+  ptyManager: PtyManager
+  wsBridge: WsBridge
+  workspaceStore: WorkspaceStore
+  preferencesStore: PreferencesStore
+  toolRegistry: ToolRegistry
+  agentSessionManager: AgentSessionManager
+  windowManager: WindowManager
+  tmuxManager: TmuxManager
+  profileStore: ProfileStore
+}
+
+function resolveShellArgs(): string[] {
+  if (os.platform() === 'win32') return []
+  return ['--login']
+}
+
+function validateTmuxName(name: string): void {
+  if (!/^[\w-]+$/.test(name)) {
+    throw new Error('Invalid tmux session name: only letters, digits, underscores, and dashes')
+  }
+}
+
+export class ToolSessionService {
+  constructor(private deps: ToolSessionServiceDeps) {}
+
+  async spawnTool(sender: WebContents, payload: ToolSpawnPayload): Promise<ToolSpawnResult> {
+    const tool = this.deps.toolRegistry.get(payload.toolId)
+    if (!tool) throw new Error(`Unknown tool: ${payload.toolId}`)
+
+    let command = this.deps.toolRegistry.resolveCommand(tool)
+    const isShell = tool.id === 'shell' || tool.command === 'shell'
+    const isAgent = this.deps.agentSessionManager.isAgentTool(tool.id)
+    let args = isShell ? resolveShellArgs() : [...tool.args]
+    let env: Record<string, string> | undefined
+
+    let agentTempId: string | undefined
+    if (isAgent) {
+      const senderWindow = BrowserWindow.fromWebContents(sender)
+      if (!senderWindow) throw new Error('No window for agent session')
+
+      let prefsReader: PreferencesReader = this.deps.preferencesStore
+      if (payload.profileId) {
+        const profileResult = await this.deps.profileStore.getInternal(payload.profileId)
+        if (profileResult.isErr()) {
+          throw new Error(profileErrorMessage(profileResult.error))
+        }
+        const profile = profileResult.value
+        if (profile.agentType !== tool.id) {
+          throw new Error(`Profile ${profile.name} is for ${profile.agentType}, not ${tool.id}`)
+        }
+        prefsReader = profileToReader(profile, this.deps.preferencesStore)
+      }
+
+      let settingsOverrides: Record<string, unknown> | undefined
+      const settingsJsonRaw = prefsReader.get(`${tool.id}.settingsJson`)
+      if (settingsJsonRaw) {
+        try {
+          settingsOverrides = JSON.parse(settingsJsonRaw) as Record<string, unknown>
+        } catch {
+          // Invalid JSON is ignored, matching the legacy tool:spawn path.
+        }
+      }
+
+      const agentSession = await this.deps.agentSessionManager.createSession(
+        tool.id,
+        payload.worktreePath,
+        payload.workspaceName ?? '',
+        payload.branch ?? null,
+        senderWindow,
+        settingsOverrides,
+      )
+      args = [...agentSession.settingsArgs, ...args]
+      if (payload.resumeSessionId) {
+        args.push(...this.deps.agentSessionManager.getResumeArgs(tool.id, payload.resumeSessionId))
+      }
+      args.push(...this.deps.agentSessionManager.getCliArgs(tool.id, prefsReader))
+      env = {
+        CANOPY_HOOK_PORT: String(agentSession.hookPort),
+        CANOPY_HOOK_PATH: agentSession.hookPath,
+        CANOPY_HOOK_TOKEN: agentSession.hookAuthToken,
+        ...agentSession.settingsEnv,
+        ...this.deps.agentSessionManager.getEnvVars(tool.id, prefsReader),
+      }
+      agentTempId = agentSession.tempId
+    }
+
+    let tmuxSessionName: string | undefined
+    const tmuxEnabled = this.deps.preferencesStore.get('tmux.enabled') === 'true'
+    if (tmuxEnabled && (await this.deps.tmuxManager.isAvailable())) {
+      const ws = this.deps.workspaceStore.getByPath(payload.worktreePath)
+      const wsId = ws?.id ?? 'default'
+      tmuxSessionName = TmuxManagerStatics.sessionName(wsId)
+      const tmuxMouse = this.deps.preferencesStore.get('tmux.mouse') === 'true'
+      await this.deps.tmuxManager.newSession({
+        name: tmuxSessionName,
+        cwd: payload.worktreePath,
+        shell: command,
+        shellArgs: args,
+        cols: payload.cols,
+        rows: payload.rows,
+        mouse: tmuxMouse,
+        env,
+      })
+      const attach = this.deps.tmuxManager.attachArgs(tmuxSessionName)
+      command = attach.command
+      args = attach.args
+    }
+
+    const session = this.deps.ptyManager.spawn({
+      command,
+      args,
+      cwd: payload.worktreePath,
+      cols: payload.cols,
+      rows: payload.rows,
+      env,
+      tmuxSessionName,
+    })
+
+    if (isAgent && agentTempId) {
+      this.deps.agentSessionManager.rekey(agentTempId, session.id)
+    }
+
+    const wsUrl = await this.deps.wsBridge.create(session.id, session.pty)
+
+    this.deps.windowManager.trackPtySession(sender.id, session.id)
+
+    session.pty.onExit(({ exitCode, signal }) => {
+      if (!sender.isDestroyed()) {
+        sender.send('pty:exit', {
+          sessionId: session.id,
+          exitCode,
+          signal,
+          tmuxSessionName: session.tmuxSessionName,
+        })
+      }
+      this.deps.windowManager.untrackPtySession(sender.id, session.id)
+      if (isAgent) {
+        this.deps.agentSessionManager.destroySession(session.id)
+      }
+    })
+
+    return {
+      sessionId: session.id,
+      wsUrl,
+      toolId: tool.id,
+      toolName: tool.name,
+      tmuxSessionName,
+    }
+  }
+
+  async attachTmux(
+    sender: WebContents,
+    payload: TmuxAttachPayload,
+  ): Promise<{
+    sessionId: string
+    wsUrl: string
+  }> {
+    validateTmuxName(payload.tmuxSessionName)
+    const attach = this.deps.tmuxManager.attachArgs(payload.tmuxSessionName)
+    const session = this.deps.ptyManager.spawn({
+      command: attach.command,
+      args: attach.args,
+      cols: payload.cols,
+      rows: payload.rows,
+      tmuxSessionName: payload.tmuxSessionName,
+    })
+    const wsUrl = await this.deps.wsBridge.create(session.id, session.pty)
+
+    this.deps.windowManager.trackPtySession(sender.id, session.id)
+
+    session.pty.onExit(({ exitCode, signal }) => {
+      if (!sender.isDestroyed()) {
+        sender.send('pty:exit', {
+          sessionId: session.id,
+          exitCode,
+          signal,
+          tmuxSessionName: payload.tmuxSessionName,
+        })
+      }
+      this.deps.windowManager.untrackPtySession(sender.id, session.id)
+    })
+
+    return { sessionId: session.id, wsUrl }
+  }
+
+  async killPty(sessionId: string, killTmux?: boolean): Promise<void> {
+    const tmuxName = this.deps.ptyManager.getTmuxSessionName(sessionId)
+    if (killTmux && tmuxName && TmuxManagerStatics.isCanopySession(tmuxName)) {
+      try {
+        await this.deps.tmuxManager.killSession(tmuxName)
+      } catch {
+        // Session may already be gone.
+      }
+    }
+    this.deps.wsBridge.destroy(sessionId)
+    this.deps.ptyManager.kill(sessionId)
+  }
+
+  isAgentTool(toolId: string): boolean {
+    return this.deps.agentSessionManager.isAgentTool(toolId)
+  }
+
+  destroyAgentSession(sessionId: string): void {
+    this.deps.agentSessionManager.destroySession(sessionId)
+  }
+
+  getToolName(toolId: string): string {
+    return this.deps.toolRegistry.get(toolId)?.name ?? toolId
+  }
+
+  async getProfileName(profileId: string): Promise<string | undefined> {
+    const result = await this.deps.profileStore.getInternal(profileId)
+    return result.isOk() ? result.value.name : undefined
+  }
+
+  async hasTmuxSession(name: string): Promise<boolean> {
+    validateTmuxName(name)
+    return this.deps.tmuxManager.hasSession(name)
+  }
+}
+
+interface TabCommandServiceDeps {
+  toolSessions: ToolSessionService
+  layoutStore: LayoutStore
+  workspaceStore: WorkspaceStore
+  browserManager: BrowserManager
+  windowManager: WindowManager
+}
+
+interface TabCommandPayloadBase {
+  worktreePath: string
+  tabs?: TabSnapshot[]
+  activeTabId?: string | null
+}
+
+interface OpenToolPayload extends TabCommandPayloadBase {
+  toolId: string
+  options?: {
+    initialUrl?: string
+    profileId?: string
+    workspaceName?: string
+    branch?: string
+  }
+}
+
+interface RestartPanePayload extends TabCommandPayloadBase {
+  tabId: string
+  paneId: string
+  options?: {
+    workspaceName?: string
+    branch?: string
+  }
+}
+
+interface CloseTabPayload extends TabCommandPayloadBase {
+  tabId: string
+}
+
+interface SaveLayoutPayload {
+  worktreePath: string
+  layoutJson: string
+  workspaceId?: string
+}
+
+function allPaneSnapshots(split: SplitSnapshot): PaneSnapshot[] {
+  validateSplitSnapshot(split)
+  if (split.type === 'leaf') return [split.pane]
+  return [...allPaneSnapshots(split.first), ...allPaneSnapshots(split.second)]
+}
+
+function updatePaneSnapshot(
+  split: SplitSnapshot,
+  paneId: string,
+  updater: (pane: PaneSnapshot) => PaneSnapshot,
+): SplitSnapshot {
+  if (split.type === 'leaf') {
+    if (split.pane.id !== paneId) return split
+    return { type: 'leaf', pane: updater(split.pane) }
+  }
+  return {
+    ...split,
+    first: updatePaneSnapshot(split.first, paneId, updater),
+    second: updatePaneSnapshot(split.second, paneId, updater),
+  }
+}
+
+function computeDisplayName(
+  toolName: string,
+  worktreePath: string,
+  toolId: string,
+  tabs: TabSnapshot[],
+  profileName?: string,
+): string {
+  const baseLabel =
+    profileName && profileName !== 'Default' ? `${toolName} (${profileName})` : toolName
+  const sameLabelCount = tabs.filter(
+    (t) =>
+      t.worktreePath === worktreePath &&
+      (t.name === baseLabel || t.name.startsWith(`${baseLabel} #`)) &&
+      t.toolId === toolId,
+  ).length
+  if (sameLabelCount === 0) return baseLabel
+  return `${baseLabel} #${sameLabelCount + 1}`
+}
+
+function tabId(): string {
+  return `tab-${randomUUID()}`
+}
+
+function paneId(): string {
+  return `pane-${randomUUID()}`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function assertString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string') throw new Error(`Invalid tab snapshot: ${label} must be a string`)
+}
+
+function assertOptionalString(value: unknown, label: string): asserts value is string | undefined {
+  if (value !== undefined && typeof value !== 'string') {
+    throw new Error(`Invalid tab snapshot: ${label} must be a string`)
+  }
+}
+
+function validatePaneSnapshot(value: unknown): asserts value is PaneSnapshot {
+  if (!isRecord(value)) throw new Error('Invalid tab snapshot: pane must be an object')
+  assertString(value.id, 'pane.id')
+  assertString(value.sessionId, 'pane.sessionId')
+  assertString(value.wsUrl, 'pane.wsUrl')
+  assertString(value.toolId, 'pane.toolId')
+  assertString(value.toolName, 'pane.toolName')
+  if (typeof value.isRunning !== 'boolean') {
+    throw new Error('Invalid tab snapshot: pane.isRunning must be a boolean')
+  }
+  if (value.exitCode !== null && typeof value.exitCode !== 'number') {
+    throw new Error('Invalid tab snapshot: pane.exitCode must be a number or null')
+  }
+  if (value.title !== null && typeof value.title !== 'string') {
+    throw new Error('Invalid tab snapshot: pane.title must be a string or null')
+  }
+  assertOptionalString(value.paneType, 'pane.paneType')
+  assertOptionalString(value.tmuxSessionName, 'pane.tmuxSessionName')
+  assertOptionalString(value.url, 'pane.url')
+  assertOptionalString(value.filePath, 'pane.filePath')
+  assertOptionalString(value.editorActiveFile, 'pane.editorActiveFile')
+  assertOptionalString(value.profileId, 'pane.profileId')
+  assertOptionalString(value.profileName, 'pane.profileName')
+  if (value.detached !== undefined && typeof value.detached !== 'boolean') {
+    throw new Error('Invalid tab snapshot: pane.detached must be a boolean')
+  }
+}
+
+function validateSplitSnapshot(value: unknown): asserts value is SplitSnapshot {
+  if (!isRecord(value)) throw new Error('Invalid tab snapshot: split must be an object')
+  if (value.type === 'leaf') {
+    validatePaneSnapshot(value.pane)
+    return
+  }
+  if (value.type !== 'split') throw new Error('Invalid tab snapshot: split.type is invalid')
+  if (value.direction !== 'horizontal' && value.direction !== 'vertical') {
+    throw new Error('Invalid tab snapshot: split.direction is invalid')
+  }
+  if (typeof value.ratio !== 'number' || !Number.isFinite(value.ratio)) {
+    throw new Error('Invalid tab snapshot: split.ratio must be a finite number')
+  }
+  validateSplitSnapshot(value.first)
+  validateSplitSnapshot(value.second)
+}
+
+function validateTabSnapshots(value: unknown): TabSnapshot[] {
+  if (!Array.isArray(value)) return []
+  for (const tab of value) {
+    if (!isRecord(tab)) throw new Error('Invalid tab snapshot: tab must be an object')
+    assertString(tab.id, 'tab.id')
+    assertString(tab.toolId, 'tab.toolId')
+    assertString(tab.toolName, 'tab.toolName')
+    assertString(tab.name, 'tab.name')
+    assertString(tab.worktreePath, 'tab.worktreePath')
+    assertString(tab.focusedPaneId, 'tab.focusedPaneId')
+    validateSplitSnapshot(tab.rootSplit)
+  }
+  return value
+}
+
+function emptyResult(
+  worktreePath: string,
+  tabs: TabSnapshot[],
+  activeTabId: string | null,
+): TabCommandResult {
+  return { worktreePath, tabs, activeTabId }
+}
+
+export class TabCommandService {
+  constructor(private deps: TabCommandServiceDeps) {}
+
+  async openTool(sender: WebContents, payload: OpenToolPayload): Promise<TabCommandResult> {
+    const tabs = [...validateTabSnapshots(payload.tabs)]
+    const pane = await this.createPane(sender, payload.toolId, payload.worktreePath, {
+      ...payload.options,
+    })
+    const id = tabId()
+    const openedTab: TabSnapshot = {
+      id,
+      toolId: pane.toolId,
+      toolName: pane.toolName,
+      name: computeDisplayName(
+        pane.toolName,
+        payload.worktreePath,
+        pane.toolId,
+        tabs,
+        pane.profileName,
+      ),
+      worktreePath: payload.worktreePath,
+      rootSplit: { type: 'leaf', pane },
+      focusedPaneId: pane.id,
+    }
+
+    tabs.push(openedTab)
+    return {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: id,
+      openedTab,
+    }
+  }
+
+  async restartPane(sender: WebContents, payload: RestartPanePayload): Promise<TabCommandResult> {
+    const tabs = [...validateTabSnapshots(payload.tabs)]
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    if (tabIndex < 0) {
+      return emptyResult(payload.worktreePath, tabs, payload.activeTabId ?? null)
+    }
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, payload.activeTabId ?? null)
+
+    const restartedPane = await this.restartPaneSnapshot(sender, payload.worktreePath, pane, {
+      workspaceName: payload.options?.workspaceName,
+      branch: payload.options?.branch,
+    })
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => restartedPane),
+    }
+
+    return {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: payload.activeTabId ?? tab.id,
+      restartedPane,
+    }
+  }
+
+  async closeTab(sender: WebContents, payload: CloseTabPayload): Promise<TabCommandResult> {
+    const tabs = [...validateTabSnapshots(payload.tabs)]
+    const idx = tabs.findIndex((tab) => tab.id === payload.tabId)
+    if (idx < 0) return emptyResult(payload.worktreePath, tabs, payload.activeTabId ?? null)
+
+    const [tab] = tabs.splice(idx, 1)
+    await this.cleanupPanes(sender, allPaneSnapshots(tab.rootSplit))
+
+    let nextActiveId = payload.activeTabId ?? null
+    if (nextActiveId === payload.tabId) {
+      nextActiveId = tabs.length > 0 ? tabs[Math.min(idx, tabs.length - 1)].id : null
+    }
+
+    return {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: nextActiveId,
+      closedTabId: payload.tabId,
+    }
+  }
+
+  saveLayout(payload: SaveLayoutPayload): void {
+    const workspaceId =
+      payload.workspaceId ?? this.deps.workspaceStore.getByPath(payload.worktreePath)?.id
+    if (!workspaceId) return
+
+    try {
+      this.deps.layoutStore.save(workspaceId, payload.worktreePath, payload.layoutJson)
+    } catch (error) {
+      if (this.deps.layoutStore.isClosed()) return
+      console.error('Failed to save layout:', error)
+    }
+  }
+
+  restoreLayout(payload: TabCommandPayloadBase & { layoutJson: string }): TabCommandResult {
+    try {
+      JSON.parse(payload.layoutJson)
+    } catch {
+      return emptyResult(payload.worktreePath, payload.tabs ?? [], payload.activeTabId ?? null)
+    }
+    return emptyResult(payload.worktreePath, payload.tabs ?? [], payload.activeTabId ?? null)
+  }
+
+  private async createPane(
+    sender: WebContents,
+    toolId: string,
+    worktreePath: string,
+    options?: {
+      initialUrl?: string
+      profileId?: string
+      workspaceName?: string
+      branch?: string
+      resumeSessionId?: string
+    },
+  ): Promise<PaneSnapshot> {
+    if (toolId === 'browser') {
+      return {
+        id: paneId(),
+        sessionId: randomUUID(),
+        wsUrl: '',
+        toolId,
+        toolName: 'Browser',
+        isRunning: true,
+        exitCode: null,
+        title: null,
+        paneType: 'browser',
+        url: options?.initialUrl,
+      }
+    }
+
+    if (toolId === 'notes' || toolId === 'drawing') {
+      return {
+        id: paneId(),
+        sessionId: randomUUID(),
+        wsUrl: '',
+        toolId,
+        toolName: toolId === 'notes' ? 'Notes' : 'Drawing',
+        isRunning: true,
+        exitCode: null,
+        title: null,
+        paneType: toolId,
+      }
+    }
+
+    if (toolId === 'editor') {
+      return {
+        id: paneId(),
+        sessionId: '',
+        wsUrl: '',
+        toolId,
+        toolName: 'Editor',
+        isRunning: true,
+        exitCode: null,
+        title: null,
+        paneType: 'editor',
+      }
+    }
+
+    const result = await this.deps.toolSessions.spawnTool(sender, {
+      toolId,
+      worktreePath,
+      workspaceName: options?.workspaceName,
+      branch: options?.branch,
+      resumeSessionId: options?.resumeSessionId,
+      profileId: options?.profileId,
+    })
+
+    let profileName: string | undefined
+    if (options?.profileId) {
+      profileName = await this.deps.toolSessions.getProfileName(options.profileId)
+    }
+
+    return {
+      id: paneId(),
+      sessionId: result.sessionId,
+      wsUrl: result.wsUrl,
+      toolId,
+      toolName: result.toolName,
+      isRunning: true,
+      exitCode: null,
+      title: null,
+      tmuxSessionName: result.tmuxSessionName,
+      profileId: options?.profileId,
+      profileName,
+    }
+  }
+
+  private async restartPaneSnapshot(
+    sender: WebContents,
+    worktreePath: string,
+    pane: PaneSnapshot,
+    options: { workspaceName?: string; branch?: string },
+  ): Promise<PaneSnapshot> {
+    if (pane.paneType === 'editor' || pane.paneType === 'diff') {
+      return pane
+    }
+
+    if (pane.paneType === 'browser') {
+      try {
+        this.deps.browserManager.teardown(pane.sessionId)
+      } catch {
+        // Already destroyed.
+      }
+      return {
+        ...pane,
+        sessionId: randomUUID(),
+        isRunning: true,
+        exitCode: null,
+        title: null,
+      }
+    }
+
+    if (pane.paneType === 'notes' || pane.paneType === 'drawing') {
+      return {
+        ...pane,
+        sessionId: randomUUID(),
+        isRunning: true,
+        exitCode: null,
+        title: null,
+      }
+    }
+
+    if (pane.tmuxSessionName && pane.detached) {
+      const exists = await this.deps.toolSessions
+        .hasTmuxSession(pane.tmuxSessionName)
+        .catch(() => false)
+      if (exists) {
+        const result = await this.deps.toolSessions.attachTmux(sender, {
+          tmuxSessionName: pane.tmuxSessionName,
+        })
+        return {
+          ...pane,
+          sessionId: result.sessionId,
+          wsUrl: result.wsUrl,
+          isRunning: true,
+          exitCode: null,
+          detached: false,
+        }
+      }
+    }
+
+    if (pane.sessionId) {
+      if (this.deps.windowManager.ownsPtySession(sender.id, pane.sessionId)) {
+        try {
+          await this.deps.toolSessions.killPty(pane.sessionId)
+        } catch {
+          // Already exited or cleaned up.
+        }
+        if (this.deps.toolSessions.isAgentTool(pane.toolId)) {
+          this.deps.toolSessions.destroyAgentSession(pane.sessionId)
+        }
+      }
+    }
+
+    const result = await this.deps.toolSessions.spawnTool(sender, {
+      toolId: pane.toolId,
+      worktreePath,
+      workspaceName: options.workspaceName,
+      branch: options.branch,
+      profileId: pane.profileId,
+    })
+
+    return {
+      ...pane,
+      sessionId: result.sessionId,
+      wsUrl: result.wsUrl,
+      isRunning: true,
+      exitCode: null,
+      title: null,
+      detached: false,
+      tmuxSessionName: result.tmuxSessionName,
+    }
+  }
+
+  private async cleanupPanes(sender: WebContents, panes: PaneSnapshot[]): Promise<void> {
+    await Promise.all(
+      panes.map(async (pane) => {
+        if (
+          pane.paneType === 'editor' ||
+          pane.paneType === 'diff' ||
+          pane.paneType === 'notes' ||
+          pane.paneType === 'drawing'
+        ) {
+          return
+        }
+
+        if (pane.paneType === 'browser') {
+          if (pane.sessionId) this.deps.browserManager.teardown(pane.sessionId)
+          return
+        }
+
+        if (pane.sessionId && this.deps.windowManager.ownsPtySession(sender.id, pane.sessionId)) {
+          if (this.deps.toolSessions.isAgentTool(pane.toolId)) {
+            this.deps.toolSessions.destroyAgentSession(pane.sessionId)
+          }
+          await this.deps.toolSessions.killPty(pane.sessionId, !!pane.tmuxSessionName)
+        }
+      }),
+    )
+  }
+}

--- a/src/main/commands/types.ts
+++ b/src/main/commands/types.ts
@@ -1,0 +1,115 @@
+export interface CommandWarning {
+  code: 'stale-paths-removed' | 'git-watch-failed' | 'tracker-auth-required' | 'layout-ignored'
+  message: string
+  paths?: string[]
+}
+
+export interface WorkspaceRowSnapshot {
+  id: string
+  path: string
+  name: string
+  is_git_repo: number
+  last_opened: string | null
+  cached_branch: string | null
+  cached_dirty: number | null
+  cached_ahead_behind: string | null
+  cached_worktree_count: number | null
+}
+
+export interface GitWorktreeSnapshot {
+  path: string
+  head: string
+  branch: string
+  isMain: boolean
+  isBare: boolean
+}
+
+export interface ProjectSnapshot {
+  workspace: WorkspaceRowSnapshot
+  isGitRepo: boolean
+  repoRoot: string | null
+  worktrees: GitWorktreeSnapshot[]
+}
+
+export interface WorkspaceStateSnapshot {
+  project: ProjectSnapshot | null
+  selectedWorktreePath: string | null
+  branch: string | null
+  isDirty: boolean
+  aheadBehind: { ahead: number; behind: number } | null
+}
+
+export interface WorkspaceCommandResult {
+  projects: ProjectSnapshot[]
+  workspaceState: WorkspaceStateSnapshot
+  restoredLayouts?: Array<{ worktreePath: string; layoutJson: string }>
+  focusedExistingWindow?: boolean
+  warnings: CommandWarning[]
+}
+
+export type PaneKind = 'terminal' | 'browser' | 'notes' | 'drawing' | 'editor'
+
+export interface PaneSnapshot {
+  id: string
+  sessionId: string
+  wsUrl: string
+  toolId: string
+  toolName: string
+  isRunning: boolean
+  exitCode: number | null
+  title: string | null
+  paneType?: PaneKind
+  tmuxSessionName?: string
+  detached?: boolean
+  url?: string
+  filePath?: string
+  editorFiles?: Array<{ filePath: string }>
+  editorActiveFile?: string
+  profileId?: string
+  profileName?: string
+}
+
+export type SplitSnapshot =
+  | { type: 'leaf'; pane: PaneSnapshot }
+  | {
+      type: 'split'
+      direction: 'horizontal' | 'vertical'
+      ratio: number
+      first: SplitSnapshot
+      second: SplitSnapshot
+    }
+
+export interface TabSnapshot {
+  id: string
+  toolId: string
+  toolName: string
+  name: string
+  worktreePath: string
+  rootSplit: SplitSnapshot
+  focusedPaneId: string
+}
+
+export interface TabCommandResult {
+  worktreePath: string
+  tabs: TabSnapshot[]
+  activeTabId: string | null
+}
+
+export interface AgentCommandResult {
+  sessionId: string
+  tabId?: string
+  paneId?: string
+}
+
+export interface RunConfigProcessSnapshot {
+  sessionId: string
+  name: string
+  configDir: string
+  worktreePath: string
+}
+
+export interface RunConfigCommandResult {
+  sessionId: string
+  wsUrl: string
+  running: RunConfigProcessSnapshot[]
+}

--- a/src/main/commands/types.ts
+++ b/src/main/commands/types.ts
@@ -47,7 +47,7 @@ export interface WorkspaceCommandResult {
   warnings: CommandWarning[]
 }
 
-export type PaneKind = 'terminal' | 'browser' | 'notes' | 'drawing' | 'editor'
+export type PaneKind = 'terminal' | 'browser' | 'notes' | 'drawing' | 'editor' | 'diff'
 
 export interface PaneSnapshot {
   id: string
@@ -93,6 +93,9 @@ export interface TabCommandResult {
   worktreePath: string
   tabs: TabSnapshot[]
   activeTabId: string | null
+  openedTab?: TabSnapshot
+  restartedPane?: PaneSnapshot
+  closedTabId?: string
 }
 
 export interface AgentCommandResult {

--- a/src/main/commands/workspaceCommands.ts
+++ b/src/main/commands/workspaceCommands.ts
@@ -1,0 +1,507 @@
+import type { WebContents } from 'electron'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import path from 'path'
+import type { WorkspaceStore } from '../db/WorkspaceStore'
+import type { LayoutStore } from '../db/LayoutStore'
+import type { WindowManager } from '../WindowManager'
+import type { WorkspaceRow } from '../db/types'
+import { GitRepository, type GitInfo } from '../git/GitRepository'
+import { GitWatcher, type GitRefreshFlags } from '../git/GitWatcher'
+import { gitErrorMessage } from '../git/errors'
+import type {
+  CommandWarning,
+  ProjectSnapshot,
+  WorkspaceCommandResult,
+  WorkspaceStateSnapshot,
+} from './types'
+
+const execFileAsync = promisify(execFile)
+
+const defaultGitInfo: GitInfo = {
+  isGitRepo: false,
+  repoRoot: null,
+  branch: null,
+  worktrees: [],
+  isDirty: false,
+  aheadBehind: null,
+}
+
+interface WorkspaceCommandServiceDeps {
+  workspaceStore: WorkspaceStore
+  layoutStore: LayoutStore
+  windowManager: WindowManager
+  persistWindowConfigs: () => void
+  validatePathAccess: (webContentsId: number, targetPath: string) => Promise<string>
+  clearWorkspaceFileCache: (path: string) => void
+}
+
+interface AttachProjectOptions {
+  selectIfEmpty?: boolean
+  warnings: CommandWarning[]
+  restoredLayouts: Array<{ worktreePath: string; layoutJson: string }>
+}
+
+export class WorkspaceCommandService {
+  private projectsByWindow = new Map<number, ProjectSnapshot[]>()
+  private selectedWorktreeByWindow = new Map<number, string>()
+  private grantedAttachPathsByWindow = new Map<number, Set<string>>()
+  private trackedWebContents = new Set<number>()
+
+  constructor(private deps: WorkspaceCommandServiceDeps) {}
+
+  async restoreWindow(
+    sender: WebContents,
+    payload: { paths: string[]; activeWorktreePath?: string; removedPaths?: string[] },
+  ): Promise<WorkspaceCommandResult> {
+    this.trackSender(sender)
+    const warnings: CommandWarning[] = []
+    const restoredLayouts: Array<{ worktreePath: string; layoutJson: string }> = []
+
+    if (payload.removedPaths && payload.removedPaths.length > 0) {
+      warnings.push(this.stalePathsWarning(payload.removedPaths))
+    }
+
+    let focusedExistingWindow = false
+    for (const projectPath of new Set(payload.paths)) {
+      focusedExistingWindow =
+        (await this.attachProjectSnapshot(sender, projectPath, {
+          selectIfEmpty: false,
+          warnings,
+          restoredLayouts,
+        }).catch((err) => {
+          const name = path.basename(projectPath) || projectPath
+          warnings.push({
+            code: 'layout-ignored',
+            message: `Failed to restore ${name}: ${err instanceof Error ? err.message : String(err)}`,
+            paths: [projectPath],
+          })
+          return false
+        })) || focusedExistingWindow
+    }
+
+    const projects = this.getProjects(sender.id)
+    let targetPath = payload.activeWorktreePath
+    if (!targetPath || !this.getProjectForWorktree(sender.id, targetPath)) {
+      targetPath = this.getDefaultWorktreePath(projects[0])
+    }
+
+    if (targetPath) {
+      this.selectedWorktreeByWindow.set(sender.id, targetPath)
+      this.deps.windowManager.setActiveWorktree(sender.id, targetPath)
+      this.deps.persistWindowConfigs()
+    }
+
+    const result = this.result(sender.id, warnings, restoredLayouts)
+    if (focusedExistingWindow) result.focusedExistingWindow = true
+    return result
+  }
+
+  async attachProject(sender: WebContents, projectPath: string): Promise<WorkspaceCommandResult> {
+    this.trackSender(sender)
+    const warnings: CommandWarning[] = []
+    const restoredLayouts: Array<{ worktreePath: string; layoutJson: string }> = []
+    const focusedExistingWindow = await this.attachProjectSnapshot(sender, projectPath, {
+      selectIfEmpty: true,
+      warnings,
+      restoredLayouts,
+    })
+    const result = this.result(sender.id, warnings, restoredLayouts)
+    if (focusedExistingWindow) result.focusedExistingWindow = true
+    return result
+  }
+
+  detachProject(sender: WebContents, projectPath: string): WorkspaceCommandResult {
+    this.trackSender(sender)
+    const projects = this.getProjects(sender.id)
+    const project = projects.find((p) => this.projectKey(p) === projectPath)
+    if (!project) return this.result(sender.id, [], [])
+
+    const key = this.projectKey(project)
+    this.deps.windowManager.removeWorkspacePath(sender.id, key)
+    if (project.repoRoot) this.deps.windowManager.disposeGitWatcher(sender.id, project.repoRoot)
+
+    const ws = this.deps.workspaceStore.getByPath(key)
+    if (ws) this.deps.layoutStore.deleteAll(ws.id)
+    this.deps.clearWorkspaceFileCache(key)
+
+    this.projectsByWindow.set(
+      sender.id,
+      projects.filter((candidate) => this.projectKey(candidate) !== key),
+    )
+
+    const remaining = this.getProjects(sender.id)
+    const selectedPath = this.selectedWorktreeByWindow.get(sender.id)
+    if (selectedPath && this.projectOwnsPath(project, selectedPath)) {
+      const fallbackPath = this.getDefaultWorktreePath(remaining[0])
+      if (fallbackPath) {
+        this.selectedWorktreeByWindow.set(sender.id, fallbackPath)
+        this.deps.windowManager.setActiveWorktree(sender.id, fallbackPath)
+      } else {
+        this.selectedWorktreeByWindow.delete(sender.id)
+        this.deps.windowManager.clearActiveWorktree(sender.id)
+      }
+    }
+
+    this.deps.persistWindowConfigs()
+    return this.result(sender.id, [], [])
+  }
+
+  async selectWorktree(sender: WebContents, worktreePath: string): Promise<WorkspaceCommandResult> {
+    this.trackSender(sender)
+    if (!this.getProjectForWorktree(sender.id, worktreePath)) {
+      await this.refreshProjectForPath(sender.id, worktreePath)
+    }
+    if (!this.getProjectForWorktree(sender.id, worktreePath)) {
+      throw new Error(`Worktree is not attached to this window: ${worktreePath}`)
+    }
+    this.selectedWorktreeByWindow.set(sender.id, worktreePath)
+    this.deps.windowManager.setActiveWorktree(sender.id, worktreePath)
+    this.deps.persistWindowConfigs()
+    return this.result(sender.id, [], [])
+  }
+
+  grantAttachPath(webContentsId: number, targetPath: string): void {
+    let paths = this.grantedAttachPathsByWindow.get(webContentsId)
+    if (!paths) {
+      paths = new Set()
+      this.grantedAttachPathsByWindow.set(webContentsId, paths)
+    }
+    paths.add(targetPath)
+  }
+
+  async initGitRepo(sender: WebContents, projectPath: string): Promise<WorkspaceCommandResult> {
+    this.trackSender(sender)
+    const resolved = await this.deps.validatePathAccess(sender.id, projectPath)
+    await execFileAsync('git', ['init'], { cwd: resolved })
+
+    const info = await GitRepository.detect(resolved).unwrapOr(defaultGitInfo)
+    const projectRoot = info.repoRoot ?? resolved
+    const projects = this.getProjects(sender.id)
+    const projectIndex = projects.findIndex(
+      (project) =>
+        project.workspace.path === projectPath || this.projectKey(project) === projectPath,
+    )
+
+    if (projectIndex < 0) return this.result(sender.id, [], [])
+
+    const existing = projects[projectIndex]
+    const workspace = this.deps.workspaceStore.upsert({
+      path: projectRoot,
+      name: existing.workspace.name,
+      isGitRepo: info.isGitRepo,
+    })
+    this.deps.workspaceStore.touch(workspace.id)
+
+    const updated: ProjectSnapshot = {
+      workspace,
+      isGitRepo: info.isGitRepo,
+      repoRoot: info.repoRoot,
+      worktrees: info.worktrees,
+    }
+    projects.splice(projectIndex, 1, updated)
+    this.projectsByWindow.set(sender.id, projects)
+
+    if (projectRoot !== projectPath) {
+      this.deps.windowManager.removeWorkspacePath(sender.id, projectPath)
+      this.deps.windowManager.addWorkspacePath(sender.id, projectRoot)
+    }
+
+    const warnings: CommandWarning[] = []
+    if (info.isGitRepo && info.repoRoot) {
+      await this.startGitWatcher(sender, info.repoRoot, info, warnings)
+    }
+
+    this.deps.persistWindowConfigs()
+    return this.result(sender.id, warnings, [])
+  }
+
+  private async attachProjectSnapshot(
+    sender: WebContents,
+    requestedPath: string,
+    options: AttachProjectOptions,
+  ): Promise<boolean> {
+    this.validateAttachPath(sender.id, requestedPath, requestedPath)
+    const info = await GitRepository.detect(requestedPath).unwrapOr(defaultGitInfo)
+    const projectPath = info.repoRoot ?? requestedPath
+    this.validateAttachPath(sender.id, requestedPath, projectPath)
+
+    const existingWindow = this.deps.windowManager.getWindowForPath(projectPath)
+    if (existingWindow && existingWindow.webContents.id !== sender.id) {
+      if (existingWindow.isMinimized()) existingWindow.restore()
+      existingWindow.focus()
+      return true
+    }
+
+    const projects = this.getProjects(sender.id)
+    const existingProject = projects.find((project) => this.projectKey(project) === projectPath)
+    if (existingProject) {
+      if (options.selectIfEmpty && !this.selectedWorktreeByWindow.get(sender.id)) {
+        const defaultWorktreePath = this.getDefaultWorktreePath(existingProject)
+        if (defaultWorktreePath) {
+          this.selectedWorktreeByWindow.set(sender.id, defaultWorktreePath)
+          this.deps.windowManager.setActiveWorktree(sender.id, defaultWorktreePath)
+          this.deps.persistWindowConfigs()
+        }
+      }
+      return false
+    }
+
+    const workspace = this.deps.workspaceStore.upsert({
+      path: projectPath,
+      name: path.basename(projectPath),
+      isGitRepo: info.isGitRepo,
+    })
+    this.deps.workspaceStore.touch(workspace.id)
+
+    const project: ProjectSnapshot = {
+      workspace,
+      isGitRepo: info.isGitRepo,
+      repoRoot: info.repoRoot,
+      worktrees: info.worktrees,
+    }
+
+    this.projectsByWindow.set(sender.id, [...projects, project])
+
+    this.deps.windowManager.addWorkspacePath(sender.id, projectPath)
+    this.deps.persistWindowConfigs()
+
+    if (info.isGitRepo && info.repoRoot) {
+      await this.startGitWatcher(sender, info.repoRoot, info, options.warnings)
+    }
+
+    this.collectRestoredLayouts(workspace, project, options.restoredLayouts)
+
+    if (options.selectIfEmpty && !this.selectedWorktreeByWindow.get(sender.id)) {
+      const defaultWorktreePath = this.getDefaultWorktreePath(project)
+      if (defaultWorktreePath) {
+        this.selectedWorktreeByWindow.set(sender.id, defaultWorktreePath)
+        this.deps.windowManager.setActiveWorktree(sender.id, defaultWorktreePath)
+        this.deps.persistWindowConfigs()
+      }
+    }
+    return false
+  }
+
+  private async startGitWatcher(
+    sender: WebContents,
+    repoRoot: string,
+    snapshot: GitInfo,
+    warnings: CommandWarning[],
+  ): Promise<void> {
+    this.deps.windowManager.disposeGitWatcher(sender.id, repoRoot)
+
+    const ws = this.deps.workspaceStore.getByPath(repoRoot)
+    const workspaceId = ws?.id ?? null
+
+    const watcher = new GitWatcher(
+      repoRoot,
+      (info, changes: GitRefreshFlags) => {
+        if (workspaceId) {
+          this.deps.workspaceStore.updateGitCache(workspaceId, {
+            branch: info.branch,
+            dirty: info.isDirty,
+            aheadBehind: info.aheadBehind
+              ? `${info.aheadBehind.ahead}/${info.aheadBehind.behind}`
+              : null,
+            worktreeCount: info.worktrees.length,
+          })
+        }
+        this.updateProjectGitInfo(sender.id, repoRoot, info)
+        if (!sender.isDestroyed()) {
+          sender.send('git:changed', { ...info, repoRoot, changes })
+        }
+      },
+      snapshot,
+    )
+
+    const startResult = await watcher.start()
+    if (startResult.isErr()) {
+      const message = gitErrorMessage(startResult.error)
+      console.warn(message)
+      warnings.push({
+        code: 'git-watch-failed',
+        message: `Git watcher failed for ${path.basename(repoRoot)} - status may not update`,
+        paths: [repoRoot],
+      })
+    }
+    this.deps.windowManager.setGitWatcher(sender.id, repoRoot, watcher)
+  }
+
+  private collectRestoredLayouts(
+    workspace: WorkspaceRow,
+    project: ProjectSnapshot,
+    restoredLayouts: Array<{ worktreePath: string; layoutJson: string }>,
+  ): void {
+    const layouts = this.deps.layoutStore.getAll(workspace.id)
+    if (layouts.length === 0) return
+
+    const ownedPaths = this.getOwnedPaths(project)
+    for (const entry of layouts) {
+      if (ownedPaths.has(entry.worktree_path)) {
+        restoredLayouts.push({ worktreePath: entry.worktree_path, layoutJson: entry.layout_json })
+      } else {
+        this.deps.layoutStore.delete(workspace.id, entry.worktree_path)
+      }
+    }
+  }
+
+  private result(
+    webContentsId: number,
+    warnings: CommandWarning[],
+    restoredLayouts: Array<{ worktreePath: string; layoutJson: string }>,
+  ): WorkspaceCommandResult {
+    return {
+      projects: this.getProjects(webContentsId),
+      workspaceState: this.workspaceState(webContentsId),
+      ...(restoredLayouts.length > 0 ? { restoredLayouts } : {}),
+      warnings,
+    }
+  }
+
+  private workspaceState(webContentsId: number): WorkspaceStateSnapshot {
+    const selectedWorktreePath = this.selectedWorktreeByWindow.get(webContentsId) ?? null
+    const project = selectedWorktreePath
+      ? this.getProjectForWorktree(webContentsId, selectedWorktreePath)
+      : null
+
+    if (!project) {
+      return {
+        project: null,
+        selectedWorktreePath,
+        branch: null,
+        isDirty: false,
+        aheadBehind: null,
+      }
+    }
+
+    const selectedWorktree = project.worktrees.find(
+      (worktree) => worktree.path === selectedWorktreePath,
+    )
+    return {
+      project,
+      selectedWorktreePath,
+      branch: selectedWorktree?.branch ?? null,
+      isDirty: false,
+      aheadBehind: null,
+    }
+  }
+
+  private getProjects(webContentsId: number): ProjectSnapshot[] {
+    return this.projectsByWindow.get(webContentsId) ?? []
+  }
+
+  private trackSender(sender: WebContents): void {
+    if (this.trackedWebContents.has(sender.id)) return
+    this.trackedWebContents.add(sender.id)
+    sender.once('destroyed', () => {
+      this.projectsByWindow.delete(sender.id)
+      this.selectedWorktreeByWindow.delete(sender.id)
+      this.grantedAttachPathsByWindow.delete(sender.id)
+      this.trackedWebContents.delete(sender.id)
+    })
+  }
+
+  private getProjectForWorktree(
+    webContentsId: number,
+    worktreePath: string,
+  ): ProjectSnapshot | null {
+    return (
+      this.getProjects(webContentsId).find((project) =>
+        this.projectOwnsPath(project, worktreePath),
+      ) ?? null
+    )
+  }
+
+  private projectOwnsPath(project: ProjectSnapshot, worktreePath: string): boolean {
+    if (project.workspace.path === worktreePath || project.repoRoot === worktreePath) return true
+    return project.worktrees.some((worktree) => worktree.path === worktreePath)
+  }
+
+  private validateAttachPath(
+    webContentsId: number,
+    requestedPath: string,
+    projectPath: string,
+  ): void {
+    const grants = this.grantedAttachPathsByWindow.get(webContentsId)
+    if (grants?.has(requestedPath) || grants?.has(projectPath)) return
+
+    const currentWindowPaths = this.deps.windowManager.getWorkspacePaths(webContentsId)
+    if (currentWindowPaths.includes(requestedPath) || currentWindowPaths.includes(projectPath))
+      return
+
+    if (
+      this.deps.workspaceStore.getByPath(requestedPath) ||
+      this.deps.workspaceStore.getByPath(projectPath)
+    ) {
+      return
+    }
+
+    throw new Error('Project path was not selected through an allowed main-process flow')
+  }
+
+  private async refreshProjectForPath(webContentsId: number, worktreePath: string): Promise<void> {
+    const info = await GitRepository.detect(worktreePath).unwrapOr(defaultGitInfo)
+    if (!info.repoRoot) return
+    this.updateProjectGitInfo(webContentsId, info.repoRoot, info)
+  }
+
+  private updateProjectGitInfo(webContentsId: number, repoRoot: string, info: GitInfo): void {
+    const projects = this.getProjects(webContentsId)
+    const detectedPaths = new Set(info.worktrees.map((worktree) => worktree.path))
+    if (info.repoRoot) detectedPaths.add(info.repoRoot)
+
+    const index = projects.findIndex((project) => {
+      if (project.repoRoot === repoRoot || project.workspace.path === repoRoot) return true
+      if (project.repoRoot && detectedPaths.has(project.repoRoot)) return true
+      if (detectedPaths.has(project.workspace.path)) return true
+      return project.worktrees.some((worktree) => detectedPaths.has(worktree.path))
+    })
+    if (index < 0) return
+
+    const current = projects[index]
+    projects.splice(index, 1, {
+      ...current,
+      isGitRepo: info.isGitRepo,
+      repoRoot: info.repoRoot ?? repoRoot,
+      worktrees: info.worktrees,
+    })
+    this.projectsByWindow.set(webContentsId, projects)
+  }
+
+  private getDefaultWorktreePath(project: ProjectSnapshot | undefined): string | undefined {
+    if (!project) return undefined
+    if (!project.isGitRepo) return project.workspace.path
+    const main = project.worktrees.find((worktree) => worktree.isMain)
+    return main?.path ?? project.repoRoot ?? project.workspace.path
+  }
+
+  private getOwnedPaths(project: ProjectSnapshot): Set<string> {
+    const ownedPaths = new Set<string>([project.workspace.path])
+    if (project.repoRoot) ownedPaths.add(project.repoRoot)
+    for (const worktree of project.worktrees) ownedPaths.add(worktree.path)
+    return ownedPaths
+  }
+
+  private projectKey(project: ProjectSnapshot): string {
+    return project.repoRoot ?? project.workspace.path
+  }
+
+  private stalePathsWarning(removedPaths: string[]): CommandWarning {
+    const basenames = removedPaths.map((removedPath) => path.basename(removedPath))
+    const hasCollision = new Set(basenames).size !== basenames.length
+    const labels = hasCollision
+      ? removedPaths.map((removedPath) => {
+          const parent = path.basename(path.dirname(removedPath))
+          const name = path.basename(removedPath)
+          return parent ? `${parent}/${name}` : name || removedPath
+        })
+      : basenames
+    const plural = removedPaths.length === 1 ? 'project' : 'projects'
+    return {
+      code: 'stale-paths-removed',
+      message: `Removed ${removedPaths.length} stale ${plural} (folder missing): ${labels.join(', ')}`,
+      paths: removedPaths,
+    }
+  }
+}

--- a/src/main/commands/workspaceCommands.ts
+++ b/src/main/commands/workspaceCommands.ts
@@ -161,6 +161,10 @@ export class WorkspaceCommandService {
     return this.result(sender.id, [], [])
   }
 
+  getWorkspaceIdForWorktree(webContentsId: number, worktreePath: string): string | null {
+    return this.getProjectForWorktree(webContentsId, worktreePath)?.workspace.id ?? null
+  }
+
   grantAttachPath(webContentsId: number, targetPath: string): void {
     let paths = this.grantedAttachPathsByWindow.get(webContentsId)
     if (!paths) {

--- a/src/main/commands/workspaceCommands.ts
+++ b/src/main/commands/workspaceCommands.ts
@@ -179,8 +179,16 @@ export class WorkspaceCommandService {
     const resolved = await this.deps.validatePathAccess(sender.id, projectPath)
     await execFileAsync('git', ['init'], { cwd: resolved })
 
-    const info = await GitRepository.detect(resolved).unwrapOr(defaultGitInfo)
-    const projectRoot = info.repoRoot ?? resolved
+    const detectedInfo = await GitRepository.detect(resolved).unwrapOr(defaultGitInfo)
+    const detectedProjectRoot = detectedInfo.repoRoot ?? resolved
+    const projectRoot = await this.deps.validatePathAccess(sender.id, detectedProjectRoot)
+    const info: GitInfo = {
+      ...detectedInfo,
+      repoRoot: detectedInfo.repoRoot ? projectRoot : detectedInfo.repoRoot,
+      worktrees: detectedInfo.worktrees.map((worktree) =>
+        worktree.path === detectedProjectRoot ? { ...worktree, path: projectRoot } : worktree,
+      ),
+    }
     const projects = this.getProjects(sender.id)
     const projectIndex = projects.findIndex(
       (project) =>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,7 +16,7 @@ import { OnboardingStore } from './db/OnboardingStore'
 import { ToolRegistry } from './tools/ToolRegistry'
 import { initSkills } from './skills'
 import { ProfileStore } from './profiles/ProfileStore'
-import { registerIpcHandlers } from './ipc/handlers'
+import { registerIpcHandlers, type IpcCommandBridge } from './ipc/handlers'
 import { AgentSessionManager } from './agents/AgentSessionManager'
 import { resolveLoginEnv } from './shell/loginEnv'
 import { WindowManager } from './WindowManager'
@@ -40,6 +40,7 @@ import { PerfHudService } from './perf/PerfHudService'
 import { CrashReporter } from './crash/CrashReporter'
 import type { WindowConfig } from './windowBounds'
 import { performance } from 'perf_hooks'
+import { GitRepository } from './git/GitRepository'
 
 const PERF = process.env.CANOPY_PERF === '1'
 if (PERF) performance.mark('app:init')
@@ -195,6 +196,7 @@ const scheduleRecurringUpdateCheck = (): void => {
 let agentSessionManager: AgentSessionManager | null = null
 let notchOverlay: NotchOverlayManager | null = null
 let crashReporter: CrashReporter | null = null
+let ipcCommandBridge: IpcCommandBridge | null = null
 
 // Register canopy:// URL scheme
 if (process.defaultApp) {
@@ -232,9 +234,22 @@ async function handleCanopyUrl(url: string): Promise<void> {
     const worktree = parsed.searchParams.get('worktree') ?? undefined
     const action = parsed.hostname === 'run' ? 'run' : 'open'
 
+    const gitInfo = await GitRepository.detect(resolved).unwrapOr({
+      isGitRepo: false,
+      repoRoot: null,
+      branch: null,
+      worktrees: [],
+      isDirty: false,
+      aheadBehind: null,
+    })
+    const dedupePaths = [gitInfo.repoRoot ?? resolved, ...gitInfo.worktrees.map((wt) => wt.path)]
+
     // Dedupe: focus existing window for this path (no confirmation needed)
-    const existing = windowManager.getWindowForPath(resolved)
+    const existing = dedupePaths
+      .map((dedupePath) => windowManager.getWindowForPath(dedupePath))
+      .find((win) => win !== null)
     if (existing) {
+      ipcCommandBridge?.grantAttachPath(existing.webContents.id, resolved)
       existing.webContents.send('url:action', { action, path: resolved, tool, worktree })
       if (existing.isMinimized()) existing.restore()
       existing.focus()
@@ -254,6 +269,7 @@ async function handleCanopyUrl(url: string): Promise<void> {
 
     const win = windowManager.createWindow()
     win.once('ready-to-show', () => {
+      ipcCommandBridge?.grantAttachPath(win.webContents.id, resolved)
       win.webContents.send('url:action', { action, path: resolved, tool, worktree })
     })
   } catch {
@@ -641,7 +657,7 @@ app.whenReady().then(async () => {
 
   if (PERF) performance.mark('app:managersReady')
 
-  registerIpcHandlers(
+  ipcCommandBridge = registerIpcHandlers(
     ptyManager,
     wsBridge,
     workspaceStore,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -740,6 +740,12 @@ app.whenReady().then(async () => {
       ipcLog!.length = 0
       return snapshot
     })
+
+    ipcMain.handle('perf:openProject', (event, payload: { path: string }) => {
+      const resolved = realpathSync(resolve(payload.path))
+      ipcCommandBridge?.grantAttachPath(event.sender.id, resolved)
+      event.sender.send('url:action', { action: 'open', path: resolved })
+    })
   }
 
   // Status-bar perf HUD (always available, gated by user preference in renderer)

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -222,6 +222,52 @@ export function registerIpcHandlers(
     }
   }
 
+  ipcMain.handle('workspace:command:restoreWindow', () => {
+    throw new Error('workspace restore command service is not registered')
+  })
+  ipcMain.handle('workspace:command:attachProject', () => {
+    throw new Error('workspace attach command service is not registered')
+  })
+  ipcMain.handle('workspace:command:detachProject', () => {
+    throw new Error('workspace detach command service is not registered')
+  })
+  ipcMain.handle('workspace:command:selectWorktree', () => {
+    throw new Error('workspace select command service is not registered')
+  })
+  ipcMain.handle('workspace:command:initGitRepo', () => {
+    throw new Error('workspace init git command service is not registered')
+  })
+  ipcMain.handle('tab:command:openTool', () => {
+    throw new Error('tab open command service is not registered')
+  })
+  ipcMain.handle('tab:command:restartPane', () => {
+    throw new Error('tab restart command service is not registered')
+  })
+  ipcMain.handle('tab:command:closeTab', () => {
+    throw new Error('tab close command service is not registered')
+  })
+  ipcMain.handle('tab:command:saveLayout', () => {
+    throw new Error('tab save layout command service is not registered')
+  })
+  ipcMain.handle('tab:command:restoreLayout', () => {
+    throw new Error('tab restore layout command service is not registered')
+  })
+  ipcMain.handle('agent:command:sendTaskContext', () => {
+    throw new Error('agent task command service is not registered')
+  })
+  ipcMain.handle('agent:command:sendReviewContext', () => {
+    throw new Error('agent review command service is not registered')
+  })
+  ipcMain.handle('agent:command:sendDrawing', () => {
+    throw new Error('agent drawing command service is not registered')
+  })
+  ipcMain.handle('runConfig:command:execute', () => {
+    throw new Error('run config command service is not registered')
+  })
+  ipcMain.handle('runConfig:command:listRunning', () => {
+    throw new Error('run config command service is not registered')
+  })
+
   // --- PTY ---
 
   ipcMain.handle(

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -13,6 +13,7 @@ import path from 'path'
 import { ok, err, type Result } from 'neverthrow'
 import type { PtyManager } from '../pty/PtyManager'
 import type { WsBridge } from '../pty/WsBridge'
+import { TmuxManager as TmuxManagerStatics } from '../pty/TmuxManager'
 import type { WorkspaceStore } from '../db/WorkspaceStore'
 import type { PreferencesStore } from '../db/PreferencesStore'
 import type { LayoutStore } from '../db/LayoutStore'
@@ -231,20 +232,22 @@ export function registerIpcHandlers(
   const toolSessionService = new ToolSessionService({
     ptyManager,
     wsBridge,
-    workspaceStore,
     preferencesStore,
     toolRegistry,
     agentSessionManager,
     windowManager,
     tmuxManager,
     profileStore,
+    resolveWorkspaceIdForWorktree: (webContentsId, worktreePath) =>
+      workspaceCommandService.getWorkspaceIdForWorktree(webContentsId, worktreePath),
   })
   const tabCommandService = new TabCommandService({
     toolSessions: toolSessionService,
     layoutStore,
-    workspaceStore,
     browserManager,
     windowManager,
+    resolveWorkspaceIdForWorktree: (webContentsId, worktreePath) =>
+      workspaceCommandService.getWorkspaceIdForWorktree(webContentsId, worktreePath),
   })
   const agentCommandService = new AgentCommandService({
     ptyManager,
@@ -286,11 +289,17 @@ export function registerIpcHandlers(
   ipcMain.handle('tab:command:closeTab', (event, payload) =>
     tabCommandService.closeTab(event.sender, payload),
   )
-  ipcMain.handle('tab:command:saveLayout', (_event, payload) =>
-    tabCommandService.saveLayout(payload),
+  ipcMain.handle('tab:command:spawnPane', (event, payload) =>
+    tabCommandService.spawnPane(event.sender, payload),
   )
-  ipcMain.handle('tab:command:restoreLayout', (_event, payload) =>
-    tabCommandService.restoreLayout(payload),
+  ipcMain.handle('tab:command:saveLayout', (event, payload) =>
+    tabCommandService.saveLayout(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:deleteLayout', (event, payload) =>
+    tabCommandService.deleteLayout(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:restoreLayout', (event, payload) =>
+    tabCommandService.restoreLayout(event.sender, payload),
   )
   ipcMain.handle('agent:command:sendTaskContext', (event, payload) =>
     agentCommandService.sendTaskContext(event.sender, payload),
@@ -311,28 +320,11 @@ export function registerIpcHandlers(
   // --- PTY ---
 
   ipcMain.handle(
-    'pty:spawn',
-    async (event, options?: { cols?: number; rows?: number; cwd?: string }) => {
-      const sender = event.sender
-      const session = ptyManager.spawn(options)
-      const wsUrl = await wsBridge.create(session.id, session.pty)
-
-      windowManager.trackPtySession(sender.id, session.id)
-
-      session.pty.onExit(({ exitCode, signal }) => {
-        if (!sender.isDestroyed()) {
-          sender.send('pty:exit', { sessionId: session.id, exitCode, signal })
-        }
-        windowManager.untrackPtySession(sender.id, session.id)
-      })
-
-      return { sessionId: session.id, wsUrl }
-    },
-  )
-
-  ipcMain.handle(
     'pty:resize',
-    (_event, payload: { sessionId: string; cols: number; rows: number }) => {
+    (event, payload: { sessionId: string; cols: number; rows: number }) => {
+      if (!windowManager.ownsPtySession(event.sender.id, payload.sessionId)) {
+        throw new Error('PTY session is not owned by this window')
+      }
       // Validate dimensions: positive integers within sane terminal bounds.
       // node-pty will otherwise throw on NaN / negative / huge values and
       // a malformed payload would be broadcast to every window as-is.
@@ -363,7 +355,10 @@ export function registerIpcHandlers(
     },
   )
 
-  ipcMain.handle('pty:kill', async (_event, payload: { sessionId: string; killTmux?: boolean }) => {
+  ipcMain.handle('pty:kill', async (event, payload: { sessionId: string; killTmux?: boolean }) => {
+    if (!windowManager.ownsPtySession(event.sender.id, payload.sessionId)) {
+      throw new Error('PTY session is not owned by this window')
+    }
     await toolSessionService.killPty(payload.sessionId, payload.killTmux)
   })
 
@@ -374,11 +369,17 @@ export function registerIpcHandlers(
     ptyManager.write(payload.sessionId, payload.data)
   })
 
-  ipcMain.handle('pty:hasChildProcess', (_event, payload: { sessionId: string }) => {
+  ipcMain.handle('pty:hasChildProcess', (event, payload: { sessionId: string }) => {
+    if (!windowManager.ownsPtySession(event.sender.id, payload.sessionId)) {
+      throw new Error('PTY session is not owned by this window')
+    }
     return ptyManager.hasChildProcess(payload.sessionId)
   })
 
-  ipcMain.handle('pty:getDimensions', (_event, payload: { sessionId: string }) => {
+  ipcMain.handle('pty:getDimensions', (event, payload: { sessionId: string }) => {
+    if (!windowManager.ownsPtySession(event.sender.id, payload.sessionId)) {
+      throw new Error('PTY session is not owned by this window')
+    }
     return ptyManager.getDimensions(payload.sessionId)
   })
 
@@ -414,48 +415,49 @@ export function registerIpcHandlers(
     },
   )
 
-  ipcMain.handle('tmux:detach', (_event, payload: { sessionId: string }) => {
+  ipcMain.handle('tmux:detach', (event, payload: { sessionId: string }) => {
+    if (!windowManager.ownsPtySession(event.sender.id, payload.sessionId)) {
+      throw new Error('PTY session is not owned by this window')
+    }
     const tmuxName = ptyManager.getTmuxSessionName(payload.sessionId)
     wsBridge.destroy(payload.sessionId)
     ptyManager.kill(payload.sessionId)
     return { tmuxSessionName: tmuxName }
   })
 
-  ipcMain.handle('tmux:killSession', async (_event, payload: { name: string }) => {
+  function senderOwnsTmuxSession(webContentsId: number, name: string): boolean {
+    return ptyManager
+      .getSessionIdsForTmuxSession(name)
+      .some((sessionId) => windowManager.ownsPtySession(webContentsId, sessionId))
+  }
+
+  async function assertCanManageTmuxSession(webContentsId: number, name: string): Promise<void> {
+    if (senderOwnsTmuxSession(webContentsId, name)) return
+
+    // Detached tmux sessions may survive an app restart without an in-memory
+    // PTY owner. Only allow names generated by Canopy on its private socket.
+    if (TmuxManagerStatics.isCanopySession(name) && (await tmuxManager.hasSession(name))) {
+      return
+    }
+    throw new Error('tmux session is not managed by Canopy')
+  }
+
+  ipcMain.handle('tmux:killSession', async (event, payload: { name: string }) => {
     validateTmuxName(payload.name)
+    await assertCanManageTmuxSession(event.sender.id, payload.name)
     await tmuxManager.killSession(payload.name)
   })
 
   ipcMain.handle(
     'tmux:renameSession',
-    async (_event, payload: { oldName: string; newName: string }) => {
+    async (event, payload: { oldName: string; newName: string }) => {
       validateTmuxName(payload.oldName)
       validateTmuxName(payload.newName)
+      await assertCanManageTmuxSession(event.sender.id, payload.oldName)
       await tmuxManager.renameSession(payload.oldName, payload.newName)
+      ptyManager.updateTmuxSessionName(payload.oldName, payload.newName)
     },
   )
-
-  // --- Tool Spawning ---
-
-  ipcMain.handle(
-    'tool:spawn',
-    async (
-      event,
-      payload: {
-        toolId: string
-        worktreePath: string
-        cols?: number
-        rows?: number
-        workspaceName?: string
-        branch?: string
-        resumeSessionId?: string
-        profileId?: string
-      },
-    ) => {
-      return toolSessionService.spawnTool(event.sender, payload)
-    },
-  )
-
   ipcMain.handle('agent:updateTitle', (_event, payload: { sessionId: string; title: string }) => {
     agentSessionManager.updateProcessTitle(payload.sessionId, payload.title)
   })
@@ -1220,65 +1222,6 @@ export function registerIpcHandlers(
       return 'main'
     }
   })
-
-  // --- Layouts ---
-
-  ipcMain.handle(
-    'layout:save',
-    (_event, payload: { workspaceId: string; worktreePath: string; layoutJson: string }) => {
-      try {
-        layoutStore.save(payload.workspaceId, payload.worktreePath, payload.layoutJson)
-      } catch (error) {
-        if (layoutStore.isClosed()) {
-          // DB may already be closed during shutdown
-          return
-        }
-        console.error('Failed to save layout:', error)
-      }
-    },
-  )
-
-  ipcMain.handle('layout:get', (_event, payload: { workspaceId: string; worktreePath: string }) => {
-    try {
-      return layoutStore.get(payload.workspaceId, payload.worktreePath)
-    } catch (error) {
-      if (layoutStore.isClosed()) {
-        // DB may already be closed during shutdown
-        return null
-      }
-      console.error('Failed to load layout:', error)
-      throw error
-    }
-  })
-
-  ipcMain.handle('layout:getAll', (_event, payload: { workspaceId: string }) => {
-    try {
-      return layoutStore.getAll(payload.workspaceId)
-    } catch (error) {
-      if (layoutStore.isClosed()) {
-        // DB may already be closed during shutdown
-        return []
-      }
-      console.error('Failed to load layouts:', error)
-      throw error
-    }
-  })
-
-  ipcMain.handle(
-    'layout:delete',
-    (_event, payload: { workspaceId: string; worktreePath: string }) => {
-      try {
-        layoutStore.delete(payload.workspaceId, payload.worktreePath)
-      } catch (error) {
-        if (layoutStore.isClosed()) {
-          // DB may already be closed during shutdown
-          return
-        }
-        console.error('Failed to delete layout:', error)
-        throw error
-      }
-    },
-  )
 
   // --- Custom Tools ---
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -34,6 +34,10 @@ import { fileWatcherErrorMessage } from '../fileWatcher/errors'
 import { runWorktreeSetup } from '../worktree/WorktreeSetupRunner'
 
 const execFileAsync = promisify(execFile)
+
+export interface IpcCommandBridge {
+  grantAttachPath(webContentsId: number, targetPath: string): void
+}
 import type { WorktreeSetupAction } from '../db/types'
 import { generateCommitMessage } from '../ai/commitMessageGenerator'
 import type { TaskTrackerManager } from '../taskTracker/TaskTrackerManager'
@@ -92,6 +96,7 @@ import type { SettingsExportService } from '../settings/SettingsExport'
 import { settingsExportErrorMessage } from '../settings/errors'
 import type { AgentType, PreferencesReader } from '../agents/types'
 import { resolveShell } from '../pty/PtyManager'
+import { WorkspaceCommandService } from '../commands/workspaceCommands'
 
 function shellExecArgs(command: string): { command: string; args: string[] } {
   const shell = resolveShell()
@@ -191,7 +196,7 @@ export function registerIpcHandlers(
   skillStore: SkillStore,
   profileStore: ProfileStore,
   settingsExportService: SettingsExportService,
-): void {
+): IpcCommandBridge {
   function broadcastToolsChanged(): void {
     const tools = toolRegistry.getAll()
     for (const win of BrowserWindow.getAllWindows()) {
@@ -222,21 +227,35 @@ export function registerIpcHandlers(
     }
   }
 
-  ipcMain.handle('workspace:command:restoreWindow', () => {
-    throw new Error('workspace restore command service is not registered')
+  const workspaceCommandService = new WorkspaceCommandService({
+    workspaceStore,
+    layoutStore,
+    windowManager,
+    persistWindowConfigs,
+    validatePathAccess: (webContentsId, targetPath) =>
+      validatePathAccess(webContentsId, targetPath),
+    clearWorkspaceFileCache: (workspacePath) => {
+      workspaceFileCache.delete(workspacePath)
+    },
   })
-  ipcMain.handle('workspace:command:attachProject', () => {
-    throw new Error('workspace attach command service is not registered')
-  })
-  ipcMain.handle('workspace:command:detachProject', () => {
-    throw new Error('workspace detach command service is not registered')
-  })
-  ipcMain.handle('workspace:command:selectWorktree', () => {
-    throw new Error('workspace select command service is not registered')
-  })
-  ipcMain.handle('workspace:command:initGitRepo', () => {
-    throw new Error('workspace init git command service is not registered')
-  })
+
+  ipcMain.handle(
+    'workspace:command:restoreWindow',
+    (event, payload: { paths: string[]; activeWorktreePath?: string; removedPaths?: string[] }) =>
+      workspaceCommandService.restoreWindow(event.sender, payload),
+  )
+  ipcMain.handle('workspace:command:attachProject', (event, payload: { path: string }) =>
+    workspaceCommandService.attachProject(event.sender, payload.path),
+  )
+  ipcMain.handle('workspace:command:detachProject', (event, payload: { path: string }) =>
+    workspaceCommandService.detachProject(event.sender, payload.path),
+  )
+  ipcMain.handle('workspace:command:selectWorktree', (event, payload: { path: string }) =>
+    workspaceCommandService.selectWorktree(event.sender, payload.path),
+  )
+  ipcMain.handle('workspace:command:initGitRepo', (event, payload: { path: string }) =>
+    workspaceCommandService.initGitRepo(event.sender, payload.path),
+  )
   ipcMain.handle('tab:command:openTool', () => {
     throw new Error('tab open command service is not registered')
   })
@@ -594,19 +613,8 @@ export function registerIpcHandlers(
     return workspaceStore.getByPath(payload.path) ?? null
   })
 
-  ipcMain.handle(
-    'db:workspace:upsert',
-    (_event, payload: { path: string; name: string; isGitRepo: boolean }) => {
-      return workspaceStore.upsert(payload)
-    },
-  )
-
   ipcMain.handle('db:workspace:remove', (_event, payload: { id: string }) => {
     workspaceStore.remove(payload.id)
-  })
-
-  ipcMain.handle('db:workspace:touch', (_event, payload: { id: string }) => {
-    workspaceStore.touch(payload.id)
   })
 
   // --- Preferences ---
@@ -844,44 +852,12 @@ export function registerIpcHandlers(
     })
   })
 
-  ipcMain.handle('app:setWorkspacePath', (event, payload: { path: string }) => {
-    windowManager.addWorkspacePath(event.sender.id, payload.path)
-    persistWindowConfigs()
-  })
-
-  ipcMain.handle('app:setActiveWorktree', (event, payload: { path: string }) => {
-    windowManager.setActiveWorktree(event.sender.id, payload.path)
-    persistWindowConfigs()
-  })
-
   ipcMain.handle(
     'app:setFocusedAgentSession',
     (event, payload: { ptySessionId: string | null }) => {
       windowManager.setFocusedAgentSession(event.sender.id, payload.ptySessionId)
     },
   )
-
-  ipcMain.handle('app:detachProject', (event, payload: { path: string }) => {
-    const senderId = event.sender.id
-    windowManager.removeWorkspacePath(senderId, payload.path)
-    windowManager.disposeGitWatcher(senderId, payload.path)
-    // Delete layouts so this workspace won't restore on next launch
-    const ws = workspaceStore.getByPath(payload.path)
-    if (ws) layoutStore.deleteAll(ws.id)
-    // Release the Quick Open file list cached for this workspace.
-    workspaceFileCache.delete(payload.path)
-    persistWindowConfigs()
-  })
-
-  ipcMain.handle('app:focusWindowForPath', (event, payload: { path: string }) => {
-    const existing = windowManager.getWindowForPath(payload.path)
-    if (existing && existing.webContents.id !== event.sender.id) {
-      if (existing.isMinimized()) existing.restore()
-      existing.focus()
-      return true
-    }
-    return false
-  })
 
   ipcMain.handle('app:focusRendererWebContents', (event) => {
     const win = BrowserWindow.fromWebContents(event.sender)
@@ -899,7 +875,40 @@ export function registerIpcHandlers(
       properties: ['openDirectory', 'createDirectory'],
       ...(payload?.defaultPath ? { defaultPath: payload.defaultPath } : {}),
     })
-    return result.canceled ? null : result.filePaths[0]
+    if (result.canceled) return null
+    const selectedPath = result.filePaths[0]
+    if (selectedPath) workspaceCommandService.grantAttachPath(event.sender.id, selectedPath)
+    return selectedPath
+  })
+
+  ipcMain.handle('dialog:confirmOpenPath', async (event, payload: { path: string }) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win || win.isDestroyed()) return null
+
+    let resolved: string
+    let home: string
+    try {
+      resolved = await fs.promises.realpath(path.resolve(payload.path))
+      home = await fs.promises.realpath(os.homedir())
+    } catch {
+      throw new Error('Path does not exist')
+    }
+    if (resolved !== home && !resolved.startsWith(home + path.sep)) {
+      throw new Error('Path must be inside your home directory')
+    }
+
+    const { response } = await dialog.showMessageBox(win, {
+      type: 'question',
+      buttons: ['Open', 'Cancel'],
+      defaultId: 1,
+      cancelId: 1,
+      message: 'Open workspace?',
+      detail: `Open this path as a workspace?\n${resolved}`,
+    })
+    if (response !== 0) return null
+
+    workspaceCommandService.grantAttachPath(event.sender.id, resolved)
+    return resolved
   })
 
   // --- Git ---
@@ -3287,4 +3296,9 @@ export function registerIpcHandlers(
     await fs.promises.unlink(resolvedTarget)
     return { success: true }
   })
+  return {
+    grantAttachPath(webContentsId: number, targetPath: string): void {
+      workspaceCommandService.grantAttachPath(webContentsId, targetPath)
+    },
+  }
 }

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -22,7 +22,7 @@ import type { AgentSessionManager } from '../agents/AgentSessionManager'
 import type { WindowManager } from '../WindowManager'
 import type { BrowserManager } from '../browser/BrowserManager'
 import type { CredentialStore, Credential } from '../db/CredentialStore'
-import { TmuxManager } from '../pty/TmuxManager'
+import type { TmuxManager } from '../pty/TmuxManager'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { GitRepository, type GitInfo } from '../git/GitRepository'
@@ -89,14 +89,14 @@ import { getTransformer } from '../skills/SkillTransformer'
 import { scanSkills } from '../skills/SkillScanner'
 import type { SkillAgentTarget } from '../skills/types'
 import type { ProfileStore } from '../profiles/ProfileStore'
-import { profileToReader } from '../profiles/ProfileStore'
 import { profileErrorMessage } from '../profiles/errors'
 import { KNOWN_AGENT_TYPES, type ProfileInput } from '../profiles/types'
 import type { SettingsExportService } from '../settings/SettingsExport'
 import { settingsExportErrorMessage } from '../settings/errors'
-import type { AgentType, PreferencesReader } from '../agents/types'
+import type { AgentType } from '../agents/types'
 import { resolveShell } from '../pty/PtyManager'
 import { WorkspaceCommandService } from '../commands/workspaceCommands'
+import { TabCommandService, ToolSessionService } from '../commands/tabCommands'
 
 function shellExecArgs(command: string): { command: string; args: string[] } {
   const shell = resolveShell()
@@ -166,11 +166,6 @@ async function runCredentialOsAuth(event: IpcMainInvokeEvent, domain: string): P
     })
 }
 
-function resolveShellArgs(): string[] {
-  if (os.platform() === 'win32') return []
-  return ['--login']
-}
-
 export function registerIpcHandlers(
   ptyManager: PtyManager,
   wsBridge: WsBridge,
@@ -238,6 +233,24 @@ export function registerIpcHandlers(
       workspaceFileCache.delete(workspacePath)
     },
   })
+  const toolSessionService = new ToolSessionService({
+    ptyManager,
+    wsBridge,
+    workspaceStore,
+    preferencesStore,
+    toolRegistry,
+    agentSessionManager,
+    windowManager,
+    tmuxManager,
+    profileStore,
+  })
+  const tabCommandService = new TabCommandService({
+    toolSessions: toolSessionService,
+    layoutStore,
+    workspaceStore,
+    browserManager,
+    windowManager,
+  })
 
   ipcMain.handle(
     'workspace:command:restoreWindow',
@@ -256,21 +269,21 @@ export function registerIpcHandlers(
   ipcMain.handle('workspace:command:initGitRepo', (event, payload: { path: string }) =>
     workspaceCommandService.initGitRepo(event.sender, payload.path),
   )
-  ipcMain.handle('tab:command:openTool', () => {
-    throw new Error('tab open command service is not registered')
-  })
-  ipcMain.handle('tab:command:restartPane', () => {
-    throw new Error('tab restart command service is not registered')
-  })
-  ipcMain.handle('tab:command:closeTab', () => {
-    throw new Error('tab close command service is not registered')
-  })
-  ipcMain.handle('tab:command:saveLayout', () => {
-    throw new Error('tab save layout command service is not registered')
-  })
-  ipcMain.handle('tab:command:restoreLayout', () => {
-    throw new Error('tab restore layout command service is not registered')
-  })
+  ipcMain.handle('tab:command:openTool', (event, payload) =>
+    tabCommandService.openTool(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:restartPane', (event, payload) =>
+    tabCommandService.restartPane(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:closeTab', (event, payload) =>
+    tabCommandService.closeTab(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:saveLayout', (_event, payload) =>
+    tabCommandService.saveLayout(payload),
+  )
+  ipcMain.handle('tab:command:restoreLayout', (_event, payload) =>
+    tabCommandService.restoreLayout(payload),
+  )
   ipcMain.handle('agent:command:sendTaskContext', () => {
     throw new Error('agent task command service is not registered')
   })
@@ -343,18 +356,7 @@ export function registerIpcHandlers(
   )
 
   ipcMain.handle('pty:kill', async (_event, payload: { sessionId: string; killTmux?: boolean }) => {
-    const tmuxName = ptyManager.getTmuxSessionName(payload.sessionId)
-    // Kill tmux BEFORE PTY so the pty:exit handler sees the session as dead
-    // (otherwise handlePtyExit checks tmuxHasSession while it's still alive)
-    if (payload.killTmux && tmuxName && TmuxManager.isCanopySession(tmuxName)) {
-      try {
-        await tmuxManager.killSession(tmuxName)
-      } catch {
-        // Session may already be gone
-      }
-    }
-    wsBridge.destroy(payload.sessionId)
-    ptyManager.kill(payload.sessionId)
+    await toolSessionService.killPty(payload.sessionId, payload.killTmux)
   })
 
   ipcMain.handle('pty:write', (_event, payload: { sessionId: string; data: string }) => {
@@ -397,33 +399,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'tmux:attach',
     async (event, payload: { tmuxSessionName: string; cols?: number; rows?: number }) => {
-      validateTmuxName(payload.tmuxSessionName)
-      const sender = event.sender
-      const attach = tmuxManager.attachArgs(payload.tmuxSessionName)
-      const session = ptyManager.spawn({
-        command: attach.command,
-        args: attach.args,
-        cols: payload.cols,
-        rows: payload.rows,
-        tmuxSessionName: payload.tmuxSessionName,
-      })
-      const wsUrl = await wsBridge.create(session.id, session.pty)
-
-      windowManager.trackPtySession(sender.id, session.id)
-
-      session.pty.onExit(({ exitCode, signal }) => {
-        if (!sender.isDestroyed()) {
-          sender.send('pty:exit', {
-            sessionId: session.id,
-            exitCode,
-            signal,
-            tmuxSessionName: payload.tmuxSessionName,
-          })
-        }
-        windowManager.untrackPtySession(sender.id, session.id)
-      })
-
-      return { sessionId: session.id, wsUrl }
+      return toolSessionService.attachTmux(event.sender, payload)
     },
   )
 
@@ -465,133 +441,7 @@ export function registerIpcHandlers(
         profileId?: string
       },
     ) => {
-      const sender = event.sender
-      const tool = toolRegistry.get(payload.toolId)
-      if (!tool) throw new Error(`Unknown tool: ${payload.toolId}`)
-
-      let command = toolRegistry.resolveCommand(tool)
-      const isShell = tool.id === 'shell' || tool.command === 'shell'
-      const isAgent = agentSessionManager.isAgentTool(tool.id)
-      let args = isShell ? resolveShellArgs() : [...tool.args]
-      let env: Record<string, string> | undefined
-
-      let agentTempId: string | undefined
-      if (isAgent) {
-        const senderWindow = BrowserWindow.fromWebContents(sender)
-        if (!senderWindow) throw new Error('No window for agent session')
-
-        // Resolve preferences reader: profile shim if profileId is set,
-        // otherwise the global preferencesStore (legacy path).
-        let prefsReader: PreferencesReader = preferencesStore
-        if (payload.profileId) {
-          const profileResult = await profileStore.getInternal(payload.profileId)
-          if (profileResult.isErr()) {
-            throw new Error(profileErrorMessage(profileResult.error))
-          }
-          const profile = profileResult.value
-          if (profile.agentType !== tool.id) {
-            throw new Error(`Profile ${profile.name} is for ${profile.agentType}, not ${tool.id}`)
-          }
-          prefsReader = profileToReader(profile, preferencesStore)
-        }
-
-        // Parse settings.json overrides from prefs (via shim when profile-bound)
-        let settingsOverrides: Record<string, unknown> | undefined
-        const settingsJsonRaw = prefsReader.get(`${tool.id}.settingsJson`)
-        if (settingsJsonRaw) {
-          try {
-            settingsOverrides = JSON.parse(settingsJsonRaw) as Record<string, unknown>
-          } catch {
-            // Invalid JSON
-          }
-        }
-
-        const agentSession = await agentSessionManager.createSession(
-          tool.id,
-          payload.worktreePath,
-          payload.workspaceName ?? '',
-          payload.branch ?? null,
-          senderWindow,
-          settingsOverrides,
-        )
-        args = [...agentSession.settingsArgs, ...args]
-        if (payload.resumeSessionId) {
-          args.push(...agentSessionManager.getResumeArgs(tool.id, payload.resumeSessionId))
-        }
-        args.push(...agentSessionManager.getCliArgs(tool.id, prefsReader))
-        env = {
-          CANOPY_HOOK_PORT: String(agentSession.hookPort),
-          CANOPY_HOOK_PATH: agentSession.hookPath,
-          CANOPY_HOOK_TOKEN: agentSession.hookAuthToken,
-          ...agentSession.settingsEnv,
-          ...agentSessionManager.getEnvVars(tool.id, prefsReader),
-        }
-        agentTempId = agentSession.tempId
-      }
-
-      // Tmux integration for all tool sessions
-      let tmuxSessionName: string | undefined
-      const tmuxEnabled = preferencesStore.get('tmux.enabled') === 'true'
-      if (tmuxEnabled && (await tmuxManager.isAvailable())) {
-        const ws = workspaceStore.getByPath(payload.worktreePath)
-        const wsId = ws?.id ?? 'default'
-        tmuxSessionName = TmuxManager.sessionName(wsId)
-        const tmuxMouse = preferencesStore.get('tmux.mouse') === 'true'
-        await tmuxManager.newSession({
-          name: tmuxSessionName,
-          cwd: payload.worktreePath,
-          shell: command,
-          shellArgs: args,
-          cols: payload.cols,
-          rows: payload.rows,
-          mouse: tmuxMouse,
-          env,
-        })
-        const attach = tmuxManager.attachArgs(tmuxSessionName)
-        command = attach.command
-        args = attach.args
-      }
-
-      const session = ptyManager.spawn({
-        command,
-        args,
-        cwd: payload.worktreePath,
-        cols: payload.cols,
-        rows: payload.rows,
-        env,
-        tmuxSessionName,
-      })
-
-      if (isAgent && agentTempId) {
-        agentSessionManager.rekey(agentTempId, session.id)
-      }
-
-      const wsUrl = await wsBridge.create(session.id, session.pty)
-
-      windowManager.trackPtySession(sender.id, session.id)
-
-      session.pty.onExit(({ exitCode, signal }) => {
-        if (!sender.isDestroyed()) {
-          sender.send('pty:exit', {
-            sessionId: session.id,
-            exitCode,
-            signal,
-            tmuxSessionName: session.tmuxSessionName,
-          })
-        }
-        windowManager.untrackPtySession(sender.id, session.id)
-        if (isAgent) {
-          agentSessionManager.destroySession(session.id)
-        }
-      })
-
-      return {
-        sessionId: session.id,
-        wsUrl,
-        toolId: tool.id,
-        toolName: tool.name,
-        tmuxSessionName,
-      }
+      return toolSessionService.spawnTool(event.sender, payload)
     },
   )
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -298,9 +298,6 @@ export function registerIpcHandlers(
   ipcMain.handle('tab:command:deleteLayout', (event, payload) =>
     tabCommandService.deleteLayout(event.sender, payload),
   )
-  ipcMain.handle('tab:command:restoreLayout', (event, payload) =>
-    tabCommandService.restoreLayout(event.sender, payload),
-  )
   ipcMain.handle('agent:command:sendTaskContext', (event, payload) =>
     agentCommandService.sendTaskContext(event.sender, payload),
   )
@@ -2787,14 +2784,6 @@ export function registerIpcHandlers(
       const resolved = await validatePathAccess(event.sender.id, payload.configDir)
       const result = await runConfigManager.deleteConfiguration(resolved, payload.name)
       unwrapOrThrow(result, runConfigErrorMessage)
-    },
-  )
-
-  ipcMain.handle(
-    'runConfig:execute',
-    async (event, payload: { configDir: string; name: string; cwd?: string }) => {
-      const result = await runConfigCommandService.execute(event.sender, payload)
-      return { sessionId: result.sessionId, wsUrl: result.wsUrl }
     },
   )
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -94,16 +94,10 @@ import { KNOWN_AGENT_TYPES, type ProfileInput } from '../profiles/types'
 import type { SettingsExportService } from '../settings/SettingsExport'
 import { settingsExportErrorMessage } from '../settings/errors'
 import type { AgentType } from '../agents/types'
-import { resolveShell } from '../pty/PtyManager'
 import { WorkspaceCommandService } from '../commands/workspaceCommands'
 import { TabCommandService, ToolSessionService } from '../commands/tabCommands'
 import { AgentCommandService } from '../commands/agentCommands'
-
-function shellExecArgs(command: string): { command: string; args: string[] } {
-  const shell = resolveShell()
-  const flag = os.platform() === 'win32' ? '-Command' : '-lc'
-  return { command: shell.command, args: [flag, command] }
-}
+import { RunConfigCommandService } from '../commands/runConfigCommands'
 
 // Session-level flag: once the user has successfully authenticated to reveal
 // a saved credential in the current app session, subsequent autofills reuse
@@ -257,6 +251,14 @@ export function registerIpcHandlers(
     agentSessionManager,
     windowManager,
   })
+  const runConfigCommandService = new RunConfigCommandService({
+    ptyManager,
+    wsBridge,
+    windowManager,
+    runConfigManager,
+    validatePathAccess: (webContentsId, targetPath) =>
+      validatePathAccess(webContentsId, targetPath),
+  })
 
   ipcMain.handle(
     'workspace:command:restoreWindow',
@@ -299,12 +301,12 @@ export function registerIpcHandlers(
   ipcMain.handle('agent:command:sendDrawing', (event, payload) =>
     agentCommandService.sendDrawing(event.sender, payload),
   )
-  ipcMain.handle('runConfig:command:execute', () => {
-    throw new Error('run config command service is not registered')
-  })
-  ipcMain.handle('runConfig:command:listRunning', () => {
-    throw new Error('run config command service is not registered')
-  })
+  ipcMain.handle('runConfig:command:execute', (event, payload) =>
+    runConfigCommandService.execute(event.sender, payload),
+  )
+  ipcMain.handle('runConfig:command:listRunning', (event) =>
+    runConfigCommandService.listRunning(event.sender),
+  )
 
   // --- PTY ---
 
@@ -2786,8 +2788,6 @@ export function registerIpcHandlers(
 
   // --- Run Configurations ---
 
-  const runConfigInstances = new Map<string, number>()
-
   ipcMain.handle('runConfig:discover', async (event, payload: { repoRoot: string }) => {
     const resolved = await validatePathAccess(event.sender.id, payload.repoRoot)
     const result = await runConfigManager.discover(resolved)
@@ -2850,130 +2850,8 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'runConfig:execute',
     async (event, payload: { configDir: string; name: string; cwd?: string }) => {
-      const resolvedConfigDir = await validatePathAccess(event.sender.id, payload.configDir)
-      const fileResult = await runConfigManager.loadFile(resolvedConfigDir)
-      const file = unwrapOrThrow(fileResult, runConfigErrorMessage)
-      const config = file.configurations.find((c) => c.name === payload.name)
-      if (!config) throw new Error(`Configuration "${payload.name}" not found`)
-
-      if (config.max_instances && config.max_instances > 0) {
-        const current = runConfigInstances.get(`${resolvedConfigDir}::${payload.name}`) ?? 0
-        if (current >= config.max_instances) {
-          throw new Error(`"${payload.name}" is already running (max ${config.max_instances})`)
-        }
-      }
-
-      if (!payload.cwd) throw new Error('No worktree selected')
-      const worktreeRoot = await validatePathAccess(event.sender.id, payload.cwd)
-      const cwd = config.cwd ? path.resolve(worktreeRoot, config.cwd) : worktreeRoot
-      if (config.cwd && cwd !== worktreeRoot && !cwd.startsWith(worktreeRoot + path.sep)) {
-        throw new Error('config.cwd must not escape the worktree directory')
-      }
-      const env = config.env
-      const fullCommand = config.args ? `${config.command} ${config.args}` : config.command
-
-      // Pre-run hook (30s timeout)
-      if (config.pre_run) {
-        const PRE_RUN_TIMEOUT = 30_000
-        // Cap captured output so a noisy pre_run can't balloon main-process
-        // memory before the timer fires. We only surface the last ~5 lines on
-        // failure, so trimming the head is safe.
-        const PRE_RUN_OUTPUT_CAP = 32_768
-        const pre = shellExecArgs(config.pre_run)
-        const preSession = ptyManager.spawn({ command: pre.command, args: pre.args, cwd, env })
-        let preOutput = ''
-        preSession.pty.onData((data) => {
-          preOutput += data
-          if (preOutput.length > PRE_RUN_OUTPUT_CAP) {
-            preOutput = preOutput.slice(-PRE_RUN_OUTPUT_CAP / 2)
-          }
-        })
-        await new Promise<void>((resolve, reject) => {
-          let done = false
-          const timer = setTimeout(() => {
-            if (!done) {
-              done = true
-              ptyManager.kill(preSession.id)
-              reject(new Error(`pre_run "${config.pre_run}" timed out after 30s`))
-            }
-          }, PRE_RUN_TIMEOUT)
-          preSession.pty.onExit(({ exitCode }) => {
-            if (done) return
-            done = true
-            clearTimeout(timer)
-            ptyManager.kill(preSession.id)
-            if (exitCode !== 0) {
-              const lastLines = preOutput.trim().split('\n').slice(-5).join('\n')
-              reject(
-                new Error(`pre_run "${config.pre_run}" failed (exit ${exitCode}):\n${lastLines}`),
-              )
-            } else resolve()
-          })
-        })
-      }
-
-      // Run main command through shell so PATH is resolved
-      const main = shellExecArgs(fullCommand)
-      const session = ptyManager.spawn({ command: main.command, args: main.args, cwd, env })
-      const wsUrl = await wsBridge.create(session.id, session.pty)
-      const senderId = event.sender.id
-      windowManager.trackPtySession(senderId, session.id)
-      const instanceKey = `${resolvedConfigDir}::${payload.name}`
-      runConfigInstances.set(instanceKey, (runConfigInstances.get(instanceKey) ?? 0) + 1)
-
-      const sender = event.sender
-      session.pty.onExit(({ exitCode, signal }) => {
-        if (!sender.isDestroyed()) {
-          sender.send('pty:exit', { sessionId: session.id, exitCode, signal })
-        }
-        windowManager.untrackPtySession(senderId, session.id)
-        const count = (runConfigInstances.get(instanceKey) ?? 1) - 1
-        if (count <= 0) runConfigInstances.delete(instanceKey)
-        else runConfigInstances.set(instanceKey, count)
-
-        // Post-run hook
-        if (config.post_run) {
-          const postCmd = config.post_run
-          const post = shellExecArgs(postCmd)
-          const postSession = ptyManager.spawn({
-            command: post.command,
-            args: post.args,
-            cwd,
-            env,
-          })
-          const POST_RUN_TIMEOUT = 30_000
-          let postDone = false
-          const postTimer = setTimeout(() => {
-            if (!postDone) {
-              postDone = true
-              ptyManager.kill(postSession.id)
-              if (!sender.isDestroyed()) {
-                sender.send('runConfig:postRunResult', {
-                  success: false,
-                  command: postCmd,
-                  exitCode: -1,
-                })
-              }
-            }
-          }, POST_RUN_TIMEOUT)
-          postSession.pty.onExit(({ exitCode: postExit }) => {
-            if (postDone) return
-            postDone = true
-            clearTimeout(postTimer)
-            if (!sender.isDestroyed()) {
-              sender.send(
-                'runConfig:postRunResult',
-                postExit === 0
-                  ? { success: true, command: postCmd }
-                  : { success: false, command: postCmd, exitCode: postExit },
-              )
-            }
-            ptyManager.kill(postSession.id)
-          })
-        }
-      })
-
-      return { sessionId: session.id, wsUrl }
+      const result = await runConfigCommandService.execute(event.sender, payload)
+      return { sessionId: result.sessionId, wsUrl: result.wsUrl }
     },
   )
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -97,6 +97,7 @@ import type { AgentType } from '../agents/types'
 import { resolveShell } from '../pty/PtyManager'
 import { WorkspaceCommandService } from '../commands/workspaceCommands'
 import { TabCommandService, ToolSessionService } from '../commands/tabCommands'
+import { AgentCommandService } from '../commands/agentCommands'
 
 function shellExecArgs(command: string): { command: string; args: string[] } {
   const shell = resolveShell()
@@ -251,6 +252,11 @@ export function registerIpcHandlers(
     browserManager,
     windowManager,
   })
+  const agentCommandService = new AgentCommandService({
+    ptyManager,
+    agentSessionManager,
+    windowManager,
+  })
 
   ipcMain.handle(
     'workspace:command:restoreWindow',
@@ -284,15 +290,15 @@ export function registerIpcHandlers(
   ipcMain.handle('tab:command:restoreLayout', (_event, payload) =>
     tabCommandService.restoreLayout(payload),
   )
-  ipcMain.handle('agent:command:sendTaskContext', () => {
-    throw new Error('agent task command service is not registered')
-  })
-  ipcMain.handle('agent:command:sendReviewContext', () => {
-    throw new Error('agent review command service is not registered')
-  })
-  ipcMain.handle('agent:command:sendDrawing', () => {
-    throw new Error('agent drawing command service is not registered')
-  })
+  ipcMain.handle('agent:command:sendTaskContext', (event, payload) =>
+    agentCommandService.sendTaskContext(event.sender, payload),
+  )
+  ipcMain.handle('agent:command:sendReviewContext', (event, payload) =>
+    agentCommandService.sendReviewContext(event.sender, payload),
+  )
+  ipcMain.handle('agent:command:sendDrawing', (event, payload) =>
+    agentCommandService.sendDrawing(event.sender, payload),
+  )
   ipcMain.handle('runConfig:command:execute', () => {
     throw new Error('run config command service is not registered')
   })
@@ -359,7 +365,10 @@ export function registerIpcHandlers(
     await toolSessionService.killPty(payload.sessionId, payload.killTmux)
   })
 
-  ipcMain.handle('pty:write', (_event, payload: { sessionId: string; data: string }) => {
+  ipcMain.handle('pty:write', (event, payload: { sessionId: string; data: string }) => {
+    if (!windowManager.ownsPtySession(event.sender.id, payload.sessionId)) {
+      throw new Error('PTY session is not owned by this window')
+    }
     ptyManager.write(payload.sessionId, payload.data)
   })
 

--- a/src/main/pty/PtyManager.ts
+++ b/src/main/pty/PtyManager.ts
@@ -76,6 +76,24 @@ export class PtyManager {
     return this.sessions.get(id)?.tmuxSessionName
   }
 
+  getSessionIdsForTmuxSession(name: string): string[] {
+    const ids: string[] = []
+    for (const [id, session] of this.sessions) {
+      if (session.tmuxSessionName === name) {
+        ids.push(id)
+      }
+    }
+    return ids
+  }
+
+  updateTmuxSessionName(oldName: string, newName: string): void {
+    for (const session of this.sessions.values()) {
+      if (session.tmuxSessionName === oldName) {
+        session.tmuxSessionName = newName
+      }
+    }
+  }
+
   isTmuxSession(id: string): boolean {
     return !!this.sessions.get(id)?.tmuxSessionName
   }

--- a/src/main/security/envBlocklist.ts
+++ b/src/main/security/envBlocklist.ts
@@ -32,6 +32,8 @@ export const BLOCKED_ENV_VARS = new Set([
   'RUBYLIB',
   'PERL5LIB',
   'CLASSPATH',
+  'JAVA_TOOL_OPTIONS',
+  '_JAVA_OPTIONS',
 
   // Git / SSH
   'GIT_SSH_COMMAND',

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -360,11 +360,6 @@ interface CanopyAPI {
   ) => Promise<PaneSnapshot>
   tabSaveLayout: (worktreePath: string, layoutJson: string) => Promise<void>
   tabDeleteLayout: (worktreePath: string) => Promise<void>
-  tabRestoreLayout: (
-    worktreePath: string,
-    layoutJson: string,
-    options?: { tabs?: TabSnapshot[]; activeTabId?: string | null },
-  ) => Promise<TabCommandResult>
 
   agentSendTaskContext: (payload: {
     text: string
@@ -377,7 +372,6 @@ interface CanopyAPI {
     sessionId?: string
   }) => Promise<AgentCommandResult>
   agentSendDrawing: (payload: {
-    pngBase64?: string
     worktreePath?: string
     sessionId?: string
   }) => Promise<AgentCommandResult>
@@ -846,11 +840,6 @@ interface CanopyAPI {
     configuration: RunConfiguration,
   ) => Promise<void>
   runConfigDeleteConfig: (configDir: string, name: string) => Promise<void>
-  runConfigExecute: (
-    configDir: string,
-    name: string,
-    cwd?: string,
-  ) => Promise<{ sessionId: string; wsUrl: string }>
   runConfigExecuteCommand: (
     configDir: string,
     name: string,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -2,6 +2,7 @@ import type {
   AgentCommandResult,
   RunConfigCommandResult,
   RunConfigProcessSnapshot,
+  TabSnapshot,
   TabCommandResult,
   WorkspaceCommandResult,
 } from '../main/commands/types'
@@ -347,12 +348,37 @@ interface CanopyAPI {
   tabOpenTool: (
     toolId: string,
     worktreePath: string,
-    options?: { initialUrl?: string; profileId?: string },
+    options?: {
+      initialUrl?: string
+      profileId?: string
+      workspaceName?: string
+      branch?: string
+      tabs?: TabSnapshot[]
+      activeTabId?: string | null
+    },
   ) => Promise<TabCommandResult>
-  tabRestartPane: (worktreePath: string, tabId: string, paneId: string) => Promise<TabCommandResult>
-  tabCloseTab: (worktreePath: string, tabId: string) => Promise<TabCommandResult>
-  tabSaveLayout: (worktreePath: string, layoutJson: string) => Promise<void>
-  tabRestoreLayout: (worktreePath: string, layoutJson: string) => Promise<TabCommandResult>
+  tabRestartPane: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+      tabs?: TabSnapshot[]
+      activeTabId?: string | null
+    },
+  ) => Promise<TabCommandResult>
+  tabCloseTab: (
+    worktreePath: string,
+    tabId: string,
+    options?: { tabs?: TabSnapshot[]; activeTabId?: string | null },
+  ) => Promise<TabCommandResult>
+  tabSaveLayout: (worktreePath: string, layoutJson: string, workspaceId?: string) => Promise<void>
+  tabRestoreLayout: (
+    worktreePath: string,
+    layoutJson: string,
+    options?: { tabs?: TabSnapshot[]; activeTabId?: string | null },
+  ) => Promise<TabCommandResult>
 
   agentSendTaskContext: (payload: {
     text: string

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -7,19 +7,6 @@ import type {
   WorkspaceCommandResult,
 } from '../main/commands/types'
 
-interface PtySpawnResult {
-  sessionId: string
-  wsUrl: string
-}
-
-interface ToolSpawnResult {
-  sessionId: string
-  wsUrl: string
-  toolId: string
-  toolName: string
-  tmuxSessionName?: string
-}
-
 interface PtyExitData {
   sessionId: string
   exitCode: number
@@ -266,7 +253,6 @@ interface CanopyAPI {
   ) => () => void
 
   // PTY
-  spawnPty: (options?: { cols?: number; rows?: number; cwd?: string }) => Promise<PtySpawnResult>
   resizePty: (sessionId: string, cols: number, rows: number) => Promise<void>
   killPty: (sessionId: string, killTmux?: boolean) => Promise<void>
   writePty: (sessionId: string, data: string) => Promise<void>
@@ -314,18 +300,6 @@ interface CanopyAPI {
   listTools: () => Promise<ToolDefinition[]>
   getTool: (id: string) => Promise<ToolDefinition | null>
   checkToolAvailability: () => Promise<Record<string, boolean>>
-  spawnTool: (
-    toolId: string,
-    worktreePath: string,
-    options?: {
-      cols?: number
-      rows?: number
-      workspaceName?: string
-      branch?: string
-      resumeSessionId?: string
-      profileId?: string
-    },
-  ) => Promise<ToolSpawnResult>
   addCustomTool: (tool: {
     id: string
     name: string
@@ -373,7 +347,19 @@ interface CanopyAPI {
     tabId: string,
     options?: { tabs?: TabSnapshot[]; activeTabId?: string | null },
   ) => Promise<TabCommandResult>
-  tabSaveLayout: (worktreePath: string, layoutJson: string, workspaceId?: string) => Promise<void>
+  tabSpawnPane: (
+    toolId: string,
+    worktreePath: string,
+    options?: {
+      initialUrl?: string
+      profileId?: string
+      workspaceName?: string
+      branch?: string
+      resumeSessionId?: string
+    },
+  ) => Promise<PaneSnapshot>
+  tabSaveLayout: (worktreePath: string, layoutJson: string) => Promise<void>
+  tabDeleteLayout: (worktreePath: string) => Promise<void>
   tabRestoreLayout: (
     worktreePath: string,
     layoutJson: string,
@@ -539,11 +525,6 @@ interface CanopyAPI {
     newWorktreePath: string,
   ) => Promise<{ success: boolean; errors: string[] }>
   abortWorktreeSetup: () => void
-
-  // Layouts
-  saveLayout: (workspaceId: string, worktreePath: string, layoutJson: string) => Promise<void>
-  getLayout: (workspaceId: string, worktreePath: string) => Promise<string | null>
-  getAllLayouts: (workspaceId: string) => Promise<{ worktree_path: string; layout_json: string }[]>
 
   // Push events (main → renderer)
   onAgentHookEvent: (callback: (data: AgentHookEventData) => void) => () => void
@@ -830,6 +811,7 @@ interface CanopyAPI {
     ts: number
     dir: string
   }> | null>
+  perfOpenProject?: (path: string) => Promise<void>
 
   // Status-bar perf HUD (always present)
   perfHud: {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,3 +1,11 @@
+import type {
+  AgentCommandResult,
+  RunConfigCommandResult,
+  RunConfigProcessSnapshot,
+  TabCommandResult,
+  WorkspaceCommandResult,
+} from '../main/commands/types'
+
 interface PtySpawnResult {
   sessionId: string
   wsUrl: string
@@ -288,6 +296,15 @@ interface CanopyAPI {
   }) => Promise<WorkspaceRow>
   removeWorkspace: (id: string) => Promise<void>
   touchWorkspace: (id: string) => Promise<void>
+  workspaceRestoreWindow: (payload: {
+    paths: string[]
+    activeWorktreePath?: string
+    removedPaths?: string[]
+  }) => Promise<WorkspaceCommandResult>
+  workspaceAttachProject: (path: string) => Promise<WorkspaceCommandResult>
+  workspaceDetachProject: (path: string) => Promise<WorkspaceCommandResult>
+  workspaceSelectWorktree: (path: string) => Promise<WorkspaceCommandResult>
+  workspaceInitGitRepo: (path: string) => Promise<WorkspaceCommandResult>
 
   // Preferences
   getPref: (key: string) => Promise<string | null>
@@ -333,6 +350,33 @@ interface CanopyAPI {
       category?: string
     },
   ) => Promise<ToolDefinition[]>
+  tabOpenTool: (
+    toolId: string,
+    worktreePath: string,
+    options?: { initialUrl?: string; profileId?: string },
+  ) => Promise<TabCommandResult>
+  tabRestartPane: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+  ) => Promise<TabCommandResult>
+  tabCloseTab: (worktreePath: string, tabId: string) => Promise<TabCommandResult>
+  tabSaveLayout: (worktreePath: string, layoutJson: string) => Promise<void>
+  tabRestoreLayout: (worktreePath: string, layoutJson: string) => Promise<TabCommandResult>
+
+  agentSendTaskContext: (payload: {
+    text: string
+    worktreePath?: string
+  }) => Promise<AgentCommandResult>
+  agentSendReviewContext: (payload: {
+    text: string
+    worktreePath?: string
+  }) => Promise<AgentCommandResult>
+  agentSendDrawing: (payload: {
+    pngBase64: string
+    worktreePath?: string
+  }) => Promise<AgentCommandResult>
+
   // App / Shell
   showInFolder: (path: string) => Promise<void>
   newWindow: () => Promise<void>
@@ -808,6 +852,12 @@ interface CanopyAPI {
     name: string,
     cwd?: string,
   ) => Promise<{ sessionId: string; wsUrl: string }>
+  runConfigExecuteCommand: (
+    configDir: string,
+    name: string,
+    cwd: string,
+  ) => Promise<RunConfigCommandResult>
+  runConfigListRunning: () => Promise<RunConfigProcessSnapshot[]>
   onRunConfigPostRunResult: (
     callback: (data: { success: boolean; command: string; exitCode?: number }) => void,
   ) => () => void

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -383,14 +383,17 @@ interface CanopyAPI {
   agentSendTaskContext: (payload: {
     text: string
     worktreePath?: string
+    sessionId?: string
   }) => Promise<AgentCommandResult>
   agentSendReviewContext: (payload: {
     text: string
     worktreePath?: string
+    sessionId?: string
   }) => Promise<AgentCommandResult>
   agentSendDrawing: (payload: {
-    pngBase64: string
+    pngBase64?: string
     worktreePath?: string
+    sessionId?: string
   }) => Promise<AgentCommandResult>
 
   // App / Shell

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -289,13 +289,7 @@ interface CanopyAPI {
   listWorkspaces: (limit?: number) => Promise<WorkspaceRow[]>
   getWorkspace: (id: string) => Promise<WorkspaceRow | null>
   getWorkspaceByPath: (path: string) => Promise<WorkspaceRow | null>
-  upsertWorkspace: (workspace: {
-    path: string
-    name: string
-    isGitRepo: boolean
-  }) => Promise<WorkspaceRow>
   removeWorkspace: (id: string) => Promise<void>
-  touchWorkspace: (id: string) => Promise<void>
   workspaceRestoreWindow: (payload: {
     paths: string[]
     activeWorktreePath?: string
@@ -355,11 +349,7 @@ interface CanopyAPI {
     worktreePath: string,
     options?: { initialUrl?: string; profileId?: string },
   ) => Promise<TabCommandResult>
-  tabRestartPane: (
-    worktreePath: string,
-    tabId: string,
-    paneId: string,
-  ) => Promise<TabCommandResult>
+  tabRestartPane: (worktreePath: string, tabId: string, paneId: string) => Promise<TabCommandResult>
   tabCloseTab: (worktreePath: string, tabId: string) => Promise<TabCommandResult>
   tabSaveLayout: (worktreePath: string, layoutJson: string) => Promise<void>
   tabRestoreLayout: (worktreePath: string, layoutJson: string) => Promise<TabCommandResult>
@@ -380,14 +370,12 @@ interface CanopyAPI {
   // App / Shell
   showInFolder: (path: string) => Promise<void>
   newWindow: () => Promise<void>
-  setWorkspacePath: (path: string) => Promise<void>
-  detachProject: (path: string) => Promise<void>
-  focusWindowForPath: (path: string) => Promise<boolean>
   focusRendererWebContents: () => Promise<void>
   setFocusedAgentSession: (ptySessionId: string | null) => Promise<void>
 
   // Dialog
   openFolder: (defaultPath?: string) => Promise<string | null>
+  confirmOpenPath: (path: string) => Promise<string | null>
 
   // Settings export / import
   exportSettings: () => Promise<{

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -52,10 +52,7 @@ const api = {
   listWorkspaces: (limit?: number) => ipcRenderer.invoke('db:workspace:list', { limit }),
   getWorkspace: (id: string) => ipcRenderer.invoke('db:workspace:get', { id }),
   getWorkspaceByPath: (path: string) => ipcRenderer.invoke('db:workspace:getByPath', { path }),
-  upsertWorkspace: (workspace: { path: string; name: string; isGitRepo: boolean }) =>
-    ipcRenderer.invoke('db:workspace:upsert', workspace),
   removeWorkspace: (id: string) => ipcRenderer.invoke('db:workspace:remove', { id }),
-  touchWorkspace: (id: string) => ipcRenderer.invoke('db:workspace:touch', { id }),
   workspaceRestoreWindow: (payload: {
     paths: string[]
     activeWorktreePath?: string
@@ -308,18 +305,14 @@ const api = {
   getHomedir: () => ipcRenderer.invoke('app:homedir') as Promise<string>,
   showInFolder: (path: string) => ipcRenderer.invoke('app:showInFolder', { path }),
   newWindow: () => ipcRenderer.invoke('app:newWindow'),
-  setWorkspacePath: (path: string) => ipcRenderer.invoke('app:setWorkspacePath', { path }),
-  setActiveWorktree: (path: string) => ipcRenderer.invoke('app:setActiveWorktree', { path }),
   setFocusedAgentSession: (ptySessionId: string | null) =>
     ipcRenderer.invoke('app:setFocusedAgentSession', { ptySessionId }),
-  detachProject: (path: string) => ipcRenderer.invoke('app:detachProject', { path }),
-  focusWindowForPath: (path: string) =>
-    ipcRenderer.invoke('app:focusWindowForPath', { path }) as Promise<boolean>,
   focusRendererWebContents: () => ipcRenderer.invoke('app:focusRendererWebContents'),
 
   // Dialog
   openFolder: (defaultPath?: string) =>
     ipcRenderer.invoke('dialog:openFolder', defaultPath ? { defaultPath } : undefined),
+  confirmOpenPath: (path: string) => ipcRenderer.invoke('dialog:confirmOpenPath', { path }),
 
   // Settings export / import
   exportSettings: () =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -121,16 +121,69 @@ const api = {
   tabOpenTool: (
     toolId: string,
     worktreePath: string,
-    options?: { initialUrl?: string; profileId?: string },
-  ) => ipcRenderer.invoke('tab:command:openTool', { toolId, worktreePath, options }),
-  tabRestartPane: (worktreePath: string, tabId: string, paneId: string) =>
-    ipcRenderer.invoke('tab:command:restartPane', { worktreePath, tabId, paneId }),
-  tabCloseTab: (worktreePath: string, tabId: string) =>
-    ipcRenderer.invoke('tab:command:closeTab', { worktreePath, tabId }),
-  tabSaveLayout: (worktreePath: string, layoutJson: string) =>
-    ipcRenderer.invoke('tab:command:saveLayout', { worktreePath, layoutJson }),
-  tabRestoreLayout: (worktreePath: string, layoutJson: string) =>
-    ipcRenderer.invoke('tab:command:restoreLayout', { worktreePath, layoutJson }),
+    options?: {
+      initialUrl?: string
+      profileId?: string
+      workspaceName?: string
+      branch?: string
+      tabs?: unknown
+      activeTabId?: string | null
+    },
+  ) => {
+    const { tabs, activeTabId, ...commandOptions } = options ?? {}
+    return ipcRenderer.invoke('tab:command:openTool', {
+      toolId,
+      worktreePath,
+      options: commandOptions,
+      tabs,
+      activeTabId,
+    })
+  },
+  tabRestartPane: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+      tabs?: unknown
+      activeTabId?: string | null
+    },
+  ) => {
+    const { tabs, activeTabId, ...commandOptions } = options ?? {}
+    return ipcRenderer.invoke('tab:command:restartPane', {
+      worktreePath,
+      tabId,
+      paneId,
+      options: commandOptions,
+      tabs,
+      activeTabId,
+    })
+  },
+  tabCloseTab: (
+    worktreePath: string,
+    tabId: string,
+    options?: { tabs?: unknown; activeTabId?: string | null },
+  ) =>
+    ipcRenderer.invoke('tab:command:closeTab', {
+      worktreePath,
+      tabId,
+      tabs: options?.tabs,
+      activeTabId: options?.activeTabId,
+    }),
+  tabSaveLayout: (worktreePath: string, layoutJson: string, workspaceId?: string) =>
+    ipcRenderer.invoke('tab:command:saveLayout', { worktreePath, layoutJson, workspaceId }),
+  tabRestoreLayout: (
+    worktreePath: string,
+    layoutJson: string,
+    options?: { tabs?: unknown; activeTabId?: string | null },
+  ) =>
+    ipcRenderer.invoke('tab:command:restoreLayout', {
+      worktreePath,
+      layoutJson,
+      tabs: options?.tabs,
+      activeTabId: options?.activeTabId,
+    }),
 
   agentSendTaskContext: (payload: { text: string; worktreePath?: string }) =>
     ipcRenderer.invoke('agent:command:sendTaskContext', payload),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -56,6 +56,19 @@ const api = {
     ipcRenderer.invoke('db:workspace:upsert', workspace),
   removeWorkspace: (id: string) => ipcRenderer.invoke('db:workspace:remove', { id }),
   touchWorkspace: (id: string) => ipcRenderer.invoke('db:workspace:touch', { id }),
+  workspaceRestoreWindow: (payload: {
+    paths: string[]
+    activeWorktreePath?: string
+    removedPaths?: string[]
+  }) => ipcRenderer.invoke('workspace:command:restoreWindow', payload),
+  workspaceAttachProject: (path: string) =>
+    ipcRenderer.invoke('workspace:command:attachProject', { path }),
+  workspaceDetachProject: (path: string) =>
+    ipcRenderer.invoke('workspace:command:detachProject', { path }),
+  workspaceSelectWorktree: (path: string) =>
+    ipcRenderer.invoke('workspace:command:selectWorktree', { path }),
+  workspaceInitGitRepo: (path: string) =>
+    ipcRenderer.invoke('workspace:command:initGitRepo', { path }),
 
   // Preferences
   getPref: (key: string) => ipcRenderer.invoke('db:prefs:get', { key }),
@@ -108,6 +121,26 @@ const api = {
       category?: string
     },
   ) => ipcRenderer.invoke('tools:updateCustom', { id, changes }),
+  tabOpenTool: (
+    toolId: string,
+    worktreePath: string,
+    options?: { initialUrl?: string; profileId?: string },
+  ) => ipcRenderer.invoke('tab:command:openTool', { toolId, worktreePath, options }),
+  tabRestartPane: (worktreePath: string, tabId: string, paneId: string) =>
+    ipcRenderer.invoke('tab:command:restartPane', { worktreePath, tabId, paneId }),
+  tabCloseTab: (worktreePath: string, tabId: string) =>
+    ipcRenderer.invoke('tab:command:closeTab', { worktreePath, tabId }),
+  tabSaveLayout: (worktreePath: string, layoutJson: string) =>
+    ipcRenderer.invoke('tab:command:saveLayout', { worktreePath, layoutJson }),
+  tabRestoreLayout: (worktreePath: string, layoutJson: string) =>
+    ipcRenderer.invoke('tab:command:restoreLayout', { worktreePath, layoutJson }),
+
+  agentSendTaskContext: (payload: { text: string; worktreePath?: string }) =>
+    ipcRenderer.invoke('agent:command:sendTaskContext', payload),
+  agentSendReviewContext: (payload: { text: string; worktreePath?: string }) =>
+    ipcRenderer.invoke('agent:command:sendReviewContext', payload),
+  agentSendDrawing: (payload: { pngBase64: string; worktreePath?: string }) =>
+    ipcRenderer.invoke('agent:command:sendDrawing', payload),
 
   // Skills
   listSkills: (opts?: { scope?: string; agent?: string; workspaceId?: string | null }) =>
@@ -1019,6 +1052,9 @@ const api = {
       sessionId: string
       wsUrl: string
     }>,
+  runConfigExecuteCommand: (configDir: string, name: string, cwd: string) =>
+    ipcRenderer.invoke('runConfig:command:execute', { configDir, name, cwd }),
+  runConfigListRunning: () => ipcRenderer.invoke('runConfig:command:listRunning'),
   onRunConfigPostRunResult: (
     callback: (data: { success: boolean; command: string; exitCode?: number }) => void,
   ) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -185,11 +185,11 @@ const api = {
       activeTabId: options?.activeTabId,
     }),
 
-  agentSendTaskContext: (payload: { text: string; worktreePath?: string }) =>
+  agentSendTaskContext: (payload: { text: string; worktreePath?: string; sessionId?: string }) =>
     ipcRenderer.invoke('agent:command:sendTaskContext', payload),
-  agentSendReviewContext: (payload: { text: string; worktreePath?: string }) =>
+  agentSendReviewContext: (payload: { text: string; worktreePath?: string; sessionId?: string }) =>
     ipcRenderer.invoke('agent:command:sendReviewContext', payload),
-  agentSendDrawing: (payload: { pngBase64: string; worktreePath?: string }) =>
+  agentSendDrawing: (payload: { pngBase64?: string; worktreePath?: string; sessionId?: string }) =>
     ipcRenderer.invoke('agent:command:sendDrawing', payload),
 
   // Skills

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -172,23 +172,12 @@ const api = {
     ipcRenderer.invoke('tab:command:saveLayout', { worktreePath, layoutJson }),
   tabDeleteLayout: (worktreePath: string) =>
     ipcRenderer.invoke('tab:command:deleteLayout', { worktreePath }),
-  tabRestoreLayout: (
-    worktreePath: string,
-    layoutJson: string,
-    options?: { tabs?: unknown; activeTabId?: string | null },
-  ) =>
-    ipcRenderer.invoke('tab:command:restoreLayout', {
-      worktreePath,
-      layoutJson,
-      tabs: options?.tabs,
-      activeTabId: options?.activeTabId,
-    }),
 
   agentSendTaskContext: (payload: { text: string; worktreePath?: string; sessionId?: string }) =>
     ipcRenderer.invoke('agent:command:sendTaskContext', payload),
   agentSendReviewContext: (payload: { text: string; worktreePath?: string; sessionId?: string }) =>
     ipcRenderer.invoke('agent:command:sendReviewContext', payload),
-  agentSendDrawing: (payload: { pngBase64?: string; worktreePath?: string; sessionId?: string }) =>
+  agentSendDrawing: (payload: { worktreePath?: string; sessionId?: string }) =>
     ipcRenderer.invoke('agent:command:sendDrawing', payload),
 
   // Skills
@@ -1084,11 +1073,6 @@ const api = {
     ipcRenderer.invoke('runConfig:updateConfig', { configDir, name, configuration }),
   runConfigDeleteConfig: (configDir: string, name: string) =>
     ipcRenderer.invoke('runConfig:deleteConfig', { configDir, name }),
-  runConfigExecute: (configDir: string, name: string, cwd?: string) =>
-    ipcRenderer.invoke('runConfig:execute', { configDir, name, cwd }) as Promise<{
-      sessionId: string
-      wsUrl: string
-    }>,
   runConfigExecuteCommand: (configDir: string, name: string, cwd: string) =>
     ipcRenderer.invoke('runConfig:command:execute', { configDir, name, cwd }),
   runConfigListRunning: () => ipcRenderer.invoke('runConfig:command:listRunning'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,8 +10,6 @@ import type { AgentType } from '../main/agents/types'
 
 const api = {
   // PTY
-  spawnPty: (options?: { cols?: number; rows?: number; cwd?: string }) =>
-    ipcRenderer.invoke('pty:spawn', options),
   resizePty: (sessionId: string, cols: number, rows: number) =>
     ipcRenderer.invoke('pty:resize', { sessionId, cols, rows }),
   killPty: (sessionId: string, killTmux?: boolean) =>
@@ -87,18 +85,6 @@ const api = {
   listTools: () => ipcRenderer.invoke('tools:list'),
   getTool: (id: string) => ipcRenderer.invoke('tools:get', { id }),
   checkToolAvailability: () => ipcRenderer.invoke('tools:checkAvailability'),
-  spawnTool: (
-    toolId: string,
-    worktreePath: string,
-    options?: {
-      cols?: number
-      rows?: number
-      workspaceName?: string
-      branch?: string
-      resumeSessionId?: string
-      profileId?: string
-    },
-  ) => ipcRenderer.invoke('tool:spawn', { toolId, worktreePath, ...options }),
   addCustomTool: (tool: {
     id: string
     name: string
@@ -171,8 +157,21 @@ const api = {
       tabs: options?.tabs,
       activeTabId: options?.activeTabId,
     }),
-  tabSaveLayout: (worktreePath: string, layoutJson: string, workspaceId?: string) =>
-    ipcRenderer.invoke('tab:command:saveLayout', { worktreePath, layoutJson, workspaceId }),
+  tabSpawnPane: (
+    toolId: string,
+    worktreePath: string,
+    options?: {
+      initialUrl?: string
+      profileId?: string
+      workspaceName?: string
+      branch?: string
+      resumeSessionId?: string
+    },
+  ) => ipcRenderer.invoke('tab:command:spawnPane', { toolId, worktreePath, options }),
+  tabSaveLayout: (worktreePath: string, layoutJson: string) =>
+    ipcRenderer.invoke('tab:command:saveLayout', { worktreePath, layoutJson }),
+  tabDeleteLayout: (worktreePath: string) =>
+    ipcRenderer.invoke('tab:command:deleteLayout', { worktreePath }),
   tabRestoreLayout: (
     worktreePath: string,
     layoutJson: string,
@@ -563,15 +562,6 @@ const api = {
   runWorktreeSetup: (workspaceId: string, repoRoot: string, newWorktreePath: string) =>
     ipcRenderer.invoke('worktree:runSetup', { workspaceId, repoRoot, newWorktreePath }),
   abortWorktreeSetup: () => ipcRenderer.send('worktree:abortSetup'),
-
-  // Layouts
-  saveLayout: (workspaceId: string, worktreePath: string, layoutJson: string) =>
-    ipcRenderer.invoke('layout:save', { workspaceId, worktreePath, layoutJson }),
-  getLayout: (workspaceId: string, worktreePath: string) =>
-    ipcRenderer.invoke('layout:get', { workspaceId, worktreePath }),
-  getAllLayouts: (workspaceId: string) => ipcRenderer.invoke('layout:getAll', { workspaceId }),
-  deleteLayout: (workspaceId: string, worktreePath: string) =>
-    ipcRenderer.invoke('layout:delete', { workspaceId, worktreePath }),
 
   // Push events (main → renderer)
   onAgentHookEvent: (
@@ -1046,6 +1036,7 @@ const api = {
     ? {
         perfDiagnostics: () => ipcRenderer.invoke('perf:diagnostics'),
         perfIpcLog: () => ipcRenderer.invoke('perf:ipcLog'),
+        perfOpenProject: (path: string) => ipcRenderer.invoke('perf:openProject', { path }),
       }
     : {}),
 

--- a/src/renderer/src/components/dashboard/WelcomeDashboard.svelte
+++ b/src/renderer/src/components/dashboard/WelcomeDashboard.svelte
@@ -101,7 +101,13 @@
       placeholder: '/path/to/project',
       submitLabel: 'Open',
     })
-    if (result) openWorkspace(result.value)
+    if (!result) return
+    try {
+      const path = await window.api.confirmOpenPath(result.value)
+      if (path) openWorkspace(path)
+    } catch (err) {
+      addToast(`Failed to open path: ${err instanceof Error ? err.message : String(err)}`)
+    }
   }
 
   function handleContextMenu(e: MouseEvent, ws: WorkspaceRow): void {

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -5,7 +5,6 @@
   import { Search, RotateCw, ChevronRight, Copy } from 'lucide-svelte'
   import { getAiSessions, focusSessionByPtyId } from '../../lib/stores/tabs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
-  import { wrapAsBracketedPaste } from '../../lib/pty/paste'
   import type { DiffChange, DiffFile } from '../../lib/types/diff'
 
   let {
@@ -322,7 +321,7 @@
     return ''
   }
 
-  function sendComment(): void {
+  async function sendComment(): Promise<void> {
     if (!commentText.trim()) return
     const sessions = getAiSessions(worktreePath)
     if (sessions.length === 0) return
@@ -340,11 +339,12 @@
       '---',
     ].join('\n')
 
-    window.api.writePty(sessions[0].sessionId, wrapAsBracketedPaste(message) + '\r')
-    focusSessionByPtyId(sessions[0].sessionId)
+    const sessionId = sessions[0].sessionId
+    await window.api.agentSendReviewContext({ text: message, worktreePath, sessionId })
+    focusSessionByPtyId(sessionId)
     window.dispatchEvent(
       new CustomEvent('canopy:focus-terminal', {
-        detail: { sessionId: sessions[0].sessionId },
+        detail: { sessionId },
       }),
     )
     closeComment()

--- a/src/renderer/src/components/drawing/drawingActions.ts
+++ b/src/renderer/src/components/drawing/drawingActions.ts
@@ -74,7 +74,7 @@ export async function sendToAgent(
 
   // OS pasteboard write is async on macOS; fast follow-up Ctrl+V can race it
   await new Promise((resolve) => setTimeout(resolve, 250))
-  await window.api.writePty(result.pane.sessionId, '\x16')
+  await window.api.agentSendDrawing({ sessionId: result.pane.sessionId })
   addToast(`Sent to ${result.pane.toolName}`)
 }
 

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -12,7 +12,6 @@
   import { fetchAndFormatTaskContext } from '../../lib/taskTracker/taskContext'
   import { setActiveTask } from '../../lib/stores/taskTracker.svelte'
   import { safeDirName } from '../../lib/sanitize'
-  import { wrapAsBracketedPaste } from '../../lib/pty/paste'
 
   interface Task {
     key: string
@@ -170,7 +169,11 @@
                 taskSnapshot,
                 workspaceState.repoRoot ?? undefined,
               )
-              await window.api.writePty(sessionId, wrapAsBracketedPaste(context) + '\r')
+              await window.api.agentSendTaskContext({
+                text: context,
+                worktreePath,
+                sessionId,
+              })
             }
           }
         } catch {

--- a/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
@@ -8,7 +8,6 @@
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import { getActiveAgentPane, switchTab } from '../../lib/stores/tabs.svelte'
   import { fetchAndFormatTaskContext } from '../../lib/taskTracker/taskContext'
-  import { wrapAsBracketedPaste } from '../../lib/pty/paste'
   import BranchCreateForm from './BranchCreateForm.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
@@ -260,7 +259,11 @@
       workspaceState.repoRoot ?? undefined,
     )
     await switchTab(result.tabId)
-    await window.api.writePty(result.pane.sessionId, wrapAsBracketedPaste(context) + '\r')
+    await window.api.agentSendTaskContext({
+      text: context,
+      worktreePath: workspaceState.selectedWorktreePath ?? undefined,
+      sessionId: result.pane.sessionId,
+    })
     addToast('Task sent to agent')
     closeDialog()
   }

--- a/src/renderer/src/lib/stores/runConfig.svelte.ts
+++ b/src/renderer/src/lib/stores/runConfig.svelte.ts
@@ -123,20 +123,11 @@ export async function deleteRunConfig(configDir: string, name: string): Promise<
   await discoverConfigs()
 }
 
-function getGlobalRunningCount(configDir: string, name: string): number {
-  let count = 0
-  for (const proc of runningProcesses.values()) {
-    if (proc.configDir === configDir && proc.name === name) count++
+function hydrateRunningProcesses(snapshots: RunningProcess[]): void {
+  runningProcesses.clear()
+  for (const snapshot of snapshots) {
+    runningProcesses.set(snapshot.sessionId, snapshot)
   }
-  return count
-}
-
-function findConfigEntry(configDir: string, name: string): RunConfiguration | undefined {
-  for (const source of sources) {
-    if (source.configDir !== configDir) continue
-    return source.file.configurations.find((c) => c.name === name)
-  }
-  return undefined
 }
 
 export async function executeRunConfig(
@@ -144,25 +135,11 @@ export async function executeRunConfig(
   name: string,
 ): Promise<{ sessionId: string; wsUrl: string } | null> {
   try {
-    const config = findConfigEntry(configDir, name)
-    const maxInstances = config?.max_instances ?? 0
-    if (maxInstances > 0) {
-      const current = getGlobalRunningCount(configDir, name)
-      if (current >= maxInstances) {
-        addToast(`"${name}" is already running (max ${maxInstances})`)
-        return null
-      }
-    }
     const cwd = workspaceState.selectedWorktreePath
     if (!cwd) return null
-    const result = await window.api.runConfigExecute(configDir, name, cwd)
-    runningProcesses.set(result.sessionId, {
-      sessionId: result.sessionId,
-      name,
-      configDir,
-      worktreePath: cwd,
-    })
-    return result
+    const result = await window.api.runConfigExecuteCommand(configDir, name, cwd)
+    hydrateRunningProcesses(await window.api.runConfigListRunning())
+    return { sessionId: result.sessionId, wsUrl: result.wsUrl }
   } catch (e) {
     addToast(`Failed to run "${name}": ${e instanceof Error ? e.message : String(e)}`)
     return null
@@ -187,6 +164,10 @@ export function initBackgroundListener(): void {
     cleanupPty()
     cleanupPostRun()
   }
+  void window.api
+    .runConfigListRunning()
+    .then((snapshots) => hydrateRunningProcesses(snapshots))
+    .catch((e) => console.warn('Failed to list running run configs:', e))
 }
 
 export function cleanupBackgroundListener(): void {

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -1216,7 +1216,7 @@ export async function reattachTmuxPane(
     }))
   } else {
     // Tmux session gone, spawn fresh
-    const result = await window.api.spawnTool(pane.toolId, worktreePath)
+    const result = await window.api.tabSpawnPane(pane.toolId, worktreePath)
     tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({
       ...p,
       sessionId: result.sessionId,
@@ -1322,7 +1322,7 @@ export async function closeAllTabsForWorktree(worktreePath: string): Promise<voi
 
   const wsId = getProjectForWorktree(worktreePath)?.workspace.id
   if (wsId) {
-    window.api.deleteLayout(wsId, worktreePath).catch(() => {})
+    window.api.tabDeleteLayout(worktreePath).catch(() => {})
   }
 }
 
@@ -1546,7 +1546,7 @@ export async function splitFocusedPane(
   if (NO_SPLIT_TOOLS.has(tab.toolId)) return
 
   // Spawn a new shell session in the same worktree
-  const result = await window.api.spawnTool('shell', worktreePath)
+  const result = await window.api.tabSpawnPane('shell', worktreePath)
   const paneId = nextPaneId()
 
   const newPane: PaneSession = {
@@ -1966,7 +1966,7 @@ function saveLayoutForWorktree(worktreePath: string): void {
   }
 
   if (serializedTabs.length === 0) {
-    window.api.deleteLayout(wsId, worktreePath).catch(() => {
+    window.api.tabDeleteLayout(worktreePath).catch(() => {
       // Ignore delete errors silently
     })
     return
@@ -1977,7 +1977,7 @@ function saveLayoutForWorktree(worktreePath: string): void {
     activeTabIndex: adjustedActiveIndex,
   }
 
-  window.api.tabSaveLayout(worktreePath, JSON.stringify(layout), wsId).catch(() => {
+  window.api.tabSaveLayout(worktreePath, JSON.stringify(layout)).catch(() => {
     // Ignore save errors silently
   })
 }
@@ -2065,7 +2065,7 @@ async function restoreSplitNode(
         options.resumeSessionId = node.agentSessionId ?? node.claudeSessionId
         if (node.profileId) options.profileId = node.profileId
       }
-      const result = await window.api.spawnTool(node.toolId, worktreePath, options)
+      const result = await window.api.tabSpawnPane(node.toolId, worktreePath, options)
       const restoredProfile = node.profileId ? getProfileById(node.profileId) : undefined
       pane = {
         id: paneId,

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -30,6 +30,12 @@ import { browserSessions } from '../browser/browserState.svelte'
 import { notesUiScope } from './notes.svelte'
 import { getProfileById } from './profiles.svelte'
 import { drawingsState } from './drawings.svelte'
+import type {
+  PaneSnapshot,
+  SplitSnapshot,
+  TabCommandResult,
+  TabSnapshot,
+} from '../../../../main/commands/types'
 
 function hasRemainingDrawingPanes(excludeId: string): boolean {
   for (const tabs of Object.values(tabsByWorktree)) {
@@ -173,6 +179,122 @@ function computeDisplayName(
   return `${baseLabel} #${sameLabelCount + 1}`
 }
 
+function paneToSnapshot(pane: PaneSession): PaneSnapshot {
+  return {
+    id: pane.id,
+    sessionId: pane.sessionId,
+    wsUrl: pane.wsUrl,
+    toolId: pane.toolId,
+    toolName: pane.toolName,
+    isRunning: pane.isRunning,
+    exitCode: pane.exitCode,
+    title: pane.title,
+    paneType: pane.paneType,
+    tmuxSessionName: pane.tmuxSessionName,
+    detached: pane.detached,
+    url: pane.url,
+    filePath: pane.filePath,
+    editorFiles: pane.editorFiles?.map((file) => ({ filePath: file.filePath })),
+    editorActiveFile: pane.editorActiveFile,
+    profileId: pane.profileId,
+    profileName: pane.profileName,
+  }
+}
+
+function splitToSnapshot(node: SplitNode): SplitSnapshot {
+  if (node.type === 'leaf') return { type: 'leaf', pane: paneToSnapshot(node.pane) }
+  return {
+    type: 'split',
+    direction: node.type === 'hsplit' ? 'horizontal' : 'vertical',
+    ratio: node.ratio,
+    first: splitToSnapshot(node.first),
+    second: splitToSnapshot(node.second),
+  }
+}
+
+function tabToSnapshot(tab: TabInfo): TabSnapshot {
+  return {
+    id: tab.id,
+    toolId: tab.toolId,
+    toolName: tab.toolName,
+    name: tab.name,
+    worktreePath: tab.worktreePath,
+    rootSplit: splitToSnapshot(tab.rootSplit),
+    focusedPaneId: tab.focusedPaneId,
+  }
+}
+
+function snapshotsForCommand(worktreePath: string): TabSnapshot[] {
+  return (tabsByWorktree[worktreePath] ?? []).map((tab) => tabToSnapshot(tab))
+}
+
+function paneFromSnapshot(snapshot: PaneSnapshot, previous?: PaneSession): PaneSession {
+  return {
+    ...previous,
+    id: snapshot.id,
+    sessionId: snapshot.sessionId,
+    wsUrl: snapshot.wsUrl,
+    toolId: snapshot.toolId,
+    toolName: snapshot.toolName,
+    isRunning: snapshot.isRunning,
+    exitCode: snapshot.exitCode,
+    title: snapshot.title,
+    paneType: snapshot.paneType,
+    filePath: snapshot.filePath ?? previous?.filePath,
+    url: snapshot.url,
+    tmuxSessionName: snapshot.tmuxSessionName,
+    detached: snapshot.detached,
+    profileId: snapshot.profileId,
+    profileName: snapshot.profileName,
+    editorFiles:
+      previous?.editorFiles ??
+      snapshot.editorFiles?.map((file) => ({
+        filePath: file.filePath,
+      })),
+    editorActiveFile: snapshot.editorActiveFile ?? previous?.editorActiveFile,
+  }
+}
+
+function splitFromSnapshot(snapshot: SplitSnapshot): SplitNode {
+  if (snapshot.type === 'leaf') return createLeaf(paneFromSnapshot(snapshot.pane))
+  return {
+    type: snapshot.direction === 'horizontal' ? 'hsplit' : 'vsplit',
+    id: `split-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    ratio: snapshot.ratio,
+    first: splitFromSnapshot(snapshot.first),
+    second: splitFromSnapshot(snapshot.second),
+  }
+}
+
+function tabFromSnapshot(snapshot: TabSnapshot): TabInfo {
+  return {
+    id: snapshot.id,
+    toolId: snapshot.toolId,
+    toolName: snapshot.toolName,
+    name: snapshot.name,
+    worktreePath: snapshot.worktreePath,
+    rootSplit: splitFromSnapshot(snapshot.rootSplit),
+    focusedPaneId: snapshot.focusedPaneId,
+  }
+}
+
+function initPaneRuntimeState(pane: PaneSession): void {
+  if (isAiToolId(pane.toolId) && pane.isRunning) {
+    initAgentSession(pane.sessionId, pane.toolId as AgentType)
+  }
+}
+
+function applyOpenedTabResult(result: TabCommandResult): TabInfo | null {
+  const snapshot = result.openedTab
+  if (!snapshot) return null
+  const tab = tabFromSnapshot(snapshot)
+  if (!tabsByWorktree[result.worktreePath]) tabsByWorktree[result.worktreePath] = []
+  tabsByWorktree[result.worktreePath].push(tab)
+  activeTabId[result.worktreePath] = result.activeTabId ?? tab.id
+  for (const pane of allPanes(tab.rootSplit)) initPaneRuntimeState(pane)
+  return tab
+}
+
 export function getActiveAgentPane(): { pane: PaneSession; tabId: string } | null {
   const path = workspaceState.selectedWorktreePath
   if (!path) return null
@@ -205,92 +327,17 @@ export async function openTool(
   worktreePath: string,
   options?: { initialUrl?: string; profileId?: string },
 ): Promise<TabInfo> {
-  let pane: PaneSession
-  const paneId = nextPaneId()
-  let toolName: string
-  let profileName: string | undefined
-
-  if (toolId === 'browser') {
-    const browserId = crypto.randomUUID()
-    toolName = 'Browser'
-    pane = {
-      id: paneId,
-      sessionId: browserId,
-      wsUrl: '',
-      toolId,
-      toolName,
-      isRunning: true,
-      exitCode: null,
-      title: null,
-      paneType: 'browser',
-      url: options?.initialUrl,
-    }
-  } else if (toolId === 'notes' || toolId === 'drawing') {
-    toolName = toolId === 'notes' ? 'Notes' : 'Drawing'
-    pane = {
-      id: paneId,
-      sessionId: crypto.randomUUID(),
-      wsUrl: '',
-      toolId,
-      toolName,
-      isRunning: true,
-      exitCode: null,
-      title: null,
-      paneType: toolId,
-    }
-  } else {
-    const spawnOptions: {
-      workspaceName?: string
-      branch?: string
-      profileId?: string
-    } = {}
-    if (AI_TOOL_IDS.has(toolId)) {
-      const project = getProjectForWorktree(worktreePath)
-      spawnOptions.workspaceName = project?.workspace.name ?? workspaceState.workspace?.name ?? ''
-      spawnOptions.branch = workspaceState.branch ?? undefined
-      if (options?.profileId) {
-        spawnOptions.profileId = options.profileId
-        profileName = getProfileById(options.profileId)?.name
-      }
-    }
-    const result = await window.api.spawnTool(toolId, worktreePath, spawnOptions)
-    toolName = result.toolName
-    pane = {
-      id: paneId,
-      sessionId: result.sessionId,
-      wsUrl: result.wsUrl,
-      toolId,
-      toolName,
-      isRunning: true,
-      exitCode: null,
-      title: null,
-      tmuxSessionName: result.tmuxSessionName,
-      profileId: options?.profileId,
-      profileName,
-    }
-    if (AI_TOOL_IDS.has(toolId)) {
-      initAgentSession(result.sessionId, toolId as AgentType)
-    }
-  }
-
-  const id = nextTabId()
-  const name = computeDisplayName(toolName, worktreePath, toolId, profileName)
-
-  const tab: TabInfo = {
-    id,
-    toolId,
-    toolName,
-    name,
-    worktreePath,
-    rootSplit: createLeaf(pane),
-    focusedPaneId: paneId,
-  }
-
-  if (!tabsByWorktree[worktreePath]) {
-    tabsByWorktree[worktreePath] = []
-  }
-  tabsByWorktree[worktreePath].push(tab)
-  activeTabId[worktreePath] = id
+  const project = getProjectForWorktree(worktreePath)
+  const result = await window.api.tabOpenTool(toolId, worktreePath, {
+    initialUrl: options?.initialUrl,
+    profileId: options?.profileId,
+    workspaceName: project?.workspace.name ?? workspaceState.workspace?.name ?? '',
+    branch: workspaceState.branch ?? undefined,
+    tabs: snapshotsForCommand(worktreePath),
+    activeTabId: activeTabId[worktreePath] ?? null,
+  })
+  const tab = applyOpenedTabResult(result)
+  if (!tab) throw new Error('tab:command:openTool did not return an opened tab')
 
   scheduleSave(worktreePath)
   return tab
@@ -507,16 +554,10 @@ export async function closeTab(tabId: string): Promise<void> {
       }
       disposeEphemeralPaneState(p)
     }
-    await Promise.all(
-      panes
-        .filter(
-          (p) => p.paneType !== 'editor' && p.paneType !== 'notes' && p.paneType !== 'drawing',
-        )
-        .map((p) => {
-          if (p.paneType === 'browser') return window.api.teardownBrowserWebview(p.sessionId)
-          return window.api.killPty(p.sessionId, !!p.tmuxSessionName)
-        }),
-    )
+    await window.api.tabCloseTab(path, tabId, {
+      tabs: snapshotsForCommand(path),
+      activeTabId: activeTabId[path] ?? null,
+    })
 
     // Remove tab
     tabsByWorktree[path].splice(idx, 1)
@@ -1124,87 +1165,27 @@ export async function restartPane(
   const pane = panes.find((p) => p.id === paneId)
   if (!pane) return
 
-  await match(pane)
-    .with({ paneType: 'editor' }, () => {
-      // Editor panes have no session to restart. The component re-reads on mount.
-    })
-    .with({ paneType: 'browser' }, async (p) => {
-      const oldUrl = p.url
-      try {
-        await window.api.teardownBrowserWebview(p.sessionId)
-      } catch {
-        // Already destroyed
-      }
-      const newBrowserId = crypto.randomUUID()
-      tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (prev) => ({
-        ...prev,
-        sessionId: newBrowserId,
-        url: oldUrl,
-        isRunning: true,
-        exitCode: null,
-        title: null,
-      }))
-    })
-    .when(
-      (p) => !!(p.tmuxSessionName && p.detached),
-      async (p) => {
-        const exists = await window.api.tmuxHasSession(p.tmuxSessionName!)
-        if (exists) {
-          const result = await window.api.tmuxAttach(p.tmuxSessionName!)
-          tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (prev) => ({
-            ...prev,
-            sessionId: result.sessionId,
-            wsUrl: result.wsUrl,
-            isRunning: true,
-            exitCode: null,
-            detached: false,
-          }))
-        } else {
-          const result = await window.api.spawnTool(p.toolId, worktreePath)
-          tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (prev) => ({
-            ...prev,
-            sessionId: result.sessionId,
-            wsUrl: result.wsUrl,
-            isRunning: true,
-            exitCode: null,
-            detached: false,
-            tmuxSessionName: result.tmuxSessionName,
-          }))
-        }
-      },
-    )
-    .otherwise(async (p) => {
-      try {
-        await window.api.killPty(p.sessionId)
-      } catch {
-        // Already exited or cleaned up
-      }
+  const project = getProjectForWorktree(worktreePath)
+  const result = await window.api.tabRestartPane(worktreePath, tabId, paneId, {
+    workspaceName: project?.workspace.name ?? workspaceState.workspace?.name ?? '',
+    branch: workspaceState.branch ?? undefined,
+    tabs: snapshotsForCommand(worktreePath),
+    activeTabId: activeTabId[worktreePath] ?? null,
+  })
+  if (!result.restartedPane) return
 
-      if (AI_TOOL_IDS.has(p.toolId)) {
-        removeAgentSession(p.sessionId)
-      }
+  if (AI_TOOL_IDS.has(pane.toolId) && pane.sessionId !== result.restartedPane.sessionId) {
+    removeAgentSession(pane.sessionId)
+  }
+  if (pane.paneType === 'browser' && pane.sessionId !== result.restartedPane.sessionId) {
+    delete browserSessions[pane.sessionId]
+  }
 
-      const options: { workspaceName?: string; branch?: string } = {}
-      if (AI_TOOL_IDS.has(p.toolId)) {
-        options.workspaceName = workspaceState.workspace?.name ?? ''
-        options.branch = workspaceState.branch ?? undefined
-      }
-      const result = await window.api.spawnTool(p.toolId, worktreePath, options)
-
-      if (AI_TOOL_IDS.has(p.toolId)) {
-        initAgentSession(result.sessionId, p.toolId as AgentType)
-      }
-
-      tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (prev) => ({
-        ...prev,
-        sessionId: result.sessionId,
-        wsUrl: result.wsUrl,
-        isRunning: true,
-        exitCode: null,
-        title: null,
-        tmuxSessionName: result.tmuxSessionName,
-      }))
-    })
+  tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (prev) => {
+    const next = paneFromSnapshot(result.restartedPane!, prev)
+    initPaneRuntimeState(next)
+    return next
+  })
 
   scheduleSave(worktreePath)
 }
@@ -1996,7 +1977,7 @@ function saveLayoutForWorktree(worktreePath: string): void {
     activeTabIndex: adjustedActiveIndex,
   }
 
-  window.api.saveLayout(wsId, worktreePath, JSON.stringify(layout)).catch(() => {
+  window.api.tabSaveLayout(worktreePath, JSON.stringify(layout), wsId).catch(() => {
     // Ignore save errors silently
   })
 }

--- a/src/renderer/src/lib/stores/workspace.svelte.ts
+++ b/src/renderer/src/lib/stores/workspace.svelte.ts
@@ -8,10 +8,11 @@ import {
 import { addToast } from './toast.svelte'
 import { clearQuickOpenCache } from './quickOpenStore.svelte'
 import { clearMru } from './quickOpenMru.svelte'
-
-function basename(p: string): string {
-  return p.split('/').pop() || p
-}
+import type {
+  ProjectSnapshot,
+  WorkspaceCommandResult,
+  WorkspaceStateSnapshot,
+} from '../../../../main/commands/types'
 
 // --- Types ---
 
@@ -49,17 +50,6 @@ export interface ProjectState {
   isGitRepo: boolean
   repoRoot: string | null
   worktrees: GitWorktreeInfo[]
-}
-
-interface AttachProjectOptions {
-  selectIfEmpty?: boolean
-  batchOrder?: Map<string, number>
-  restoreIndex?: number
-}
-
-interface AttachProjectResult {
-  projectPath: string
-  defaultWorktreePath: string
 }
 
 interface WorkspaceState {
@@ -110,7 +100,13 @@ export const projects: ProjectState[] = $state([])
 let attachQueue: Promise<void> = Promise.resolve()
 
 export async function attachProject(path: string): Promise<void> {
-  const result = attachQueue.then(() => attachProjectImpl(path))
+  const result = attachQueue.then(async () => {
+    const commandResult = await window.api.workspaceAttachProject(path)
+    await applyWorkspaceCommandResult(commandResult)
+    if (commandResult.workspaceState.selectedWorktreePath) {
+      await hydrateSelectedWorktree(commandResult.workspaceState.selectedWorktreePath)
+    }
+  })
   attachQueue = result
     .then(() => undefined)
     .catch((err) => {
@@ -124,9 +120,17 @@ export async function restoreProjects(
   activeWorktreePath?: string,
   removedPaths?: string[],
 ): Promise<void> {
-  const result = attachQueue.then(() =>
-    restoreProjectsImpl(paths, activeWorktreePath, removedPaths),
-  )
+  const result = attachQueue.then(async () => {
+    const commandResult = await window.api.workspaceRestoreWindow({
+      paths,
+      activeWorktreePath,
+      removedPaths,
+    })
+    await applyWorkspaceCommandResult(commandResult)
+    if (commandResult.workspaceState.selectedWorktreePath) {
+      await hydrateSelectedWorktree(commandResult.workspaceState.selectedWorktreePath)
+    }
+  })
   attachQueue = result
     .then(() => undefined)
     .catch((err) => {
@@ -139,213 +143,88 @@ function getProjectKey(project: ProjectState): string {
   return project.repoRoot ?? project.workspace.path
 }
 
-function getDefaultWorktreePath(project: ProjectState): string {
-  if (!project.isGitRepo) return project.workspace.path
-  const main = project.worktrees.find((wt) => wt.isMain)
-  return main?.path ?? project.repoRoot ?? project.workspace.path
-}
-
-function reorderProjects(batchOrder: Map<string, number>): void {
-  const before = projects.length
-  const ordered = [...projects]
-    .map((project, index) => ({
-      project,
-      index,
-      order: batchOrder.get(getProjectKey(project)),
-    }))
-    .sort((a, b) => {
-      if (a.order === undefined && b.order === undefined) return a.index - b.index
-      if (a.order === undefined) return 1
-      if (b.order === undefined) return -1
-      if (a.order !== b.order) return a.order - b.order
-      return a.index - b.index
-    })
-    .map((entry) => entry.project)
-
-  projects.splice(0, projects.length, ...ordered)
-  if (projects.length !== before) {
-    console.error(
-      `[workspace] reorder lost projects: ${before} -> ${projects.length}`,
-      ordered.map(getProjectKey),
-    )
+function projectFromSnapshot(project: ProjectSnapshot): ProjectState {
+  return {
+    workspace: project.workspace,
+    isGitRepo: project.isGitRepo,
+    repoRoot: project.repoRoot,
+    worktrees: project.worktrees,
   }
 }
 
-async function restoreProjectsImpl(
-  paths: string[],
-  activeWorktreePath?: string,
-  removedPaths?: string[],
-): Promise<void> {
-  if (removedPaths && removedPaths.length > 0) {
-    // Show basename when unique, otherwise include parent dir so colliding
-    // names stay distinguishable (e.g. "src/foo/project" vs "home/bar/project").
-    const basenames = removedPaths.map(basename)
-    const hasCollision = new Set(basenames).size !== basenames.length
-    const labels = hasCollision
-      ? removedPaths.map((p) => {
-          const parts = p.split('/').filter(Boolean)
-          return parts.slice(-2).join('/') || p
-        })
-      : basenames
-    const plural = removedPaths.length === 1 ? 'project' : 'projects'
-    addToast(
-      `Removed ${removedPaths.length} stale ${plural} (folder missing): ${labels.join(', ')}`,
-    )
-  }
-
-  const uniquePaths = [...new Set(paths)]
-  if (uniquePaths.length === 0) {
-    if (activeWorktreePath) await selectWorktree(activeWorktreePath)
+function applyWorkspaceStateSnapshot(snapshot: WorkspaceStateSnapshot): void {
+  if (!snapshot.project) {
+    workspaceState.workspace = null
+    workspaceState.isGitRepo = false
+    workspaceState.repoRoot = null
+    workspaceState.worktrees = []
+    workspaceState.selectedWorktreePath = snapshot.selectedWorktreePath
+    workspaceState.branch = snapshot.branch
+    workspaceState.isDirty = snapshot.isDirty
+    workspaceState.aheadBehind = snapshot.aheadBehind
     return
   }
 
-  const batchOrder = new Map<string, number>()
-  const settled = await Promise.allSettled(
-    uniquePaths.map((path, index) =>
-      attachProjectImpl(path, {
-        selectIfEmpty: false,
-        batchOrder,
-        restoreIndex: index,
-      }),
-    ),
-  )
-  const results = settled.map((s) => (s.status === 'fulfilled' ? s.value : undefined))
-  const failures: string[] = []
-  const skipped: string[] = []
-  for (let i = 0; i < settled.length; i++) {
-    const s = settled[i]
-    if (s.status === 'rejected') {
-      console.error(`[workspace] failed to restore project "${uniquePaths[i]}":`, s.reason)
-      failures.push(uniquePaths[i].split('/').pop() || uniquePaths[i])
-    } else if (!s.value) {
-      skipped.push(uniquePaths[i])
+  const key = snapshot.project.repoRoot ?? snapshot.project.workspace.path
+  const project = projects.find((candidate) => getProjectKey(candidate) === key)
+
+  workspaceState.workspace = project?.workspace ?? snapshot.project.workspace
+  workspaceState.isGitRepo = project?.isGitRepo ?? snapshot.project.isGitRepo
+  workspaceState.repoRoot = project?.repoRoot ?? snapshot.project.repoRoot
+  workspaceState.worktrees = project?.worktrees ?? snapshot.project.worktrees
+  workspaceState.selectedWorktreePath = snapshot.selectedWorktreePath
+  workspaceState.branch = snapshot.branch
+  workspaceState.isDirty = snapshot.isDirty
+  workspaceState.aheadBehind = snapshot.aheadBehind
+}
+
+async function loadRepoConfigsForNewProjects(existingKeys: Set<string>): Promise<void> {
+  for (const project of projects) {
+    const projectKey = getProjectKey(project)
+    if (existingKeys.has(projectKey) || !project.repoRoot) continue
+
+    try {
+      await loadRepoConfig(project.repoRoot)
+      if (getRepoConfig()?.trackers.length && !hasAnyCredentials()) {
+        addToast('Tracker requires authentication - configure token in Preferences')
+      }
+    } catch (err) {
+      console.error(`[workspace] loadRepoConfig failed for "${projectKey}":`, err)
     }
-  }
-  if (skipped.length > 0) {
-    console.warn('[workspace] restore skipped (dedup/focus):', skipped)
-  }
-  console.debug(
-    `[workspace] restore done: ${results.filter(Boolean).length} ok, ${failures.length} failed, ${skipped.length} skipped, ${projects.length} in sidebar`,
-  )
-  if (failures.length > 0) {
-    addToast(`Failed to restore: ${failures.join(', ')}`)
-  }
-
-  let targetPath = activeWorktreePath
-  if (!targetPath || !getProjectForWorktree(targetPath)) {
-    targetPath = results.find((result) => result)?.defaultWorktreePath
-  }
-
-  if (targetPath) {
-    await selectWorktree(targetPath)
   }
 }
 
-async function attachProjectImpl(
-  path: string,
-  options: AttachProjectOptions = {},
-): Promise<AttachProjectResult | undefined> {
-  const { selectIfEmpty = true, batchOrder, restoreIndex } = options
-  // Dedupe: if another window already has this path, focus it instead
-  const focused = await window.api.focusWindowForPath(path)
-  if (focused) return
-
-  // Detect git info
-  const info: GitInfo = await window.api.gitDetect(path)
-  const projectPath = info.repoRoot ?? path
-
-  // Already attached in this window?
-  if (projects.some((p) => (p.repoRoot ?? p.workspace.path) === projectPath)) {
-    const existing = projects.find((p) => (p.repoRoot ?? p.workspace.path) === projectPath)
-    if (!existing) return
-    return {
-      projectPath,
-      defaultWorktreePath: getDefaultWorktreePath(existing),
+async function restoreCommandLayouts(result: WorkspaceCommandResult): Promise<void> {
+  for (const entry of result.restoredLayouts ?? []) {
+    try {
+      await restoreLayout(entry.worktreePath, entry.layoutJson)
+    } catch {
+      // Layout restore failed, will fall back to ensureDefaultTab.
     }
   }
+}
 
-  // Upsert workspace in DB
-  const name = basename(projectPath)
-  const ws = await window.api.upsertWorkspace({
-    path: projectPath,
-    name,
-    isGitRepo: info.isGitRepo,
-  })
-  await window.api.touchWorkspace(ws.id)
+async function applyWorkspaceCommandResult(
+  result: WorkspaceCommandResult,
+  options: { restoreLayouts?: boolean; loadNewProjectConfigs?: boolean } = {},
+): Promise<void> {
+  const { restoreLayouts = true, loadNewProjectConfigs = true } = options
+  const existingKeys = new Set(projects.map(getProjectKey))
 
-  // Register with main process for dedup + config persistence
-  await window.api.setWorkspacePath(projectPath)
-
-  // Add to projects
-  const project: ProjectState = {
-    workspace: ws,
-    isGitRepo: info.isGitRepo,
-    repoRoot: info.repoRoot,
-    worktrees: info.worktrees,
-  }
-  projects.push(project)
-  console.debug(`[workspace] attached "${name}" (${projectPath}), total: ${projects.length}`)
-  if (batchOrder && restoreIndex !== undefined) {
-    batchOrder.set(projectPath, restoreIndex)
-    reorderProjects(batchOrder)
+  for (const warning of result.warnings) {
+    addToast(warning.message)
   }
 
-  // Start git watcher if git repo
-  try {
-    if (info.isGitRepo && info.repoRoot) {
-      await window.api.gitWatch(info.repoRoot, info)
-    }
-  } catch (err) {
-    console.error(`[workspace] gitWatch failed for "${projectPath}":`, err)
-    addToast(`Git watcher failed for ${name} — status may not update`)
+  projects.splice(0, projects.length, ...result.projects.map(projectFromSnapshot))
+
+  if (restoreLayouts) {
+    await restoreCommandLayouts(result)
   }
 
-  // Auto-detect .canopy/config.json for task tracker
-  try {
-    if (info.repoRoot) {
-      await loadRepoConfig(info.repoRoot)
-      if (getRepoConfig()?.trackers.length && !hasAnyCredentials()) {
-        addToast('Tracker requires authentication — configure token in Preferences')
-      }
-    }
-  } catch (err) {
-    console.error(`[workspace] loadRepoConfig failed for "${projectPath}":`, err)
-  }
+  applyWorkspaceStateSnapshot(result.workspaceState)
 
-  // Restore saved layouts BEFORE selecting worktree so that ensureDefaultTab
-  // (triggered by selectWorktree) finds existing tabs and doesn't spawn extras
-  try {
-    const layouts = await window.api.getAllLayouts(ws.id)
-    if (layouts.length > 0) {
-      // Only restore layouts whose worktree_path belongs to this project
-      const ownedPaths = new Set(
-        info.isGitRepo ? info.worktrees.map((wt) => wt.path) : [projectPath],
-      )
-      for (const entry of layouts) {
-        if (ownedPaths.has(entry.worktree_path)) {
-          await restoreLayout(entry.worktree_path, entry.layout_json)
-        }
-      }
-      // Clean up cross-contaminated entries saved under wrong workspace ID
-      const stale = layouts.filter((e) => !ownedPaths.has(e.worktree_path))
-      for (const entry of stale) {
-        window.api.deleteLayout(ws.id, entry.worktree_path).catch(() => {})
-      }
-    }
-  } catch {
-    // Layout restore failed, will fall back to ensureDefaultTab
-  }
-
-  // Auto-select if this is the first project or no active selection
-  const defaultWorktreePath = getDefaultWorktreePath(project)
-
-  if (selectIfEmpty && !workspaceState.selectedWorktreePath) {
-    await selectWorktree(defaultWorktreePath)
-  }
-
-  return {
-    projectPath,
-    defaultWorktreePath,
+  if (loadNewProjectConfigs) {
+    await loadRepoConfigsForNewProjects(existingKeys)
   }
 }
 
@@ -380,30 +259,22 @@ export async function detachProject(path: string): Promise<void> {
     clearMru(wtPath)
   }
 
-  // Unwatch git
-  if (project.isGitRepo && project.repoRoot) {
-    await window.api.gitUnwatch(project.repoRoot)
-  }
-
-  // Unregister from main process
-  await window.api.detachProject(path)
+  const wasActive =
+    workspaceState.repoRoot === project.repoRoot ||
+    workspaceState.workspace?.id === project.workspace.id
+  const commandResult = await window.api.workspaceDetachProject(path)
 
   // Remove from array
   projects.splice(idx, 1)
+  await applyWorkspaceCommandResult(commandResult, {
+    restoreLayouts: false,
+    loadNewProjectConfigs: false,
+  })
 
-  // If active selection was in this project, fall back
-  if (
-    workspaceState.repoRoot === project.repoRoot ||
-    workspaceState.workspace?.id === project.workspace.id
-  ) {
-    if (projects.length > 0) {
-      const next = projects[0]
-      if (next.isGitRepo) {
-        const main = next.worktrees.find((wt) => wt.isMain)
-        await selectWorktree(main?.path ?? next.repoRoot ?? next.workspace.path)
-      } else {
-        await selectWorktree(next.workspace.path)
-      }
+  // Main owns fallback selection; renderer performs UI-only side effects for the returned selection.
+  if (wasActive) {
+    if (workspaceState.selectedWorktreePath) {
+      await hydrateSelectedWorktree(workspaceState.selectedWorktreePath)
     } else {
       workspaceState.workspace = null
       workspaceState.isGitRepo = false
@@ -430,30 +301,13 @@ export async function initGitRepo(projectPath: string): Promise<void> {
   const project = projects.find((p) => p.workspace.path === projectPath)
   if (!project || project.isGitRepo) return
 
-  const info: GitInfo = await window.api.gitInit(projectPath)
-  project.isGitRepo = info.isGitRepo
-  project.repoRoot = info.repoRoot
-  project.worktrees = info.worktrees
-
-  // Update workspace in DB
-  const ws = await window.api.upsertWorkspace({
-    path: info.repoRoot ?? projectPath,
-    name: project.workspace.name,
-    isGitRepo: info.isGitRepo,
+  const commandResult = await window.api.workspaceInitGitRepo(projectPath)
+  await applyWorkspaceCommandResult(commandResult, {
+    restoreLayouts: false,
+    loadNewProjectConfigs: false,
   })
-  project.workspace = ws
-
-  // Start git watcher
-  if (info.isGitRepo && info.repoRoot) {
-    await window.api.gitWatch(info.repoRoot, info)
-  }
-
-  // If this project is the active selection, update workspaceState
-  if (workspaceState.workspace?.id === ws.id) {
-    workspaceState.isGitRepo = info.isGitRepo
-    workspaceState.repoRoot = info.repoRoot
-    workspaceState.worktrees = info.worktrees
-    workspaceState.branch = info.branch
+  if (commandResult.workspaceState.selectedWorktreePath) {
+    await hydrateSelectedWorktree(commandResult.workspaceState.selectedWorktreePath)
   }
 }
 
@@ -461,7 +315,9 @@ export async function initGitRepo(projectPath: string): Promise<void> {
 export function getProjectForWorktree(wtPath: string): ProjectState | undefined {
   return projects.find(
     (p) =>
-      p.worktrees.some((wt) => wt.path === wtPath) || (!p.isGitRepo && p.workspace.path === wtPath),
+      p.worktrees.some((wt) => wt.path === wtPath) ||
+      p.repoRoot === wtPath ||
+      p.workspace.path === wtPath,
   )
 }
 
@@ -518,17 +374,15 @@ export async function openWorkspace(path: string): Promise<void> {
 }
 
 export async function selectWorktree(path: string): Promise<void> {
-  // Find which project owns this worktree
-  const project = getProjectForWorktree(path)
-  if (project) {
-    workspaceState.workspace = project.workspace
-    workspaceState.isGitRepo = project.isGitRepo
-    workspaceState.repoRoot = project.repoRoot
-    workspaceState.worktrees = project.worktrees
-  }
+  const commandResult = await window.api.workspaceSelectWorktree(path)
+  await applyWorkspaceCommandResult(commandResult, {
+    restoreLayouts: false,
+    loadNewProjectConfigs: false,
+  })
+  await hydrateSelectedWorktree(path)
+}
 
-  window.api.setActiveWorktree(path)
-  workspaceState.selectedWorktreePath = path
+async function hydrateSelectedWorktree(path: string): Promise<void> {
   await loadActiveTask(path)
 
   // Start (or restart) the file tree watcher for the newly active worktree.
@@ -540,6 +394,7 @@ export async function selectWorktree(path: string): Promise<void> {
     console.error(`[workspace] watchFiles failed for "${path}":`, err)
   }
 
+  const project = getProjectForWorktree(path)
   if (project?.isGitRepo) {
     const wt = project.worktrees.find((w) => w.path === path)
     if (wt) {


### PR DESCRIPTION
## What

Moves workspace, tab/session, agent context, run config, and related renderer mutation flows behind main-owned command services. Removes generic renderer-exposed spawn/layout IPC surfaces and validates sender-owned workspace/session state before privileged mutations.

## Why

The renderer should be close to read-only and should not compose privileged domain mutations directly. This tightens Electron process boundaries so filesystem, PTY, tmux, layout, and run-config mutations are owned and validated in the main process.

## How to test

1. Run `npm run lint`
2. Run `npm run typecheck`
3. Open a workspace and verify worktree selection, project attach/detach, opening tools, restarting/closing tabs, and run config execution still work.
4. With tmux enabled in dev, verify attach/detach and kill/rename behavior for Canopy sessions.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [ ] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly
- [x] Feature docs in `docs/` updated (behavior, config, errors, security — if any changed)