### PR TITLE
fix(worktree): allow creation paths under home dir on Windows

### DIFF
--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -56,6 +56,12 @@ Before removing a worktree or deleting a branch, the app can check for work that
 2. `GitRepository.getStatusPorcelain()` runs `git status --porcelain` in the specified worktree directory.
 3. Returns raw porcelain output. A non-empty result means the worktree has uncommitted changes.
 
+### Worktree path validation
+
+Worktrees are intentionally created OUTSIDE the workspace (default `worktrees.baseDir` is `~/canopy/worktrees`), so the strict workspace-only containment used by other create operations does not apply. Both creation (`gitWorktreeAdd`, `gitWorktreeCheckout`) and removal (`gitWorktreeRemove`) accept any absolute path that resolves under either the user's home directory or any workspace path registered to the window. System locations like `/etc` or `C:\Program Files` remain blocked.
+
+Creation paths additionally walk up to the closest existing ancestor before realpath-normalizing, so a non-existent leaf is OK; the tail is then rechecked to reject escapes via `..`. The same TOCTOU-safe pattern as `validateCreationPath` is used.
+
 ### Post-creation setup
 
 Worktree setup actions are configured per workspace and stored in the preferences database under the key `workspace:<workspaceId>:worktreeSetup` as a JSON array.
@@ -103,14 +109,18 @@ Example configuration (JSON):
 
 ## Error states
 
