### PR TITLE
feat(taskTracker): pick base branch for worktree from task

### DIFF
--- a/docs/integrations/task-tracker.md
+++ b/docs/integrations/task-tracker.md
@@ -59,10 +59,9 @@ Jira maps `issuetype.subtask = true` to `subtask`, and normalizes type names (`U
 
 1. User clicks "Create Branch" on a task.
 2. Canopy resolves the branch name using the configured `branchTemplate`. The default template is `{branchType}/{taskKey}-{taskTitle}`.
-3. A confirmation dialog shows the proposed branch name.
-4. If the working tree has uncommitted changes, Canopy prompts to stash them. If the user declines or the stash fails, the operation is cancelled.
-5. Canopy creates and checks out the new branch from the current branch via `gitBranchCreate`.
-6. On failure, an error dialog is shown with the Git error message.
+3. The create form shows the proposed branch name, an optional branch-type select, an optional agent to launch, and a **base branch** picker (grouped local/remote, populated from `gitBranches`). The base defaults to the currently active branch but can be changed to any local or remote branch.
+4. Canopy creates a worktree for the new branch off the selected base via `gitWorktreeAdd`, then runs any configured worktree setup actions and optionally launches the selected agent with the task context.
+5. On failure, an error dialog is shown with the Git error message.
 
 ### Branch template system
 

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -48,6 +48,15 @@
   let initialized = $state(false)
   let fullTask = $state<Task>(task)
   let selectedAgentId = $state(getPref('taskTracker.lastAgent', ''))
+  let branches = $state<{ local: string[]; remote: string[] }>({ local: [], remote: [] })
+  let selectedBaseBranch = $state('')
+
+  let baseBranchGroups = $derived(
+    [
+      { label: 'Local', options: branches.local.map((b) => ({ value: b, label: b })) },
+      { label: 'Remote', options: branches.remote.map((b) => ({ value: b, label: b })) },
+    ].filter((g) => g.options.length > 0),
+  )
 
   let availableAgents = $derived.by(() => {
     const tools = getTools()
@@ -56,19 +65,30 @@
   })
 
   async function init(): Promise<void> {
-    const [typeInfo, foundTask] = await Promise.all([
+    const repoRoot = workspaceState.repoRoot
+    const [typeInfo, foundTask, branchList] = await Promise.all([
       window.api
         .taskTrackerResolveBranchType(
           task.type,
           connectionId,
           selectedBoardId || undefined,
-          workspaceState.repoRoot || undefined,
+          repoRoot || undefined,
         )
         .catch(() => null),
       window.api.taskTrackerFindTaskByKey(task.key).catch(() => null),
+      repoRoot ? window.api.gitBranches(repoRoot).catch(() => null) : Promise.resolve(null),
     ])
 
     if (foundTask) fullTask = foundTask as Task
+
+    if (branchList) {
+      branches = { local: branchList.local, remote: branchList.remote }
+    }
+    // Default the base to the currently active branch (the prior hard-coded
+    // behaviour), but fall back to the repo's reported current branch, then
+    // to the first available local branch so the picker is never empty.
+    selectedBaseBranch =
+      workspaceState.branch ?? branchList?.current ?? branches.local[0] ?? branches.remote[0] ?? ''
 
     if (typeInfo) {
       branchTypeOptions = typeInfo.options
@@ -118,8 +138,8 @@
 
   async function confirmBranchCreation(): Promise<void> {
     const repoRoot = workspaceState.repoRoot
-    const currentBranch = workspaceState.branch
-    if (!repoRoot || !currentBranch || !resolvedBranchName) return
+    const baseBranch = selectedBaseBranch
+    if (!repoRoot || !baseBranch || !resolvedBranchName) return
 
     const baseDir = getPref('worktrees.baseDir', '~/canopy/worktrees')
     const projectName = repoRoot.split(/[/\\]/).pop() || 'project'
@@ -133,7 +153,7 @@
     creatingWorktree = true
     setPref('taskTracker.lastAgent', selectedAgentId)
     try {
-      await window.api.gitWorktreeAdd(repoRoot, worktreePath, resolvedBranchName, currentBranch)
+      await window.api.gitWorktreeAdd(repoRoot, worktreePath, resolvedBranchName, baseBranch)
       await setActiveTask(worktreePath, {
         taskKey: fullTask.key,
         summary: fullTask.summary,
@@ -265,6 +285,19 @@
         />
       </div>
     {/if}
+    {#if baseBranchGroups.length > 0}
+      <div class="flex items-center gap-2.5">
+        <span class="text-sm text-text-muted w-[50px] flex-shrink-0">Base</span>
+        <CustomSelect
+          value={selectedBaseBranch}
+          groups={baseBranchGroups}
+          onchange={(v) => {
+            selectedBaseBranch = v
+          }}
+          maxWidth="none"
+        />
+      </div>
+    {/if}
     <div class="flex items-center gap-2.5">
       <span class="text-sm text-text-muted w-[50px] flex-shrink-0">Branch</span>
       <code class="text-sm text-accent-text bg-bg-input px-2.5 py-[5px] rounded-lg flex-1"
@@ -295,7 +328,7 @@
       <button
         class="px-3.5 py-1.5 border-0 rounded-lg bg-accent-bg text-accent-text text-sm font-inherit cursor-pointer enabled:hover:bg-accent-bg-hover disabled:opacity-50 disabled:cursor-default"
         onclick={confirmBranchCreation}
-        disabled={creatingWorktree || !resolvedBranchName}
+        disabled={creatingWorktree || !resolvedBranchName || !selectedBaseBranch}
       >
         {#if creatingWorktree}Creating...{:else if selectedAgentId}Create & Start Agent{:else}Create
           & Switch{/if}


### PR DESCRIPTION
## What

Add a **Base** branch picker to the Jira/task "Create Branch" form (`BranchCreateForm`). The picker is grouped local/remote (populated from `gitBranches`) and defaults to the currently active branch, but lets the user create the worktree off any other local or remote branch. The create button stays disabled until a base is resolved.

## Why

Previously the form always created the worktree off the currently active branch with no way to override it. Users starting a task while sitting on an unrelated branch had to switch branches first, or ended up branching from the wrong base. This lets them pick the correct base (e.g. `next`, `main`, a release branch) directly in the form.

## How to test

1. Open a task → Create Branch: **Base** defaults to the active branch.
2. Change base to another local branch → confirm the new worktree branches off it (`git log` on the worktree shows the chosen base as ancestor).
3. Change base to a remote-only branch (e.g. `origin/foo`) → worktree creation succeeds.
4. Repo with a single branch → picker still shows it and create works.
5. Create button is disabled until both branch name and base are resolved.

## Screenshots / recordings

N/A (compact select consistent with the form's existing Type/Agent selects).

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [x] Non-core feature is behind a feature flag (off by default) — N/A, additive UI on existing form
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (all interactive elements reachable via keyboard) — reuses `CustomSelect`
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle` — reuses existing `git:branches`
- [x] Renderer code does not import Node.js modules directly
- [x] Feature docs in `docs/` updated — `docs/integrations/task-tracker.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)