-| Error                                | User sees                                   | Cause                                                                  |
-| ------------------------------------ | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `GitCommandFailed` (worktree add)    | "Git worktree add failed: \<message\>"      | Branch already checked out in another worktree, or path already exists |
-| `GitCommandFailed` (worktree remove) | "Git worktree remove failed: \<message\>"   | Worktree has uncommitted changes and force was not set                 |
-| `InvalidRef`                         | "Invalid git ref: \<ref\>"                  | Branch name starts with `-`                                            |
-| Setup command timeout                | "Command timed out after 5 minutes"         | A setup action's shell command did not exit within 300 seconds         |
-| Setup command failure                | "\<label\>: Command exited with code \<N\>" | A setup action's shell command returned non-zero                       |
-| Setup aborted                        | "Setup aborted"                             | User cancelled the setup while it was running                          |
+| Error                                | User sees                                                | Cause                                                                                |
+| ------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `GitCommandFailed` (worktree add)    | "Git worktree add failed: \<message\>"                   | Branch already checked out in another worktree, or path already exists               |
+| `GitCommandFailed` (worktree remove) | "Git worktree remove failed: \<message\>"                | Worktree has uncommitted changes and force was not set                               |
+| `InvalidRef`                         | "Invalid git ref: \<ref\>"                               | Branch name starts with `-`                                                          |
+| Path not absolute                    | "Worktree path must be absolute"                         | Renderer passed a relative path to create or remove                                  |
+| No existing ancestor                 | "Access denied: no existing ancestor"                    | Creation path walks up past the filesystem root without finding an existing ancestor |
+| Path outside allowed roots           | "Access denied: worktree path outside home or workspace" | Resolved path is not under `$HOME` or a registered workspace                         |
+| Path escapes ancestor                | "Access denied: worktree path escapes ancestor"          | Non-existent tail of the creation path escapes its ancestor via `..` or absolute ref |
+| Setup command timeout                | "Command timed out after 5 minutes"                      | A setup action's shell command did not exit within 300 seconds                       |
+| Setup command failure                | "\<label\>: Command exited with code \<N\>"              | A setup action's shell command returned non-zero                                     |
+| Setup aborted                        | "Setup aborted"                                          | User cancelled the setup while it was running                                        |
 
 ## Source files
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1910,6 +1910,9 @@ export function registerIpcHandlers(
   // an inactive worktree under ~/canopy/worktrees would otherwise fail
   // because only the *active* worktree is in WindowManager's allow-list.
   async function validateWorktreeExistingPath(wcId: number, targetPath: string): Promise<string> {
+    if (!path.isAbsolute(targetPath)) {
+      throw new Error('Worktree path must be absolute')
+    }
     const resolved = path.normalize(await fs.promises.realpath(targetPath))
     if (!(await isUnderHomeOrWorkspace(wcId, resolved))) {
       throw new Error('Access denied: worktree path outside home or workspace')

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1126,7 +1126,7 @@ export function registerIpcHandlers(
       const expanded = payload.path.startsWith('~/')
         ? os.homedir() + payload.path.slice(1)
         : payload.path
-      const resolvedPath = await validateCreationPath(event.sender.id, expanded)
+      const resolvedPath = await validateWorktreeCreationPath(event.sender.id, expanded)
       const result = await GitRepository.worktreeAdd(
         resolvedRepo,
         resolvedPath,
@@ -1152,7 +1152,7 @@ export function registerIpcHandlers(
       const expanded = payload.path.startsWith('~/')
         ? os.homedir() + payload.path.slice(1)
         : payload.path
-      const resolvedPath = await validateCreationPath(event.sender.id, expanded)
+      const resolvedPath = await validateWorktreeCreationPath(event.sender.id, expanded)
       const result = await GitRepository.worktreeAddCheckout(
         resolvedRepo,
         resolvedPath,
@@ -1167,7 +1167,7 @@ export function registerIpcHandlers(
     'git:worktreeRemove',
     async (event, payload: { repoRoot: string; path: string; force: boolean }) => {
       const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
-      const resolvedTarget = await validatePathAccess(event.sender.id, payload.path)
+      const resolvedTarget = await validateWorktreeExistingPath(event.sender.id, payload.path)
       const result = await GitRepository.worktreeRemove(resolvedRepo, resolvedTarget, payload.force)
       return unwrapOrThrow(result, gitErrorMessage)
     },
@@ -1839,6 +1839,82 @@ export function registerIpcHandlers(
       throw new Error('Access denied: path escapes workspace')
     }
     return finalPath
+  }
+
+  // Containment check shared by worktree validators: a resolved (realpath'd)
+  // path is acceptable if it lives under the user's home directory OR any
+  // workspace path registered to this window. Windows paths compare
+  // case-insensitively to match validatePathAccess.
+  async function isUnderHomeOrWorkspace(wcId: number, resolved: string): Promise<boolean> {
+    const homeReal = path.normalize(
+      await fs.promises.realpath(os.homedir()).catch(() => os.homedir()),
+    )
+    const allowed = windowManager.getWorkspacePaths(wcId)
+    const resolvedAllowed = await Promise.all(
+      allowed.map(async (wp) => {
+        try {
+          return path.normalize(await fs.promises.realpath(wp))
+        } catch {
+          return path.normalize(wp)
+        }
+      }),
+    )
+    const bases = [homeReal, ...resolvedAllowed]
+    const isWin = process.platform === 'win32'
+    return bases.some((base) => {
+      const target = isWin ? resolved.toLowerCase() : resolved
+      const b = isWin ? base.toLowerCase() : base
+      return target === b || target.startsWith(b + path.sep)
+    })
+  }
+
+  // Worktrees are intentionally created OUTSIDE the workspace by design (the
+  // default `worktrees.baseDir` pref is `~/canopy/worktrees`), so the strict
+  // workspace-only containment used by validateCreationPath wrongly blocks
+  // them — most visibly on Windows where the home dir is never a workspace
+  // ancestor. This validator applies the same TOCTOU-safe ancestor walk and
+  // escape-via-`..` rejection, but relaxes containment to "under home OR
+  // workspace", which still prevents writes to system locations like /etc or
+  // C:\Program Files while permitting the documented worktree layout.
+  async function validateWorktreeCreationPath(wcId: number, targetPath: string): Promise<string> {
+    if (!path.isAbsolute(targetPath)) {
+      throw new Error('Worktree path must be absolute')
+    }
+    const normalized = path.normalize(targetPath)
+    let ancestor = normalized
+    const tail: string[] = []
+    while (true) {
+      try {
+        await fs.promises.access(ancestor)
+        break
+      } catch {
+        const parent = path.dirname(ancestor)
+        if (parent === ancestor) throw new Error('Access denied: no existing ancestor')
+        tail.unshift(path.basename(ancestor))
+        ancestor = parent
+      }
+    }
+    const resolvedAncestor = path.normalize(await fs.promises.realpath(ancestor))
+    if (!(await isUnderHomeOrWorkspace(wcId, resolvedAncestor))) {
+      throw new Error('Access denied: worktree path outside home or workspace')
+    }
+    const finalPath = path.join(resolvedAncestor, ...tail)
+    const rel = path.relative(resolvedAncestor, finalPath)
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new Error('Access denied: worktree path escapes ancestor')
+    }
+    return finalPath
+  }
+
+  // Same relaxed containment for existing worktree paths (remove). Removing
+  // an inactive worktree under ~/canopy/worktrees would otherwise fail
+  // because only the *active* worktree is in WindowManager's allow-list.
+  async function validateWorktreeExistingPath(wcId: number, targetPath: string): Promise<string> {
+    const resolved = path.normalize(await fs.promises.realpath(targetPath))
+    if (!(await isUnderHomeOrWorkspace(wcId, resolved))) {
+      throw new Error('Access denied: worktree path outside home or workspace')
+    }
+    return resolved
   }
 
   ipcMain.handle('fs:createFile', async (event, payload: { filePath: string }): Promise<void> => {


### PR DESCRIPTION
## Summary

- Worktree creation on Windows fails with `Access denied: path outside workspace`. The 2026-05-22 audit wired `validateCreationPath` into `git:worktreeAdd` / `git:worktreeCheckout`, but worktrees are intentionally created OUTSIDE the workspace (default `worktrees.baseDir` is `~/canopy/worktrees`). On Windows the home dir is never a workspace ancestor, so every creation gets rejected.
- New `validateWorktreeCreationPath` keeps the TOCTOU-safe ancestor walk and escape-via-`..` rejection from `validateCreationPath`, but relaxes containment to **home OR workspace**. System locations like `/etc` or `C:\Program Files` remain blocked.
- `git:worktreeRemove` switches to the matching `validateWorktreeExistingPath` — `WindowManager` only exposes the *active* worktree, so removing inactive ones hit the same wall.

## Test plan

- [ ] Windows: create a worktree from `Sidebar → +` with default `worktrees.baseDir` (`~/canopy/worktrees`) — succeeds.
- [ ] Windows: create a worktree from the task tracker `BranchCreateForm` — succeeds.
- [ ] macOS / Linux: regression check — create + remove worktree still work.
- [ ] Remove an inactive worktree (one that is not currently selected) — succeeds.
- [ ] Try a manually-crafted path outside home + workspace (e.g. `C:\Program Files\evil` or `/etc/evil`) via DevTools — still rejected with the new error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)