### PR TITLE
refactor: move app state ownership to main process

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,10 +21,17 @@ IPC handlers validate input from the renderer (the renderer is untrusted). Write
 Renderer code should prefer main-owned command IPC for domain mutations. Low-level IPC primitives
 are reserved for UI-native operations or command-service internals; renderer stores should not
 compose privileged primitives into workspace, session, layout, agent, or run-config workflows.
-Layout persistence uses main-owned save/delete commands that derive workspace identity from the
-sender's attached workspace state. Full saved-layout interpretation is still renderer-assisted:
-the renderer parses the persisted split tree and requests main-owned pane/tmux commands for each
-session. Moving full layout hydration into main is a follow-up boundary-tightening step.
+
+The main process owns workspace and tab domain state for each window. Renderer stores mirror the
+latest `AppStateSnapshot` from `app:getState` and `app:stateChanged`, then keep only UI-ephemeral
+state locally (dialog state, transient editor jumps, browser/drawing UI state). Tab mutations go
+through `tab:command:*` handlers, which validate sender ownership, mutate main-owned state, and
+return a `TabCommandResult` snapshot for the affected worktree.
+
+Startup restore is coordinated by `app:getStartupRestoreState` and `app:completeStartupRestore`.
+If a window has a pending restore snapshot, the renderer shows the restore placeholder instead of
+the dashboard until main-owned layout hydration finishes. The dashboard is the fallback only when
+there is no restorable workspace/window state.
 
 ## Error handling
 
@@ -59,7 +66,10 @@ Renderer state uses Svelte 5 runes in `.svelte.ts` store files under `src/render
 - `$derived` for computed values
 - `$effect` for side effects (must return cleanup functions when registering listeners or timers)
 
-Main process state is mostly stateless per-request, except for long-lived managers (PTY sessions, Git watchers, file watchers, remote sessions) that maintain in-memory maps of active resources.
+Main process state includes per-window workspace/tab snapshots plus long-lived managers (PTY
+sessions, Git watchers, file watchers, remote sessions) that maintain in-memory maps of active
+resources. Window snapshots are saved on close/quit and restored with their original project-to-
+window grouping so multiple projects that lived in one window reopen in that same window.
 
 ## Data storage
 

--- a/docs/core/terminal.md
+++ b/docs/core/terminal.md
@@ -101,8 +101,14 @@ Detected URLs in terminal output are clickable. Behavior depends on the `urlOpen
 
 1. When a user closes a tab, the system checks whether the PTY has child processes (`pgrep -P <pid>` on Unix, `wmic` on Windows).
 2. For AI tool tabs, it checks whether the agent status is in an active state (thinking, tool calling, compacting, waiting for permission).
-3. If active processes are found, a confirmation dialog appears: "This tab has N running processes that will be terminated."
+3. If active processes are found, a confirmation dialog appears before the PTY is killed.
 4. On confirmation, all PTYs in the tab's split tree are killed.
+
+Closing all tabs for a worktree uses the same safety path. The renderer first aggregates active
+process warnings across tabs, then runs the unsaved-editor preflight for every open tab. If the
+user cancels either prompt, the worktree removal/detach operation that requested the close is
+cancelled as well. Closing the final tab leaves the worktree with no tabs; Canopy no longer opens
+a replacement shell automatically.
 
 ### Tmux session lifecycle
 

--- a/docs/features/file-editor.md
+++ b/docs/features/file-editor.md
@@ -38,14 +38,16 @@ properties derived from the xterm ANSI palette.
 
 ### Loading content
 
-1. `EditorPane` calls `window.api.readFile(filePath, 2 MB)` and
-   `window.api.statFile(filePath)` in sequence.
-2. Files above 2 MB or with null bytes in the first 8 KB are treated as
+1. `EditorPane` calls the renderer tab store's `loadEditorFile(...)` helper.
+2. The helper invokes `tab:command:loadEditorFile`; the main process validates
+   the sender/worktree/pane, reads the file, returns stat metadata, and updates
+   the main-owned editor file snapshot.
+3. Files above 2 MB or with null bytes in the first 8 KB are treated as
    read-only (binary / truncated). A banner explains why.
-3. If the user has no write permission (`statFile.canWrite === false`), the
-   editor is shown read-only with a banner.
-4. The file's line ending is detected (LF vs CRLF) and preserved on save.
-5. `detectIndent` inspects up to 1000 leading-whitespace samples and picks
+4. If the user has no write permission (`canWrite === false`), the editor is
+   shown read-only with a banner.
+5. The file's line ending is detected (LF vs CRLF) and preserved on save.
+6. `detectIndent` inspects up to 1000 leading-whitespace samples and picks
    the indent unit (tabs or N spaces, snapped to {2, 4, 8}) based on the
    most common positive step between consecutive indent levels. Users can
    override via the status bar dropdowns.
@@ -57,8 +59,8 @@ properties derived from the xterm ANSI palette.
 2. A dirty sub-tab shows a gray dot; the hosting top-level tab also shows a
    gray dot if any of its editor sub-tabs are dirty.
 3. `Cmd/Ctrl+S` (or clicking the Save button) writes the buffer via
-   `window.api.writeFile`. Line endings are normalized to match the file's
-   original style.
+   `tab:command:saveEditorFile`. Line endings are normalized in the main
+   command to match the file's original style.
 4. Right before writing, `skipNextWatcherEvent = true` is set. When the
    parcel file-tree watcher reports the self-generated change event within
    1500 ms, the editor skips the reload — preserving cursor position and
@@ -66,10 +68,11 @@ properties derived from the xterm ANSI palette.
 
 ### Stale-write detection
 
-1. `writeFile` includes the last-known `mtimeMs` as `expectedMtimeMs`.
-2. If the main process detects the on-disk mtime has changed since load,
-   the write is rejected with `StaleWrite` and the editor shows the
-   conflict banner.
+1. `tab:command:saveEditorFile` includes the last-known `mtimeMs` as
+   `expectedMtimeMs`.
+2. If the main process detects the on-disk mtime has changed since load, the
+   write is rejected with `StaleWrite`, the main-owned editor snapshot is left
+   unchanged, and the editor shows the conflict banner.
 
 ### External change detection
 
@@ -157,25 +160,34 @@ A pane with zero files after a merge/detach is not restored.
 
 ## IPC surface
 
-| Handler                        | Purpose                                                                                    |
-| ------------------------------ | ------------------------------------------------------------------------------------------ |
-| `fs:readFile`                  | Bounded read (up to 10 MB hard cap), binary detection, truncation flag.                    |
-| `fs:writeFile`                 | Writes UTF-8, optionally gated by `expectedMtimeMs` to detect stale saves.                 |
-| `fs:stat`                      | Returns `{ mtimeMs, size, canWrite }`.                                                     |
-| `fs:createFile`                | Creates an empty file (`wx` flag), creating parent dirs as needed. Used by file tree.      |
-| `fs:mkdir`                     | Recursively creates a directory. Used by file tree.                                        |
-| `dialog:confirmUnsavedChanges` | Native 3-way dialog (Save / Don't Save / Cancel) used by tab and worktree close preflight. |
+| Handler                                  | Purpose                                                                                               |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `tab:command:openEditorFile`             | Opens/focuses an editor file in the main-owned tab snapshot.                                          |
+| `tab:command:loadEditorFile`             | Bounded read (up to 10 MB hard cap), binary detection, truncation flag, stat, and snapshot update.    |
+| `tab:command:saveEditorFile`             | Writes UTF-8, optionally gated by `expectedMtimeMs` to detect stale saves, then updates the snapshot. |
+| `tab:command:updateEditorFileState`      | Stores dirty/current/original content metadata for an open editor sub-tab.                            |
+| `tab:command:setActiveEditorFile`        | Changes the active editor sub-tab in a pane.                                                          |
+| `tab:command:moveEditorFile`             | Reorders editor sub-tabs within a pane.                                                               |
+| `tab:command:moveEditorFileBetweenPanes` | Moves an editor sub-tab between editor panes.                                                         |
+| `tab:command:detachEditorFile`           | Detaches an editor sub-tab into its own top-level editor tab.                                         |
+| `tab:command:closeEditorFile`            | Closes one editor sub-tab and collapses empty panes/tabs.                                             |
+| `tab:command:prepareCloseEditorFile`     | Dirty-file Save / Don't Save / Cancel preflight for one editor sub-tab.                               |
+| `tab:command:prepareCloseTab`            | Dirty-file Save / Don't Save / Cancel preflight before closing a tab.                                 |
+| `tab:command:prepareCloseAllForWorktree` | Batched dirty-file and active-process preflight before closing all tabs in a worktree.                |
+| `fs:createFile`                          | Creates an empty file (`wx` flag), creating parent dirs as needed. Used by file tree.                 |
+| `fs:mkdir`                               | Recursively creates a directory. Used by file tree.                                                   |
+| `dialog:confirmUnsavedChanges`           | Native 3-way dialog (Save / Don't Save / Cancel) used by tab and worktree close preflight.            |
 
-Tab close and close-all worktree flows use main-owned `tab:command:prepareCloseTab` before
-destroying panes. Dirty files are saved through the same validated write path as manual saves.
-If any save fails, the close is cancelled and no PTY/browser/editor cleanup runs.
+Tab close and close-all worktree flows use main-owned preflight commands before destroying
+panes. Dirty files are saved through the same validated `tab:command:saveEditorFile` path
+as manual saves. If any save fails, the close is cancelled and no PTY/browser/editor
+cleanup runs.
 
-Read/write/stat handlers validate `filePath` through `validatePathAccess`,
-which calls `fs.realpath` on the target and rejects anything outside the
-renderer's workspace roots. Create handlers (`fs:createFile`, `fs:mkdir`)
-use `validateCreationPath`, which walks up to the closest existing ancestor,
-runs `validatePathAccess` against it, and rejects tails that escape via
-`..` or absolute references — needed because the target itself does not
+Editor load/save commands validate `filePath` through `validatePathAccess`, which calls
+`fs.realpath` on the target and rejects anything outside the renderer's workspace roots.
+Create handlers (`fs:createFile`, `fs:mkdir`) use `validateCreationPath`, which walks up
+to the closest existing ancestor, runs `validatePathAccess` against it, and rejects tails
+that escape via `..` or absolute references — needed because the target itself does not
 yet exist and `realpath` would fail with `ENOENT`.
 
 ## Keyboard shortcuts
@@ -208,8 +220,9 @@ yet exist and `realpath` would fail with `ENOENT`.
 - Extensions / theme / language: `src/renderer/src/components/editor/cm/`
 - Indent detection: `src/renderer/src/components/editor/cm/detectIndent.ts`
 - State + sub-tab operations: `src/renderer/src/lib/stores/tabs.svelte.ts`
+- Main-owned editor/tab commands: `src/main/commands/tabCommands.ts`
 - Pane routing: `src/renderer/src/components/terminal/PaneWrapper.svelte`
-- IPC handlers: `src/main/ipc/handlers.ts` (`fs:readFile`, `fs:writeFile`, `fs:stat`, `dialog:confirmUnsavedChanges`)
+- IPC handlers: `src/main/ipc/handlers.ts` (`tab:command:*EditorFile`, `dialog:confirmUnsavedChanges`)
 - IPC error type: `src/main/ipc/fsErrors.ts`
 - Path detection: `src/renderer/src/lib/pathDetection/linkify.ts`
 - Theme CSS vars: `src/renderer/src/lib/theme/appTheme.ts`

--- a/docs/features/file-editor.md
+++ b/docs/features/file-editor.md
@@ -157,14 +157,18 @@ A pane with zero files after a merge/detach is not restored.
 
 ## IPC surface
 
-| Handler                        | Purpose                                                                               |
-| ------------------------------ | ------------------------------------------------------------------------------------- |
-| `fs:readFile`                  | Bounded read (up to 10 MB hard cap), binary detection, truncation flag.               |
-| `fs:writeFile`                 | Writes UTF-8, optionally gated by `expectedMtimeMs` to detect stale saves.            |
-| `fs:stat`                      | Returns `{ mtimeMs, size, canWrite }`.                                                |
-| `fs:createFile`                | Creates an empty file (`wx` flag), creating parent dirs as needed. Used by file tree. |
-| `fs:mkdir`                     | Recursively creates a directory. Used by file tree.                                   |
-| `dialog:confirmUnsavedChanges` | Native 3-way dialog (Save / Don't Save / Cancel) used by `closeTab`.                  |
+| Handler                        | Purpose                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------ |
+| `fs:readFile`                  | Bounded read (up to 10 MB hard cap), binary detection, truncation flag.                    |
+| `fs:writeFile`                 | Writes UTF-8, optionally gated by `expectedMtimeMs` to detect stale saves.                 |
+| `fs:stat`                      | Returns `{ mtimeMs, size, canWrite }`.                                                     |
+| `fs:createFile`                | Creates an empty file (`wx` flag), creating parent dirs as needed. Used by file tree.      |
+| `fs:mkdir`                     | Recursively creates a directory. Used by file tree.                                        |
+| `dialog:confirmUnsavedChanges` | Native 3-way dialog (Save / Don't Save / Cancel) used by tab and worktree close preflight. |
+
+Tab close and close-all worktree flows use main-owned `tab:command:prepareCloseTab` before
+destroying panes. Dirty files are saved through the same validated write path as manual saves.
+If any save fails, the close is cancelled and no PTY/browser/editor cleanup runs.
 
 Read/write/stat handlers validate `filePath` through `validatePathAccess`,
 which calls `fs.realpath` on the target and rejects anything outside the

--- a/docs/integrations/agents.md
+++ b/docs/integrations/agents.md
@@ -96,6 +96,12 @@ All four adapters support resuming a previous session:
 - Gemini: `--resume {sessionId}`
 - OpenCode: `--continue --session {sessionId}`
 
+Canopy stores two identifiers for each agent PTY. The hook route uses an internal `hookSessionId`
+allocated before process spawn, while `agentSessionId` is updated from normalized hook payloads
+when the CLI reports its real conversation/session ID. Resume commands always use
+`agentSessionId`; falling back to the internal hook route ID would make Claude/Codex report
+"session not found".
+
 ### Worktree-level status aggregation
 
 `getWorktreeAgentStatus()` scans all agent panes in a worktree's tabs and returns the highest-priority status: `waitingPermission` > `error` > `working` (thinking/toolCalling/compacting) > `idle` > `none`.

--- a/e2e/agent-session-resume.spec.ts
+++ b/e2e/agent-session-resume.spec.ts
@@ -1,0 +1,266 @@
+import { test, expect, type ElectronApplication, type Page, _electron } from '@playwright/test'
+import { existsSync, realpathSync } from 'fs'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { delimiter, join, resolve } from 'path'
+
+const appDir = resolve(__dirname, '..')
+
+const agentCases = [
+  {
+    toolId: 'claude',
+    sessionId: 'claude-real-session-e2e',
+    expectedResumeArgs: ' --resume claude-real-session-e2e',
+  },
+  {
+    toolId: 'codex',
+    sessionId: 'codex-real-session-e2e',
+    expectedResumeArgs: 'resume codex-real-session-e2e',
+  },
+] as const
+
+interface AppStateSnapshot {
+  workspace: {
+    projects: Array<{ workspace: { path: string } }>
+  }
+  tabs: {
+    tabsByWorktree: Record<string, unknown[]>
+  }
+}
+
+interface CanopyWindow extends Window {
+  api: {
+    getAppState: () => Promise<AppStateSnapshot>
+    perfOpenProject?: (path: string) => Promise<void>
+    tabOpenTool?: (toolId: string, worktreePath: string) => Promise<unknown>
+    tabSaveCurrentLayout?: (worktreePath: string) => Promise<void>
+  }
+}
+
+async function launchApp(userDataDir: string, fakeBinDir: string): Promise<ElectronApplication> {
+  const fakeShell = join(fakeBinDir, 'canopy-login-env-shell')
+  return _electron.launch({
+    args: [resolve(appDir, 'out/main/index.js')],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      CANOPY_E2E: '1',
+      CANOPY_PERF: '1',
+      CANOPY_TEST_USER_DATA: userDataDir,
+      PATH: `${fakeBinDir}${delimiter}${process.env.PATH ?? ''}`,
+      ...(process.platform === 'win32' ? {} : { SHELL: fakeShell }),
+    },
+  })
+}
+
+async function closeApp(app: ElectronApplication | null): Promise<void> {
+  if (!app) return
+  const proc = app.process()
+  if (proc.exitCode !== null || proc.signalCode !== null) return
+
+  await Promise.race([
+    app.close().catch(() => {}),
+    new Promise<void>((resolve) =>
+      setTimeout(() => {
+        if (proc.pid) {
+          try {
+            process.kill(proc.pid)
+          } catch {
+            // Process already exited.
+          }
+        }
+        resolve()
+      }, 5_000),
+    ),
+  ])
+}
+
+async function waitForExit(app: ElectronApplication, label: string): Promise<void> {
+  const proc = app.process()
+  if (proc.exitCode !== null || proc.signalCode !== null) return
+  await Promise.race([
+    new Promise<void>((resolve) => proc.once('exit', () => resolve())),
+    new Promise<void>((_resolve, reject) =>
+      setTimeout(() => reject(new Error(`${label} did not exit`)), 10_000),
+    ),
+  ])
+}
+
+async function quitApp(app: ElectronApplication, label: string): Promise<void> {
+  await app.evaluate(({ app, dialog }) => {
+    dialog.showMessageBox = async () => ({ response: 0, checkboxChecked: false })
+    app.quit()
+  })
+  await waitForExit(app, label)
+}
+
+async function waitForLineCount(
+  filePath: string,
+  expectedCount: number,
+  label: string,
+): Promise<string[]> {
+  const startedAt = Date.now()
+  let lines: string[] = []
+
+  while (Date.now() - startedAt < 8_000) {
+    if (existsSync(filePath)) {
+      const content = await readFile(filePath, 'utf-8')
+      lines = content
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+      if (lines.length >= expectedCount) return lines
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+
+  throw new Error(`Expected ${expectedCount} ${label} invocation(s), got ${lines.length}`)
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 8_000) {
+    if (existsSync(filePath)) return
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`Timed out waiting for ${filePath}`)
+}
+
+async function getAppState(page: Page): Promise<AppStateSnapshot> {
+  return page.evaluate(() => (window as unknown as CanopyWindow).api.getAppState())
+}
+
+async function waitForProjectCount(page: Page, expectedCount: number): Promise<void> {
+  const startedAt = Date.now()
+  let lastCount = 0
+
+  while (Date.now() - startedAt < 8_000) {
+    const state = await getAppState(page)
+    lastCount = state.workspace.projects.length
+    if (lastCount === expectedCount) return
+    await page.waitForTimeout(100)
+  }
+
+  throw new Error(`Expected ${expectedCount} project(s), got ${lastCount}`)
+}
+
+async function createFakeAgent(
+  fakeBinDir: string,
+  binaryName: string,
+  hookSessionId: string,
+  argsLogPath: string,
+  hookMarkerPath: string,
+): Promise<void> {
+  await mkdir(fakeBinDir, { recursive: true })
+
+  if (process.platform !== 'win32') {
+    const fakeShellPath = join(fakeBinDir, 'canopy-login-env-shell')
+    await writeFile(
+      fakeShellPath,
+      `#!/bin/sh
+exec /usr/bin/env -0
+`,
+      'utf-8',
+    )
+    await chmod(fakeShellPath, 0o755)
+  }
+
+  const shPath = join(fakeBinDir, binaryName)
+  await writeFile(
+    shPath,
+    `#!/bin/sh
+printf '%s\\n' "$*" >> "$FAKE_CODEX_ARGS_LOG"
+if [ -n "$CANOPY_HOOK_PORT" ]; then
+  printf '{"hook_event_name":"SessionStart","session_id":"${hookSessionId}"}' | curl -s -X POST "http://127.0.0.1:\${CANOPY_HOOK_PORT}\${CANOPY_HOOK_PATH:-}/hook" -H "Content-Type: application/json" -H "X-Canopy-Auth: \${CANOPY_HOOK_TOKEN}" --data-binary @- >/dev/null 2>&1
+fi
+printf 'sent' > "$FAKE_CODEX_HOOK_MARKER"
+sleep 300
+`,
+    'utf-8',
+  )
+  await chmod(shPath, 0o755)
+
+  await writeFile(
+    join(fakeBinDir, `${binaryName}.cmd`),
+    `@echo off
+echo %*>>"%FAKE_CODEX_ARGS_LOG%"
+powershell -NoProfile -Command "$body = '{\\"hook_event_name\\":\\"SessionStart\\",\\"session_id\\":\\"${hookSessionId}\\"}'; Invoke-RestMethod -Method Post -Uri ('http://127.0.0.1:' + $env:CANOPY_HOOK_PORT + $env:CANOPY_HOOK_PATH + '/hook') -Headers @{'Content-Type'='application/json'; 'X-Canopy-Auth'=$env:CANOPY_HOOK_TOKEN} -Body $body | Out-Null" >NUL 2>NUL
+echo sent>"%FAKE_CODEX_HOOK_MARKER%"
+timeout /t 300 >NUL
+`,
+    'utf-8',
+  )
+
+  process.env.FAKE_CODEX_ARGS_LOG = argsLogPath
+  process.env.FAKE_CODEX_HOOK_MARKER = hookMarkerPath
+}
+
+for (const agentCase of agentCases) {
+  test(`persists real ${agentCase.toolId} hook session id for resume`, async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), 'canopy-e2e-agent-resume-data-'))
+    const rawProject = await mkdtemp(join(tmpdir(), 'canopy-e2e-agent-resume-project-'))
+    const projectPath = realpathSync(rawProject)
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'canopy-e2e-fake-bin-'))
+    const argsLogPath = join(fakeBinDir, `${agentCase.toolId}-args.log`)
+    const hookMarkerPath = join(fakeBinDir, `${agentCase.toolId}-hook-sent`)
+    let app: ElectronApplication | null = null
+
+    try {
+      await writeFile(join(rawProject, 'README.md'), 'Project\n')
+      await createFakeAgent(
+        fakeBinDir,
+        agentCase.toolId,
+        agentCase.sessionId,
+        argsLogPath,
+        hookMarkerPath,
+      )
+
+      app = await launchApp(userDataDir, fakeBinDir)
+      let page = await app.firstWindow()
+      await page.waitForLoadState('domcontentloaded')
+      await page.waitForFunction(() => {
+        const api = (window as unknown as CanopyWindow).api
+        return Boolean(api?.perfOpenProject && api?.tabOpenTool && api?.tabSaveCurrentLayout)
+      })
+
+      await page.evaluate(
+        (path) => (window as unknown as CanopyWindow).api.perfOpenProject?.(path),
+        projectPath,
+      )
+      await waitForProjectCount(page, 1)
+      await page.evaluate(
+        ({ path, toolId }) => (window as unknown as CanopyWindow).api.tabOpenTool?.(toolId, path),
+        { path: projectPath, toolId: agentCase.toolId },
+      )
+
+      await waitForFile(hookMarkerPath)
+      await page.evaluate(
+        (path) => (window as unknown as CanopyWindow).api.tabSaveCurrentLayout?.(path),
+        projectPath,
+      )
+      await quitApp(app, `initial ${agentCase.toolId} app`)
+      app = null
+
+      const firstInvocations = await waitForLineCount(argsLogPath, 1, agentCase.toolId)
+      expect(firstInvocations[0]).not.toContain(agentCase.sessionId)
+
+      app = await launchApp(userDataDir, fakeBinDir)
+      page = await app.firstWindow()
+      await page.waitForLoadState('domcontentloaded')
+      await waitForProjectCount(page, 1)
+
+      const invocations = await waitForLineCount(argsLogPath, 2, agentCase.toolId)
+      expect(` ${invocations[1]}`).toContain(agentCase.expectedResumeArgs)
+
+      await quitApp(app, `restored ${agentCase.toolId} app`)
+      app = null
+    } finally {
+      delete process.env.FAKE_CODEX_ARGS_LOG
+      delete process.env.FAKE_CODEX_HOOK_MARKER
+      await closeApp(app)
+      await rm(userDataDir, { recursive: true, force: true })
+      await rm(rawProject, { recursive: true, force: true })
+      await rm(fakeBinDir, { recursive: true, force: true })
+    }
+  })
+}

--- a/e2e/app-state.spec.ts
+++ b/e2e/app-state.spec.ts
@@ -117,6 +117,19 @@ interface AppStateApi {
     | { ok: false; reason: 'cancelled' }
     | { ok: false; reason: 'save-failed'; failedCount: number }
   >
+  tabPrepareCloseAllForWorktree?: (
+    worktreePath: string,
+    options?: { confirmedActiveProcesses?: boolean },
+  ) => Promise<
+    | { ok: true }
+    | { ok: false; reason: 'cancelled' }
+    | { ok: false; reason: 'save-failed'; failedCount: number }
+    | {
+        ok: false
+        reason: 'active-processes'
+        warnings: Array<{ tabName: string; description: string }>
+      }
+  >
   tabGetCloseWarning?: (
     worktreePath: string,
     target: { kind: 'tab'; tabId: string } | { kind: 'pane'; tabId: string; paneId: string },
@@ -556,6 +569,7 @@ test('main process exposes and publishes app state snapshots', async ({ electron
       tabOpenTool: typeof api.tabOpenTool,
       tabSaveCurrentLayout: typeof api.tabSaveCurrentLayout,
       tabPrepareCloseTab: typeof api.tabPrepareCloseTab,
+      tabPrepareCloseAllForWorktree: typeof api.tabPrepareCloseAllForWorktree,
       tabGetCloseWarning: typeof api.tabGetCloseWarning,
       tabSaveEditorFile: typeof api.tabSaveEditorFile,
       tabPrepareCloseEditorFile: typeof api.tabPrepareCloseEditorFile,
@@ -606,6 +620,7 @@ test('main process exposes and publishes app state snapshots', async ({ electron
   expect(apiShape.tabOpenTool).toBe('function')
   expect(apiShape.tabSaveCurrentLayout).toBe('function')
   expect(apiShape.tabPrepareCloseTab).toBe('function')
+  expect(apiShape.tabPrepareCloseAllForWorktree).toBe('function')
   expect(apiShape.tabGetCloseWarning).toBe('function')
   expect(apiShape.tabSaveEditorFile).toBe('function')
   expect(apiShape.tabPrepareCloseEditorFile).toBe('function')
@@ -2414,6 +2429,25 @@ test('main process exposes and publishes app state snapshots', async ({ electron
       paneId: expect.any(String),
       paneSessionId: runConfigTab.sessionId,
     })
+
+  const closeAllPreflight = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabPrepareCloseAllForWorktree !== 'function') {
+      throw new Error('Missing tabPrepareCloseAllForWorktree API')
+    }
+    return api.tabPrepareCloseAllForWorktree(projectPath)
+  }, tmpDir)
+  expect(closeAllPreflight).toEqual({
+    ok: false,
+    reason: 'active-processes',
+    warnings: [{ tabName: 'E2E Command', description: '1 running process' }],
+  })
+
+  const confirmedCloseAllPreflight = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    return api.tabPrepareCloseAllForWorktree(projectPath, { confirmedActiveProcesses: true })
+  }, tmpDir)
+  expect(confirmedCloseAllPreflight).toEqual({ ok: true })
 
   const closeAllResult = await workspacePage.evaluate((projectPath) => {
     const api = (window as unknown as { api: Required<AppStateApi> }).api

--- a/e2e/app-state.spec.ts
+++ b/e2e/app-state.spec.ts
@@ -1,0 +1,3348 @@
+import { test, expect } from './fixtures'
+import { execFileSync, execSync } from 'child_process'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises'
+import { homedir } from 'os'
+import { join } from 'path'
+import type { Page } from '@playwright/test'
+
+let tmpDir: string
+let extraTmpPaths: string[] = []
+
+interface AppStateSnapshot {
+  workspace: {
+    projects: Array<{
+      workspace: { path: string }
+      repoRoot: string | null
+    }>
+    workspaceState: {
+      selectedWorktreePath: string | null
+      isDirty: boolean
+    }
+  }
+  tabs?: {
+    tabsByWorktree: Record<
+      string,
+      Array<{
+        id: string
+        toolId: string
+        worktreePath: string
+        focusedPaneId: string
+        suspended?: unknown
+        rootSplit: {
+          type: 'leaf' | 'split'
+          id?: string
+          direction?: 'horizontal' | 'vertical'
+          ratio?: number
+          pane?: {
+            id: string
+            sessionId: string
+            wsUrl: string
+            toolId: string
+            toolName: string
+            isRunning?: boolean
+            exitCode?: number | null
+            detached?: boolean
+            inspectorOpen?: boolean
+            tmuxSessionName?: string
+            filePath?: string
+            editorActiveFile?: string
+            editorFiles?: Array<{ filePath: string }>
+          }
+          first?: unknown
+          second?: unknown
+        }
+      }>
+    >
+    activeTabIdByWorktree: Record<string, string | null>
+  }
+}
+
+interface AppStateApi {
+  getAppState?: () => Promise<AppStateSnapshot>
+  onAppStateChanged?: (callback: (snapshot: AppStateSnapshot) => void) => () => void
+  setPref?: (key: string, value: string) => Promise<void>
+  resizePty?: (sessionId: string, cols: number, rows: number) => Promise<void>
+  workspaceSelectWorktree?: (path: string) => Promise<unknown>
+  tabOpenTool?: (toolId: string, worktreePath: string) => Promise<{ openedTab?: { id: string } }>
+  tabOpenDiff?: (worktreePath: string) => Promise<{ openedTab?: { id: string } }>
+  tabOpenSessionTab?: (
+    worktreePath: string,
+    name: string,
+    sessionId: string,
+  ) => Promise<{ openedTab?: { id: string } }>
+  runConfigSave?: (
+    configDir: string,
+    config: {
+      configurations: Array<{
+        name: string
+        command: string
+        args?: string
+      }>
+    },
+  ) => Promise<void>
+  runConfigExecuteCommand?: (
+    configDir: string,
+    name: string,
+    cwd: string,
+  ) => Promise<{ sessionId: string; wsUrl: string }>
+  tabOpenEditorFile?: (
+    worktreePath: string,
+    filePath: string,
+  ) => Promise<{
+    activeTabId: string | null
+    openedTab?: { id: string }
+  }>
+  tabDetachEditorFile?: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+  ) => Promise<{
+    activeTabId: string | null
+    openedTab?: { id: string }
+  }>
+  tabCloseEditorFile?: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+  ) => Promise<{ activeTabId: string | null; closedTabId?: string }>
+  tabCloseTab?: (
+    worktreePath: string,
+    tabId: string,
+  ) => Promise<{ activeTabId: string | null; closedTabId?: string; tabs: unknown[] }>
+  tabPrepareCloseTab?: (
+    worktreePath: string,
+    tabId: string,
+  ) => Promise<
+    | { ok: true }
+    | { ok: false; reason: 'cancelled' }
+    | { ok: false; reason: 'save-failed'; failedCount: number }
+  >
+  tabGetCloseWarning?: (
+    worktreePath: string,
+    target: { kind: 'tab'; tabId: string } | { kind: 'pane'; tabId: string; paneId: string },
+  ) => Promise<{ description: string | null }>
+  tabReopenClosedTab?: (worktreePath: string) => Promise<{
+    activeTabId: string | null
+    openedTab?: { id: string; toolId: string }
+  }>
+  tabMoveEditorFile?: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    toIndex: number,
+  ) => Promise<{ activeTabId: string | null }>
+  tabMoveEditorFileBetweenPanes?: (
+    worktreePath: string,
+    sourcePaneId: string,
+    targetPaneId: string,
+    filePath: string,
+    toIndex: number,
+  ) => Promise<{ activeTabId: string | null }>
+  tabSetActiveEditorFile?: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+  ) => Promise<{ activeTabId: string | null }>
+  tabUpdateEditorFileState?: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    patch: Record<string, unknown>,
+  ) => Promise<{ activeTabId: string | null }>
+  tabSaveEditorFile?: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    options: {
+      content: string
+      fileLineEnding?: 'LF' | 'CRLF'
+      expectedMtimeMs?: number
+    },
+  ) => Promise<
+    | { ok: true; mtimeMs: number; size: number; result: { activeTabId: string | null } }
+    | { ok: false; tag: 'StaleWrite'; actualMtimeMs: number }
+    | { ok: false; tag: 'WriteFailed' | 'StatFailed'; message: string }
+  >
+  tabPrepareCloseEditorFile?: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+  ) => Promise<
+    | { ok: true }
+    | { ok: false; reason: 'cancelled' }
+    | { ok: false; reason: 'save-failed'; failedCount: number }
+  >
+  tabLoadEditorFile?: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    options?: { maxBytes?: number },
+  ) => Promise<
+    | {
+        ok: true
+        binary: false
+        content: string
+        truncated: boolean
+        size: number
+        canWrite: boolean
+        mtimeMs: number
+        fileLineEnding: 'LF' | 'CRLF'
+      }
+    | {
+        ok: true
+        binary: true
+        size: number
+        canWrite: boolean
+        mtimeMs: number
+      }
+    | { ok: false; tag: 'ReadFailed' | 'StatFailed'; message: string }
+  >
+  fileTreeReadDir?: (
+    dirPath: string,
+  ) => Promise<Array<{ name: string; isDirectory: boolean; size: number }>>
+  fileTreeCreateFile?: (filePath: string) => Promise<void>
+  fileTreeCreateDirectory?: (dirPath: string) => Promise<void>
+  fileTreeGetGitStatus?: (
+    repoRoot: string,
+    worktreePath: string,
+  ) => Promise<{
+    statuses: Record<string, string>
+    changedDirs: string[]
+    affectedPaths: string[]
+  }>
+  changesGetDiff?: (payload: { worktreePath: string }) => Promise<{
+    files: Array<{ path: string; status: string }>
+  }>
+  changesStageFile?: (payload: { worktreePath: string; filePath: string }) => Promise<void>
+  changesRevertFile?: (payload: { worktreePath: string; filePath: string }) => Promise<void>
+  taskTrackerPrepareBranchFromTask?: (payload: {
+    connectionId: string
+    task: Record<string, unknown>
+    boardId?: string
+    branchType?: string
+    repoRoot: string
+  }) => Promise<{ branchName: string }>
+  taskTrackerCreateBranchFromTask?: (payload: {
+    connectionId: string
+    task: Record<string, unknown>
+    boardId?: string
+    branchType?: string
+    repoRoot: string
+    baseBranch: string
+    stashBeforeCreate?: boolean
+  }) => Promise<{ branchName: string }>
+  worktreeRemoveWithBranch?: (payload: {
+    repoRoot: string
+    worktreePath: string
+    branch?: string
+    deleteBranch?: boolean
+    forceOnFailure?: boolean
+  }) => Promise<{
+    worktreeRemoved: boolean
+    branchDeleted: boolean
+    forcedWorktreeRemove: boolean
+    forcedBranchDelete: boolean
+  }>
+  worktreePrepareRemove?: (payload: {
+    repoRoot: string
+    worktreePath: string
+    branch: string
+  }) => Promise<{
+    hasUncommittedChanges: boolean
+    unmergedCommitCount: number
+    branchMerged: boolean
+    forceRequired: boolean
+    canDeleteBranch: boolean
+    warnings: string[]
+  }>
+  worktreeGetMergedBranches?: (payload: {
+    repoRoot: string
+    branches: string[]
+  }) => Promise<{ mergedBranches: string[] }>
+  worktreeListBranches?: (payload: {
+    repoRoot: string
+  }) => Promise<{ local: string[]; remote: string[]; current: string | null }>
+  worktreeRefreshBranches?: (payload: {
+    repoRoot: string
+  }) => Promise<{ local: string[]; remote: string[]; current: string | null }>
+  gitBranchPrepareDelete?: (payload: { repoRoot: string; branch: string }) => Promise<{
+    branchMerged: boolean
+    forceRequired: boolean
+    warnings: string[]
+  }>
+  gitBranchDeleteWithPreflight?: (payload: {
+    repoRoot: string
+    branch: string
+    forceIfUnmerged?: boolean
+  }) => Promise<{
+    branchDeleted: boolean
+    forcedBranchDelete: boolean
+    branchMerged: boolean
+  }>
+  gitPreparePush?: (payload: { repoRoot: string }) => Promise<
+    | {
+        hasUpstream: false
+        confirmationMessage: string
+      }
+    | {
+        hasUpstream: true
+        branch: string
+        remote: string
+        commitCount: number
+        confirmationMessage: string
+      }
+  >
+  gitPullWithPreferences?: (payload: {
+    repoRoot: string
+  }) => Promise<{ summary: string; rebase: boolean }>
+  gitCommitWorktree?: (payload: {
+    repoRoot: string
+    message: string
+    stageAll?: boolean
+  }) => Promise<{ hash: string; summary: string }>
+  gitPushWorktree?: (payload: { repoRoot: string }) => Promise<{ branch: string; remote: string }>
+  gitFetchWorktree?: (payload: { repoRoot: string }) => Promise<void>
+  gitStashWorktree?: (payload: { repoRoot: string }) => Promise<void>
+  gitStashPopWorktree?: (payload: { repoRoot: string }) => Promise<void>
+  gitBranchCreateFromHead?: (payload: { repoRoot: string; branch: string }) => Promise<void>
+  worktreeCreate?: (
+    payload:
+      | {
+          repoRoot: string
+          worktreePath: string
+          mode: 'new'
+          branch: string
+          baseBranch: string
+        }
+      | {
+          repoRoot: string
+          worktreePath: string
+          mode: 'existing'
+          branch: string
+          createLocalTracking?: boolean
+        },
+  ) => Promise<{ branch: string; worktreePath: string }>
+  taskTrackerCreateWorktreeFromTask?: (payload: {
+    connectionId: string
+    task: Record<string, unknown>
+    boardId?: string
+    branchType?: string
+    repoRoot: string
+    worktreePath: string
+    baseBranch: string
+  }) => Promise<{ branchName: string; worktreePath: string }>
+  taskTrackerBuildTaskContext?: (payload: {
+    connectionId: string
+    task: Record<string, unknown>
+    repoRoot?: string
+    trackerId?: string
+  }) => Promise<string>
+  tabUpdatePaneTitle?: (
+    worktreePath: string,
+    sessionId: string,
+    title: string,
+  ) => Promise<{ activeTabId: string | null }>
+  tabUpdatePaneUrl?: (
+    worktreePath: string,
+    sessionId: string,
+    url: string,
+  ) => Promise<{ activeTabId: string | null }>
+  tabUpdateTmuxSessionName?: (
+    worktreePath: string,
+    oldName: string,
+    newName: string,
+  ) => Promise<{ activeTabId: string | null }>
+  tabHandlePtyExit?: (
+    worktreePath: string,
+    sessionId: string,
+    exitCode: number,
+    tmuxSessionName?: string,
+  ) => Promise<{ activeTabId: string | null }>
+  tabKillTmuxPane?: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+  ) => Promise<{ activeTabId: string | null }>
+  tabReattachTmuxPane?: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+  ) => Promise<{ activeTabId: string | null }>
+  tabToggleFocusedInspector?: (
+    worktreePath: string,
+    tabId: string,
+  ) => Promise<{ activeTabId: string | null }>
+  tabSplitPane?: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+    direction: 'horizontal' | 'vertical',
+  ) => Promise<unknown>
+  tabFocusPane?: (worktreePath: string, tabId: string, paneId: string) => Promise<unknown>
+  tabClosePane?: (worktreePath: string, tabId: string, paneId: string) => Promise<unknown>
+  tabCloseAllForWorktree?: (
+    worktreePath: string,
+  ) => Promise<{ tabs: unknown[]; activeTabId: string | null }>
+  tabKillAll?: () => Promise<{
+    tabsByWorktree: Record<string, unknown[]>
+    activeTabIdByWorktree: Record<string, string | null>
+  }>
+  tabRestoreLayout?: (
+    worktreePath: string,
+    layoutJson: string,
+  ) => Promise<{
+    restored?: boolean
+    tabs: Array<{
+      id: string
+      toolId: string
+      suspended?: unknown
+      rootSplit: {
+        type: 'leaf' | 'split'
+        pane?: {
+          paneType?: string
+          url?: string
+          isRunning?: boolean
+        }
+      }
+    }>
+    activeTabId: string | null
+  }>
+  tabResumeSuspendedTab?: (
+    worktreePath: string,
+    tabId: string,
+  ) => Promise<{ activeTabId: string | null }>
+  tabSaveCurrentLayout?: (worktreePath: string) => Promise<unknown>
+  tabFocusSession?: (sessionId: string) => Promise<{ activeTabId: string | null } | null>
+  tabNavigatePaneFocus?: (
+    worktreePath: string,
+    tabId: string,
+    direction: 'left' | 'right' | 'up' | 'down',
+  ) => Promise<unknown>
+  tabUpdateSplitRatio?: (
+    worktreePath: string,
+    tabId: string,
+    splitId: string,
+    ratio: number,
+  ) => Promise<unknown>
+  tabSetActiveTab?: (worktreePath: string, tabId: string) => Promise<unknown>
+  tabMoveTab?: (worktreePath: string, fromIndex: number, toIndex: number) => Promise<unknown>
+  tabMoveTabToSplit?: (
+    worktreePath: string,
+    sourceTabId: string,
+    targetTabId: string,
+    targetPaneId: string,
+    direction: 'horizontal' | 'vertical',
+    position: 'first' | 'second',
+  ) => Promise<unknown>
+  tabMovePaneToTarget?: (
+    worktreePath: string,
+    sourceTabId: string,
+    sourcePaneId: string,
+    targetTabId: string,
+    targetPaneId: string,
+    direction: 'horizontal' | 'vertical',
+    position: 'first' | 'second',
+  ) => Promise<unknown>
+  tabDetachPaneToTab?: (
+    worktreePath: string,
+    sourceTabId: string,
+    sourcePaneId: string,
+  ) => Promise<{ openedTab?: { id: string } }>
+}
+
+function hasProject(snapshot: AppStateSnapshot, projectPath: string): boolean {
+  return snapshot.workspace.projects.some(
+    (project) => project.workspace.path === projectPath || project.repoRoot === projectPath,
+  )
+}
+
+async function dismissSetupWizard(page: Page): Promise<void> {
+  const skipSetup = page.getByRole('button', { name: 'Skip setup' })
+  if (!(await skipSetup.isVisible({ timeout: 1_000 }).catch(() => false))) return
+  await skipSetup.click()
+  await page.getByRole('dialog', { name: 'Setup wizard' }).waitFor({
+    state: 'detached',
+    timeout: 5_000,
+  })
+}
+
+async function openShellTabWithPane(
+  page: Page,
+  projectPath: string,
+): Promise<{ id: string; paneId: string; sessionId: string; wsUrl: string }> {
+  return page.evaluate(async (path) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabOpenTool !== 'function') {
+      throw new Error('Missing tabOpenTool API')
+    }
+    const result = await api.tabOpenTool('shell', path)
+    const tabId = result.openedTab?.id
+    if (!tabId) throw new Error('Shell tab did not open')
+
+    const snapshot = await api.getAppState()
+    const tab = snapshot.tabs?.tabsByWorktree[path]?.find((candidate) => candidate.id === tabId)
+    const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+    if (!pane) throw new Error('Shell pane did not open')
+
+    return { id: tabId, paneId: pane.id, sessionId: pane.sessionId, wsUrl: pane.wsUrl }
+  }, projectPath)
+}
+
+test.beforeEach(async () => {
+  extraTmpPaths = []
+  tmpDir = await mkdtemp(join(homedir(), 'canopy-e2e-app-state-'))
+  execSync('git init', { cwd: tmpDir })
+  execSync('git config user.email "test@test.com"', { cwd: tmpDir })
+  execSync('git config user.name "Test"', { cwd: tmpDir })
+  await writeFile(join(tmpDir, 'README.md'), '# Test Project\n')
+  execSync('git add . && git commit -m "init"', { cwd: tmpDir })
+  await writeFile(join(tmpDir, 'DIRTY.txt'), 'uncommitted\n')
+})
+
+test.afterEach(async () => {
+  await Promise.all([
+    rm(tmpDir, { recursive: true, force: true }),
+    ...extraTmpPaths.map((target) => rm(target, { recursive: true, force: true })),
+  ])
+})
+
+test('main process exposes and publishes app state snapshots', async ({ electronApp, page }) => {
+  await page.waitForFunction(() => !!(window as unknown as { api?: unknown }).api)
+  await dismissSetupWizard(page)
+
+  const apiShape = await page.evaluate(() => {
+    const api = (window as unknown as { api: AppStateApi }).api
+    return {
+      getAppState: typeof api.getAppState,
+      onAppStateChanged: typeof api.onAppStateChanged,
+      tabSyncState: typeof (api as AppStateApi & { tabSyncState?: unknown }).tabSyncState,
+      tabSaveLayout: typeof (api as AppStateApi & { tabSaveLayout?: unknown }).tabSaveLayout,
+      hasChildProcess: typeof (api as AppStateApi & { hasChildProcess?: unknown }).hasChildProcess,
+      writeFile: typeof (api as AppStateApi & { writeFile?: unknown }).writeFile,
+      readFile: typeof (api as AppStateApi & { readFile?: unknown }).readFile,
+      statFile: typeof (api as AppStateApi & { statFile?: unknown }).statFile,
+      readDir: typeof (api as AppStateApi & { readDir?: unknown }).readDir,
+      createFile: typeof (api as AppStateApi & { createFile?: unknown }).createFile,
+      mkdir: typeof (api as AppStateApi & { mkdir?: unknown }).mkdir,
+      confirmUnsavedChanges: typeof (api as AppStateApi & { confirmUnsavedChanges?: unknown })
+        .confirmUnsavedChanges,
+      fileTreeReadDir: typeof api.fileTreeReadDir,
+      fileTreeCreateFile: typeof api.fileTreeCreateFile,
+      fileTreeCreateDirectory: typeof api.fileTreeCreateDirectory,
+      fileTreeGetGitStatus: typeof api.fileTreeGetGitStatus,
+      changesGetDiff: typeof api.changesGetDiff,
+      changesStageFile: typeof api.changesStageFile,
+      changesRevertFile: typeof api.changesRevertFile,
+      taskTrackerPrepareBranchFromTask: typeof api.taskTrackerPrepareBranchFromTask,
+      taskTrackerCreateBranchFromTask: typeof api.taskTrackerCreateBranchFromTask,
+      worktreeRemoveWithBranch: typeof api.worktreeRemoveWithBranch,
+      worktreePrepareRemove: typeof api.worktreePrepareRemove,
+      worktreeGetMergedBranches: typeof api.worktreeGetMergedBranches,
+      worktreeListBranches: typeof api.worktreeListBranches,
+      worktreeRefreshBranches: typeof api.worktreeRefreshBranches,
+      gitBranchPrepareDelete: typeof api.gitBranchPrepareDelete,
+      gitBranchDeleteWithPreflight: typeof api.gitBranchDeleteWithPreflight,
+      gitPreparePush: typeof api.gitPreparePush,
+      gitPullWithPreferences: typeof api.gitPullWithPreferences,
+      gitCommitWorktree: typeof api.gitCommitWorktree,
+      gitPushWorktree: typeof api.gitPushWorktree,
+      gitFetchWorktree: typeof api.gitFetchWorktree,
+      gitStashWorktree: typeof api.gitStashWorktree,
+      gitStashPopWorktree: typeof api.gitStashPopWorktree,
+      gitBranchCreateFromHead: typeof api.gitBranchCreateFromHead,
+      worktreeCreate: typeof api.worktreeCreate,
+      taskTrackerCreateWorktreeFromTask: typeof api.taskTrackerCreateWorktreeFromTask,
+      taskTrackerBuildTaskContext: typeof api.taskTrackerBuildTaskContext,
+      tabOpenTool: typeof api.tabOpenTool,
+      tabSaveCurrentLayout: typeof api.tabSaveCurrentLayout,
+      tabPrepareCloseTab: typeof api.tabPrepareCloseTab,
+      tabGetCloseWarning: typeof api.tabGetCloseWarning,
+      tabSaveEditorFile: typeof api.tabSaveEditorFile,
+      tabPrepareCloseEditorFile: typeof api.tabPrepareCloseEditorFile,
+      tabLoadEditorFile: typeof api.tabLoadEditorFile,
+      tabReopenClosedTab: typeof api.tabReopenClosedTab,
+    }
+  })
+
+  expect(apiShape.getAppState).toBe('function')
+  expect(apiShape.onAppStateChanged).toBe('function')
+  expect(apiShape.tabSyncState).toBe('undefined')
+  expect(apiShape.tabSaveLayout).toBe('undefined')
+  expect(apiShape.hasChildProcess).toBe('undefined')
+  expect(apiShape.writeFile).toBe('undefined')
+  expect(apiShape.readFile).toBe('undefined')
+  expect(apiShape.statFile).toBe('undefined')
+  expect(apiShape.readDir).toBe('undefined')
+  expect(apiShape.createFile).toBe('undefined')
+  expect(apiShape.mkdir).toBe('undefined')
+  expect(apiShape.confirmUnsavedChanges).toBe('undefined')
+  expect(apiShape.fileTreeReadDir).toBe('function')
+  expect(apiShape.fileTreeCreateFile).toBe('function')
+  expect(apiShape.fileTreeCreateDirectory).toBe('function')
+  expect(apiShape.fileTreeGetGitStatus).toBe('function')
+  expect(apiShape.changesGetDiff).toBe('function')
+  expect(apiShape.changesStageFile).toBe('function')
+  expect(apiShape.changesRevertFile).toBe('function')
+  expect(apiShape.taskTrackerPrepareBranchFromTask).toBe('function')
+  expect(apiShape.taskTrackerCreateBranchFromTask).toBe('function')
+  expect(apiShape.worktreeRemoveWithBranch).toBe('function')
+  expect(apiShape.worktreePrepareRemove).toBe('function')
+  expect(apiShape.worktreeGetMergedBranches).toBe('function')
+  expect(apiShape.worktreeListBranches).toBe('function')
+  expect(apiShape.worktreeRefreshBranches).toBe('function')
+  expect(apiShape.gitBranchPrepareDelete).toBe('function')
+  expect(apiShape.gitBranchDeleteWithPreflight).toBe('function')
+  expect(apiShape.gitPreparePush).toBe('function')
+  expect(apiShape.gitPullWithPreferences).toBe('function')
+  expect(apiShape.gitCommitWorktree).toBe('function')
+  expect(apiShape.gitPushWorktree).toBe('function')
+  expect(apiShape.gitFetchWorktree).toBe('function')
+  expect(apiShape.gitStashWorktree).toBe('function')
+  expect(apiShape.gitStashPopWorktree).toBe('function')
+  expect(apiShape.gitBranchCreateFromHead).toBe('function')
+  expect(apiShape.worktreeCreate).toBe('function')
+  expect(apiShape.taskTrackerCreateWorktreeFromTask).toBe('function')
+  expect(apiShape.taskTrackerBuildTaskContext).toBe('function')
+  expect(apiShape.tabOpenTool).toBe('function')
+  expect(apiShape.tabSaveCurrentLayout).toBe('function')
+  expect(apiShape.tabPrepareCloseTab).toBe('function')
+  expect(apiShape.tabGetCloseWarning).toBe('function')
+  expect(apiShape.tabSaveEditorFile).toBe('function')
+  expect(apiShape.tabPrepareCloseEditorFile).toBe('function')
+  expect(apiShape.tabLoadEditorFile).toBe('function')
+  expect(apiShape.tabReopenClosedTab).toBe('function')
+
+  const newWindowPromise = electronApp.waitForEvent('window')
+  await electronApp.evaluate(({ app, dialog }, projectPath) => {
+    const originalShowMessageBox = dialog.showMessageBox
+    dialog.showMessageBox = async () => ({ response: 0, checkboxChecked: false })
+    app.emit(
+      'open-url',
+      { preventDefault: () => {} },
+      `canopy://open?path=${encodeURIComponent(projectPath)}`,
+    )
+    setTimeout(() => {
+      dialog.showMessageBox = originalShowMessageBox
+    }, 1_000)
+  }, tmpDir)
+
+  const workspacePage = await newWindowPromise
+  await workspacePage.waitForFunction(() => {
+    const api = (window as unknown as { api?: AppStateApi }).api
+    return typeof api?.getAppState === 'function'
+  })
+  await dismissSetupWizard(workspacePage)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api
+            .getAppState()
+            .then((snapshot) =>
+              snapshot.workspace.projects.some(
+                (project) =>
+                  project.workspace.path === projectPath || project.repoRoot === projectPath,
+              ),
+            )
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toBe(true)
+
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabOpenTool !== 'function') {
+      throw new Error('Missing tabOpenTool API')
+    }
+    return api.tabOpenTool('shell', projectPath)
+  }, tmpDir)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+            const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+            return tabs.some((tab) => tab.toolId === 'shell' && tab.id === activeTabId)
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toBe(true)
+
+  const shellTab = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    return api.getAppState().then((snapshot) => {
+      const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+      const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+      return tabs.find((tab) => tab.toolId === 'shell' && tab.id === activeTabId) ?? null
+    })
+  }, tmpDir)
+  expect(shellTab).not.toBeNull()
+  await expect(workspacePage.getByRole('tablist', { name: 'Terminal tabs' })).toBeVisible({
+    timeout: 10_000,
+  })
+  await expect(workspacePage.getByText(/Press .* to open a new tab/)).not.toBeVisible()
+
+  const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+  await workspacePage.keyboard.press(`${modifier}+K`)
+  await expect(workspacePage.getByRole('dialog', { name: 'Command palette' })).toBeVisible()
+  await workspacePage.keyboard.press('Escape')
+  await expect(workspacePage.getByRole('dialog', { name: 'Command palette' })).not.toBeVisible()
+  await workspacePage.keyboard.press(`${modifier}+,`)
+  await expect(workspacePage.getByRole('dialog', { name: /Settings/ })).toBeVisible()
+  await workspacePage.keyboard.press('Escape')
+  await expect(workspacePage.getByRole('dialog', { name: /Settings/ })).not.toBeVisible()
+
+  const initialPaneId =
+    shellTab?.rootSplit.type === 'leaf' ? shellTab.rootSplit.pane?.id : undefined
+  const initialSessionId =
+    shellTab?.rootSplit.type === 'leaf' ? shellTab.rootSplit.pane?.sessionId : undefined
+  expect(initialPaneId).toBeTruthy()
+  expect(initialSessionId).toBeTruthy()
+
+  await expect(
+    page.evaluate(async (sessionId) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      await api.resizePty(sessionId, 100, 30)
+      return true
+    }, initialSessionId!),
+  ).resolves.toBe(true)
+
+  const closeWarning = await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabGetCloseWarning !== 'function') {
+        throw new Error('Missing tabGetCloseWarning API')
+      }
+      return api.tabGetCloseWarning(projectPath, { kind: 'tab', tabId })
+    },
+    { projectPath: tmpDir, tabId: shellTab!.id },
+  )
+  expect(closeWarning).toEqual({ description: null })
+
+  const closePreflight = await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabPrepareCloseTab !== 'function') {
+        throw new Error('Missing tabPrepareCloseTab API')
+      }
+      return api.tabPrepareCloseTab(projectPath, tabId)
+    },
+    { projectPath: tmpDir, tabId: shellTab!.id },
+  )
+  expect(closePreflight).toEqual({ ok: true })
+
+  const rootEntries = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.fileTreeReadDir !== 'function') {
+      throw new Error('Missing fileTreeReadDir API')
+    }
+    return api.fileTreeReadDir(projectPath)
+  }, tmpDir)
+  expect(rootEntries).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ name: 'README.md', isDirectory: false, size: 15 }),
+      expect.objectContaining({ name: 'DIRTY.txt', isDirectory: false, size: 12 }),
+    ]),
+  )
+
+  const newFilePath = join(tmpDir, 'nested', 'from-file-tree.txt')
+  const newDirPath = join(tmpDir, 'created-dir')
+  await workspacePage.evaluate(
+    ({ filePath, dirPath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.fileTreeCreateFile !== 'function') {
+        throw new Error('Missing fileTreeCreateFile API')
+      }
+      if (typeof api.fileTreeCreateDirectory !== 'function') {
+        throw new Error('Missing fileTreeCreateDirectory API')
+      }
+      return Promise.all([api.fileTreeCreateFile(filePath), api.fileTreeCreateDirectory(dirPath)])
+    },
+    { filePath: newFilePath, dirPath: newDirPath },
+  )
+  expect(await readFile(newFilePath, 'utf8')).toBe('')
+  expect((await stat(newDirPath)).isDirectory()).toBe(true)
+
+  const fileTreeGitStatus = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.fileTreeGetGitStatus !== 'function') {
+      throw new Error('Missing fileTreeGetGitStatus API')
+    }
+    return api.fileTreeGetGitStatus(projectPath, projectPath)
+  }, tmpDir)
+  expect(fileTreeGitStatus.statuses).toMatchObject({
+    'DIRTY.txt': '?',
+    'nested/': '?',
+  })
+  expect(fileTreeGitStatus.changedDirs).toEqual(['nested'])
+  expect(fileTreeGitStatus.affectedPaths).toEqual(expect.arrayContaining(['DIRTY.txt', 'nested/']))
+
+  await writeFile(join(tmpDir, 'README.md'), '# Test Project\ntracked change\n')
+  const taskTrackerBranch = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.taskTrackerPrepareBranchFromTask !== 'function') {
+      throw new Error('Missing taskTrackerPrepareBranchFromTask API')
+    }
+    if (typeof api.taskTrackerCreateBranchFromTask !== 'function') {
+      throw new Error('Missing taskTrackerCreateBranchFromTask API')
+    }
+    const task = {
+      key: 'CANOPY-101',
+      summary: 'Move renderer branch creation to main',
+      description: '',
+      status: 'Open',
+      priority: 'Medium',
+      type: 'task',
+    }
+    return api
+      .taskTrackerPrepareBranchFromTask({
+        connectionId: 'e2e',
+        task,
+        repoRoot: projectPath,
+      })
+      .then((prepared) =>
+        api
+          .taskTrackerCreateBranchFromTask({
+            connectionId: 'e2e',
+            task,
+            repoRoot: projectPath,
+            baseBranch: 'HEAD',
+            stashBeforeCreate: true,
+          })
+          .then((created) => ({ prepared, created })),
+      )
+  }, tmpDir)
+  expect(taskTrackerBranch).toEqual({
+    prepared: { branchName: 'CANOPY-101' },
+    created: { branchName: 'CANOPY-101' },
+  })
+  expect(execSync('git branch --list CANOPY-101', { cwd: tmpDir }).toString()).toContain(
+    'CANOPY-101',
+  )
+  expect(await readFile(join(tmpDir, 'README.md'), 'utf8')).toBe('# Test Project\n')
+
+  const taskWorktreePath = `${tmpDir}-task-worktree`
+  extraTmpPaths.push(taskWorktreePath)
+  const taskWorktreeResult = await workspacePage.evaluate(
+    ({ projectPath, worktreePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.taskTrackerCreateWorktreeFromTask !== 'function') {
+        throw new Error('Missing taskTrackerCreateWorktreeFromTask API')
+      }
+      return api.taskTrackerCreateWorktreeFromTask({
+        connectionId: 'e2e',
+        task: {
+          key: 'CANOPY-202',
+          summary: 'Create worktree from task in main',
+          description: '',
+          status: 'Open',
+          priority: 'Medium',
+          type: 'task',
+        },
+        repoRoot: projectPath,
+        worktreePath,
+        baseBranch: 'HEAD',
+      })
+    },
+    { projectPath: tmpDir, worktreePath: taskWorktreePath },
+  )
+  expect(taskWorktreeResult).toEqual({
+    branchName: 'CANOPY-202',
+    worktreePath: taskWorktreePath,
+  })
+  expect((await stat(join(taskWorktreePath, 'README.md'))).isFile()).toBe(true)
+  expect(execSync('git branch --list CANOPY-202', { cwd: tmpDir }).toString()).toContain(
+    'CANOPY-202',
+  )
+
+  const genericWorktreePath = `${tmpDir}-generic-worktree`
+  extraTmpPaths.push(genericWorktreePath)
+  const genericWorktreeResult = await workspacePage.evaluate(
+    ({ projectPath, worktreePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.worktreeCreate !== 'function') {
+        throw new Error('Missing worktreeCreate API')
+      }
+      return api.worktreeCreate({
+        repoRoot: projectPath,
+        worktreePath,
+        mode: 'new',
+        branch: 'CANOPY-GENERIC',
+        baseBranch: 'HEAD',
+      })
+    },
+    { projectPath: tmpDir, worktreePath: genericWorktreePath },
+  )
+  expect(genericWorktreeResult).toEqual({
+    branch: 'CANOPY-GENERIC',
+    worktreePath: genericWorktreePath,
+  })
+  expect((await stat(join(genericWorktreePath, 'README.md'))).isFile()).toBe(true)
+
+  const taskContext = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.taskTrackerBuildTaskContext !== 'function') {
+      throw new Error('Missing taskTrackerBuildTaskContext API')
+    }
+    return api.taskTrackerBuildTaskContext({
+      connectionId: 'e2e',
+      repoRoot: projectPath,
+      task: {
+        key: 'CANOPY-303',
+        summary: 'Build task context in main',
+        description: 'First line\r\n\r\n\r\nSecond line',
+        status: 'Open',
+        priority: 'High',
+        type: 'task',
+        url: 'https://example.test/CANOPY-303',
+      },
+    })
+  }, tmpDir)
+  expect(taskContext).toContain('Work on the following task:')
+  expect(taskContext).toContain('# CANOPY-303: Build task context in main')
+  expect(taskContext).toContain('Status: Open | Priority: High | Type: task')
+  expect(taskContext).toContain('URL: https://example.test/CANOPY-303')
+  expect(taskContext).toContain('First line\n\nSecond line')
+  expect(taskContext).not.toContain('undefined')
+
+  const pushPreflight = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.gitPreparePush !== 'function') {
+      throw new Error('Missing gitPreparePush API')
+    }
+    return api.gitPreparePush({ repoRoot: projectPath })
+  }, tmpDir)
+  expect(pushPreflight).toEqual({
+    hasUpstream: false,
+    confirmationMessage: 'No upstream branch — push and set tracking to origin?',
+  })
+
+  await writeFile(join(tmpDir, '.git', 'info', 'exclude'), '\n.canopy-e2e-pull/\n', {
+    flag: 'a',
+  })
+  const pullBasePath = join(tmpDir, '.canopy-e2e-pull')
+  const pullRepoPath = join(pullBasePath, 'repo')
+  const pullRemotePath = join(pullBasePath, 'remote.git')
+  const pullWriterPath = join(pullBasePath, 'writer')
+  execFileSync('git', ['init', pullRepoPath])
+  execSync('git config user.email "test@test.com"', { cwd: pullRepoPath })
+  execSync('git config user.name "Test"', { cwd: pullRepoPath })
+  await writeFile(join(pullRepoPath, 'README.md'), '# Pull Repo\n')
+  execSync('git add . && git commit -m "init"', { cwd: pullRepoPath })
+  const pullBranch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: pullRepoPath,
+  })
+    .toString()
+    .trim()
+  execFileSync('git', ['clone', '--bare', pullRepoPath, pullRemotePath])
+  execFileSync('git', ['remote', 'add', 'origin', pullRemotePath], { cwd: pullRepoPath })
+  execFileSync('git', ['push', '-u', 'origin', pullBranch], { cwd: pullRepoPath })
+  execFileSync('git', ['clone', '-b', pullBranch, pullRemotePath, pullWriterPath])
+  execSync('git config user.email "test@test.com"', { cwd: pullWriterPath })
+  execSync('git config user.name "Test"', { cwd: pullWriterPath })
+  await writeFile(join(pullWriterPath, 'PULL_REMOTE.txt'), 'remote update\n')
+  execSync('git add PULL_REMOTE.txt && git commit -m "remote update"', { cwd: pullWriterPath })
+  execFileSync('git', ['push', 'origin', pullBranch], { cwd: pullWriterPath })
+
+  const pullResult = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.setPref !== 'function') {
+      throw new Error('Missing setPref API')
+    }
+    if (typeof api.gitPullWithPreferences !== 'function') {
+      throw new Error('Missing gitPullWithPreferences API')
+    }
+    return api
+      .setPref('gitPullRebase', 'false')
+      .then(() => api.gitPullWithPreferences({ repoRoot: projectPath }))
+  }, pullRepoPath)
+  expect(pullResult).toEqual({ summary: '1 file(s) updated', rebase: false })
+  expect(await readFile(join(pullRepoPath, 'PULL_REMOTE.txt'), 'utf8')).toBe('remote update\n')
+  await writeFile(join(pullWriterPath, 'FETCH_REMOTE.txt'), 'fetch update\n')
+  execSync('git add FETCH_REMOTE.txt && git commit -m "fetch update"', { cwd: pullWriterPath })
+  execFileSync('git', ['push', 'origin', pullBranch], { cwd: pullWriterPath })
+
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.gitFetchWorktree !== 'function') {
+      throw new Error('Missing gitFetchWorktree API')
+    }
+    return api.gitFetchWorktree({ repoRoot: projectPath })
+  }, pullRepoPath)
+  const fetchedRemoteHead = execFileSync(
+    'git',
+    ['rev-parse', `origin/${pullBranch}:FETCH_REMOTE.txt`],
+    { cwd: pullRepoPath },
+  )
+    .toString()
+    .trim()
+  expect(fetchedRemoteHead).toBeTruthy()
+
+  await writeFile(join(pullRepoPath, 'README.md'), '# Pull Repo\nlocal change\n')
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.gitStashWorktree !== 'function') {
+      throw new Error('Missing gitStashWorktree API')
+    }
+    return api.gitStashWorktree({ repoRoot: projectPath })
+  }, pullRepoPath)
+  expect(execSync('git status --porcelain', { cwd: pullRepoPath }).toString().trim()).toBe('')
+  expect(execSync('git stash list', { cwd: pullRepoPath }).toString()).toContain('WIP on')
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.gitStashPopWorktree !== 'function') {
+      throw new Error('Missing gitStashPopWorktree API')
+    }
+    return api.gitStashPopWorktree({ repoRoot: projectPath })
+  }, pullRepoPath)
+  expect(await readFile(join(pullRepoPath, 'README.md'), 'utf8')).toBe(
+    '# Pull Repo\nlocal change\n',
+  )
+  const commitResult = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.gitCommitWorktree !== 'function') {
+      throw new Error('Missing gitCommitWorktree API')
+    }
+    return api.gitCommitWorktree({
+      repoRoot: projectPath,
+      message: 'local wrapper commit',
+      stageAll: true,
+    })
+  }, pullRepoPath)
+  expect(commitResult.hash).toBeTruthy()
+  expect(execSync('git log -1 --pretty=%s', { cwd: pullRepoPath }).toString().trim()).toBe(
+    'local wrapper commit',
+  )
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.gitBranchCreateFromHead !== 'function') {
+      throw new Error('Missing gitBranchCreateFromHead API')
+    }
+    return api.gitBranchCreateFromHead({
+      repoRoot: projectPath,
+      branch: 'CANOPY-WRAPPER-BRANCH',
+    })
+  }, pullRepoPath)
+  expect(
+    execSync('git branch --list CANOPY-WRAPPER-BRANCH', { cwd: pullRepoPath }).toString(),
+  ).toContain('CANOPY-WRAPPER-BRANCH')
+  const listedBranches = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.worktreeListBranches !== 'function') {
+      throw new Error('Missing worktreeListBranches API')
+    }
+    return api.worktreeListBranches({ repoRoot: projectPath })
+  }, pullRepoPath)
+  expect(listedBranches.local).toContain('CANOPY-WRAPPER-BRANCH')
+  execFileSync('git', ['checkout', '-b', 'CANOPY-REFRESH-BRANCH'], { cwd: pullWriterPath })
+  await writeFile(join(pullWriterPath, 'REFRESH_BRANCH.txt'), 'refresh branch\n')
+  execSync('git add REFRESH_BRANCH.txt && git commit -m "refresh branch"', {
+    cwd: pullWriterPath,
+  })
+  execFileSync('git', ['push', 'origin', 'CANOPY-REFRESH-BRANCH'], { cwd: pullWriterPath })
+  const refreshedBranches = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.worktreeRefreshBranches !== 'function') {
+      throw new Error('Missing worktreeRefreshBranches API')
+    }
+    return api.worktreeRefreshBranches({ repoRoot: projectPath })
+  }, pullRepoPath)
+  expect(refreshedBranches.remote).toContain('origin/CANOPY-REFRESH-BRANCH')
+  await writeFile(join(pullRepoPath, 'README.md'), '# Pull Repo\nchanges diff\n')
+  const changesDiff = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.changesGetDiff !== 'function') {
+      throw new Error('Missing changesGetDiff API')
+    }
+    return api.changesGetDiff({ worktreePath: projectPath })
+  }, pullRepoPath)
+  expect(changesDiff.files.map((file) => file.path)).toContain('README.md')
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.changesRevertFile !== 'function') {
+      throw new Error('Missing changesRevertFile API')
+    }
+    return api.changesRevertFile({ worktreePath: projectPath, filePath: 'README.md' })
+  }, pullRepoPath)
+  expect(execSync('git status --porcelain', { cwd: pullRepoPath }).toString().trim()).toBe('')
+  await writeFile(join(pullRepoPath, 'README.md'), '# Pull Repo\nchanges staged\n')
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.changesStageFile !== 'function') {
+      throw new Error('Missing changesStageFile API')
+    }
+    return api.changesStageFile({ worktreePath: projectPath, filePath: 'README.md' })
+  }, pullRepoPath)
+  expect(execSync('git diff --cached --name-only', { cwd: pullRepoPath }).toString().trim()).toBe(
+    'README.md',
+  )
+
+  const pushRepoPath = join(pullBasePath, 'push-repo')
+  const pushRemotePath = join(pullBasePath, 'push-remote.git')
+  execFileSync('git', ['init', pushRepoPath])
+  execSync('git config user.email "test@test.com"', { cwd: pushRepoPath })
+  execSync('git config user.name "Test"', { cwd: pushRepoPath })
+  await writeFile(join(pushRepoPath, 'README.md'), '# Push Repo\n')
+  execSync('git add . && git commit -m "init"', { cwd: pushRepoPath })
+  execFileSync('git', ['init', '--bare', pushRemotePath])
+  execFileSync('git', ['remote', 'add', 'origin', pushRemotePath], { cwd: pushRepoPath })
+  const pushBranch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: pushRepoPath,
+  })
+    .toString()
+    .trim()
+  const pushHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: pushRepoPath })
+    .toString()
+    .trim()
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.gitPushWorktree !== 'function') {
+      throw new Error('Missing gitPushWorktree API')
+    }
+    return api.gitPushWorktree({ repoRoot: projectPath })
+  }, pushRepoPath)
+  const remotePushHead = execFileSync('git', ['rev-parse', pushBranch], {
+    cwd: pushRemotePath,
+  })
+    .toString()
+    .trim()
+  expect(remotePushHead).toBe(pushHead)
+
+  execSync('git branch CANOPY-BATCH-MERGED HEAD', { cwd: tmpDir })
+  const batchHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: tmpDir }).toString().trim()
+  const batchTree = execFileSync('git', ['rev-parse', `${batchHead}^{tree}`], { cwd: tmpDir })
+    .toString()
+    .trim()
+  const batchUnmergedCommit = execFileSync(
+    'git',
+    ['commit-tree', batchTree, '-p', batchHead, '-m', 'batch unmerged branch e2e'],
+    { cwd: tmpDir },
+  )
+    .toString()
+    .trim()
+  execFileSync('git', ['branch', 'CANOPY-BATCH-UNMERGED', batchUnmergedCommit], { cwd: tmpDir })
+  const mergedBranchBatch = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.worktreeGetMergedBranches !== 'function') {
+      throw new Error('Missing worktreeGetMergedBranches API')
+    }
+    return api.worktreeGetMergedBranches({
+      repoRoot: projectPath,
+      branches: ['CANOPY-BATCH-MERGED', 'CANOPY-BATCH-UNMERGED', '(detached)'],
+    })
+  }, tmpDir)
+  expect(mergedBranchBatch).toEqual({ mergedBranches: ['CANOPY-BATCH-MERGED'] })
+
+  execSync('git branch CANOPY-BRANCH-MERGED HEAD', { cwd: tmpDir })
+  const mergedBranchDelete = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.gitBranchPrepareDelete !== 'function') {
+      throw new Error('Missing gitBranchPrepareDelete API')
+    }
+    if (typeof api.gitBranchDeleteWithPreflight !== 'function') {
+      throw new Error('Missing gitBranchDeleteWithPreflight API')
+    }
+    return api
+      .gitBranchPrepareDelete({
+        repoRoot: projectPath,
+        branch: 'CANOPY-BRANCH-MERGED',
+      })
+      .then((preflight) =>
+        api
+          .gitBranchDeleteWithPreflight({
+            repoRoot: projectPath,
+            branch: 'CANOPY-BRANCH-MERGED',
+          })
+          .then((deleted) => ({ preflight, deleted })),
+      )
+  }, tmpDir)
+  expect(mergedBranchDelete).toEqual({
+    preflight: { branchMerged: true, forceRequired: false, warnings: [] },
+    deleted: { branchDeleted: true, forcedBranchDelete: false, branchMerged: true },
+  })
+  expect(
+    execSync('git branch --list CANOPY-BRANCH-MERGED', { cwd: tmpDir }).toString().trim(),
+  ).toBe('')
+
+  const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: tmpDir }).toString().trim()
+  const tree = execFileSync('git', ['rev-parse', `${head}^{tree}`], { cwd: tmpDir })
+    .toString()
+    .trim()
+  const unmergedCommit = execFileSync(
+    'git',
+    ['commit-tree', tree, '-p', head, '-m', 'unmerged branch delete e2e'],
+    { cwd: tmpDir },
+  )
+    .toString()
+    .trim()
+  execFileSync('git', ['branch', 'CANOPY-BRANCH-UNMERGED', unmergedCommit], { cwd: tmpDir })
+  const unmergedBranchDelete = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.gitBranchPrepareDelete !== 'function') {
+      throw new Error('Missing gitBranchPrepareDelete API')
+    }
+    if (typeof api.gitBranchDeleteWithPreflight !== 'function') {
+      throw new Error('Missing gitBranchDeleteWithPreflight API')
+    }
+    return api
+      .gitBranchPrepareDelete({
+        repoRoot: projectPath,
+        branch: 'CANOPY-BRANCH-UNMERGED',
+      })
+      .then((preflight) =>
+        api
+          .gitBranchDeleteWithPreflight({
+            repoRoot: projectPath,
+            branch: 'CANOPY-BRANCH-UNMERGED',
+            forceIfUnmerged: true,
+          })
+          .then((deleted) => ({ preflight, deleted })),
+      )
+  }, tmpDir)
+  expect(unmergedBranchDelete).toEqual({
+    preflight: {
+      branchMerged: false,
+      forceRequired: true,
+      warnings: ['Branch has not been fully merged.'],
+    },
+    deleted: { branchDeleted: true, forcedBranchDelete: true, branchMerged: false },
+  })
+  expect(
+    execSync('git branch --list CANOPY-BRANCH-UNMERGED', { cwd: tmpDir }).toString().trim(),
+  ).toBe('')
+
+  const removeWorktreePath = `${tmpDir}-remove-worktree`
+  extraTmpPaths.push(removeWorktreePath)
+  execSync('git branch CANOPY-REMOVE HEAD', { cwd: tmpDir })
+  execFileSync('git', ['worktree', 'add', removeWorktreePath, 'CANOPY-REMOVE'], { cwd: tmpDir })
+  await writeFile(join(removeWorktreePath, 'feature.txt'), 'new branch work\n')
+  execSync('git add feature.txt && git commit -m "worktree branch change"', {
+    cwd: removeWorktreePath,
+  })
+  const worktreeRemovePreflight = await workspacePage.evaluate(
+    ({ projectPath, worktreePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.worktreePrepareRemove !== 'function') {
+        throw new Error('Missing worktreePrepareRemove API')
+      }
+      return api.worktreePrepareRemove({
+        repoRoot: projectPath,
+        worktreePath,
+        branch: 'CANOPY-REMOVE',
+      })
+    },
+    { projectPath: tmpDir, worktreePath: removeWorktreePath },
+  )
+  expect(worktreeRemovePreflight).toEqual({
+    hasUncommittedChanges: false,
+    unmergedCommitCount: 2,
+    branchMerged: false,
+    forceRequired: true,
+    canDeleteBranch: false,
+    warnings: ['2 unmerged commit(s) not on any remote.'],
+  })
+  const worktreeRemoveResult = await workspacePage.evaluate(
+    ({ projectPath, worktreePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.worktreeRemoveWithBranch !== 'function') {
+        throw new Error('Missing worktreeRemoveWithBranch API')
+      }
+      return api.worktreeRemoveWithBranch({
+        repoRoot: projectPath,
+        worktreePath,
+        branch: 'CANOPY-REMOVE',
+        deleteBranch: true,
+        forceOnFailure: true,
+      })
+    },
+    { projectPath: tmpDir, worktreePath: removeWorktreePath },
+  )
+  expect(worktreeRemoveResult).toEqual({
+    worktreeRemoved: true,
+    branchDeleted: true,
+    forcedWorktreeRemove: false,
+    forcedBranchDelete: true,
+  })
+  await expect(
+    stat(removeWorktreePath).then(
+      () => true,
+      () => false,
+    ),
+  ).resolves.toBe(false)
+  expect(execSync('git branch --list CANOPY-REMOVE', { cwd: tmpDir }).toString().trim()).toBe('')
+
+  const injectedFocusResult = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabFocusSession !== 'function') {
+      throw new Error('Missing tabFocusSession API')
+    }
+    return (
+      api.tabFocusSession as unknown as (
+        sessionId: string,
+        options?: Record<string, unknown>,
+      ) => Promise<unknown>
+    )('renderer-injected-session', {
+      tabsByWorktree: {
+        [projectPath]: [
+          {
+            id: 'renderer-injected-tab',
+            toolId: 'shell',
+            toolName: 'Shell',
+            name: 'Injected',
+            worktreePath: projectPath,
+            focusedPaneId: 'renderer-injected-pane',
+            rootSplit: {
+              type: 'leaf',
+              pane: {
+                id: 'renderer-injected-pane',
+                sessionId: 'renderer-injected-session',
+                wsUrl: '',
+                toolId: 'shell',
+                toolName: 'Shell',
+                isRunning: true,
+                exitCode: null,
+                title: null,
+              },
+            },
+          },
+        ],
+      },
+    })
+  }, tmpDir)
+  expect(injectedFocusResult).toBeNull()
+
+  await workspacePage.evaluate(
+    ({ projectPath, sessionId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabUpdatePaneTitle !== 'function') {
+        throw new Error('Missing tabUpdatePaneTitle API')
+      }
+      return api.tabUpdatePaneTitle(projectPath, sessionId, 'Main owned title')
+    },
+    { projectPath: tmpDir, sessionId: initialSessionId! },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                title: pane?.title ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: shellTab!.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: shellTab!.id,
+      title: 'Main owned title',
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, sessionId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabUpdatePaneUrl !== 'function') {
+        throw new Error('Missing tabUpdatePaneUrl API')
+      }
+      return api.tabUpdatePaneUrl(projectPath, sessionId, 'https://example.test/path')
+    },
+    { projectPath: tmpDir, sessionId: initialSessionId! },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                url: pane?.url ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: shellTab!.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: shellTab!.id,
+      url: 'https://example.test/path',
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId, paneId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabSplitPane !== 'function') {
+        throw new Error('Missing tabSplitPane API')
+      }
+      return api.tabSplitPane(projectPath, tabId, paneId, 'horizontal')
+    },
+    { projectPath: tmpDir, tabId: shellTab!.id, paneId: initialPaneId! },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+            const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+            const tab = tabs.find((candidate) => candidate.id === activeTabId)
+            return {
+              splitType: tab?.rootSplit.type ?? null,
+              splitId: tab?.rootSplit.type === 'split' ? (tab.rootSplit.id ?? null) : null,
+              ratio: tab?.rootSplit.type === 'split' ? (tab.rootSplit.ratio ?? null) : null,
+              focusedPaneId: tab?.focusedPaneId ?? null,
+              hasTwoChildren:
+                tab?.rootSplit.type === 'split' &&
+                Boolean(tab.rootSplit.first) &&
+                Boolean(tab.rootSplit.second),
+            }
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      splitType: 'split',
+      splitId: expect.any(String),
+      ratio: 0.5,
+      focusedPaneId: expect.not.stringMatching(initialPaneId!),
+      hasTwoChildren: true,
+    })
+
+  const splitPaneId = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    return api.getAppState().then((snapshot) => {
+      const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+      const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+        (candidate) => candidate.id === activeTabId,
+      )
+      return tab?.focusedPaneId ?? null
+    })
+  }, tmpDir)
+  expect(splitPaneId).toBeTruthy()
+  expect(splitPaneId).not.toBe(initialPaneId)
+
+  const splitId = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    return api.getAppState().then((snapshot) => {
+      const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+      const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+        (candidate) => candidate.id === activeTabId,
+      )
+      return tab?.rootSplit.type === 'split' ? (tab.rootSplit.id ?? null) : null
+    })
+  }, tmpDir)
+  expect(splitId).toBeTruthy()
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId, paneId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabFocusPane !== 'function') {
+        throw new Error('Missing tabFocusPane API')
+      }
+      return api.tabFocusPane(projectPath, tabId, paneId)
+    },
+    { projectPath: tmpDir, tabId: shellTab!.id, paneId: initialPaneId! },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+            const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+              (candidate) => candidate.id === activeTabId,
+            )
+            return tab?.focusedPaneId ?? null
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toBe(initialPaneId)
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabNavigatePaneFocus !== 'function') {
+        throw new Error('Missing tabNavigatePaneFocus API')
+      }
+      return api.tabNavigatePaneFocus(projectPath, tabId, 'down')
+    },
+    { projectPath: tmpDir, tabId: shellTab!.id },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+            const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+              (candidate) => candidate.id === activeTabId,
+            )
+            return tab?.focusedPaneId ?? null
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toBe(splitPaneId)
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId, targetSplitId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabUpdateSplitRatio !== 'function') {
+        throw new Error('Missing tabUpdateSplitRatio API')
+      }
+      return api.tabUpdateSplitRatio(projectPath, tabId, targetSplitId, 0.37)
+    },
+    { projectPath: tmpDir, tabId: shellTab!.id, targetSplitId: splitId! },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+            const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+              (candidate) => candidate.id === activeTabId,
+            )
+            return tab?.rootSplit.type === 'split' ? (tab.rootSplit.ratio ?? null) : null
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toBe(0.37)
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId, paneId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabClosePane !== 'function') {
+        throw new Error('Missing tabClosePane API')
+      }
+      return api.tabClosePane(projectPath, tabId, paneId)
+    },
+    { projectPath: tmpDir, tabId: shellTab!.id, paneId: splitPaneId! },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+            const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+              (candidate) => candidate.id === activeTabId,
+            )
+            return {
+              splitType: tab?.rootSplit.type ?? null,
+              paneId: tab?.rootSplit.type === 'leaf' ? (tab.rootSplit.pane?.id ?? null) : null,
+              focusedPaneId: tab?.focusedPaneId ?? null,
+            }
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      splitType: 'leaf',
+      paneId: initialPaneId,
+      focusedPaneId: initialPaneId,
+    })
+
+  const secondTab = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabOpenTool !== 'function') {
+      throw new Error('Missing tabOpenTool API')
+    }
+    return api.tabOpenTool('shell', projectPath).then((result) => result.openedTab ?? null)
+  }, tmpDir)
+  expect(secondTab?.id).toBeTruthy()
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => ({
+            tabIds: (snapshot.tabs?.tabsByWorktree[projectPath] ?? []).map((tab) => tab.id),
+            activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+          }))
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      tabIds: expect.arrayContaining([secondTab!.id]),
+      activeTabId: secondTab!.id,
+    })
+
+  const reopenSourceTab = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    return api.tabOpenTool('shell', projectPath).then((result) => result.openedTab ?? null)
+  }, tmpDir)
+  expect(reopenSourceTab?.id).toBeTruthy()
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabCloseTab !== 'function') {
+        throw new Error('Missing tabCloseTab API')
+      }
+      return api.tabCloseTab(projectPath, tabId)
+    },
+    { projectPath: tmpDir, tabId: reopenSourceTab!.id },
+  )
+
+  const reopenedTab = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabReopenClosedTab !== 'function') {
+      throw new Error('Missing tabReopenClosedTab API')
+    }
+    return api.tabReopenClosedTab(projectPath).then((result) => result.openedTab ?? null)
+  }, tmpDir)
+  expect(reopenedTab?.toolId).toBe('shell')
+  expect(reopenedTab?.id).toBeTruthy()
+  expect(reopenedTab?.id).not.toBe(reopenSourceTab!.id)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              return {
+                present: tabs.some((tab) => tab.id === tabId && tab.toolId === 'shell'),
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: reopenedTab!.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      present: true,
+      activeTabId: reopenedTab!.id,
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.tabCloseTab(projectPath, tabId)
+    },
+    { projectPath: tmpDir, tabId: reopenedTab!.id },
+  )
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabSetActiveTab !== 'function') {
+        throw new Error('Missing tabSetActiveTab API')
+      }
+      return api.tabSetActiveTab(projectPath, tabId)
+    },
+    { projectPath: tmpDir, tabId: shellTab!.id },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api
+            .getAppState()
+            .then((snapshot) => snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null)
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toBe(shellTab!.id)
+
+  const moveExpectation = await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.getAppState().then((snapshot) => {
+        const tabIds = (snapshot.tabs?.tabsByWorktree[projectPath] ?? []).map((tab) => tab.id)
+        const fromIndex = tabIds.indexOf(tabId)
+        if (fromIndex < 0) throw new Error(`Opened tab not found: ${tabId}`)
+        const toIndex = fromIndex === 0 ? tabIds.length - 1 : 0
+        const expected = [...tabIds]
+        const [moved] = expected.splice(fromIndex, 1)
+        expected.splice(toIndex, 0, moved)
+        return { fromIndex, toIndex, expected }
+      })
+    },
+    { projectPath: tmpDir, tabId: secondTab!.id },
+  )
+
+  await workspacePage.evaluate(
+    ({ projectPath, fromIndex, toIndex }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabMoveTab !== 'function') {
+        throw new Error('Missing tabMoveTab API')
+      }
+      return api.tabMoveTab(projectPath, fromIndex, toIndex)
+    },
+    {
+      projectPath: tmpDir,
+      fromIndex: moveExpectation.fromIndex,
+      toIndex: moveExpectation.toIndex,
+    },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => ({
+            tabIds: (snapshot.tabs?.tabsByWorktree[projectPath] ?? []).map((tab) => tab.id),
+            activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+          }))
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      tabIds: moveExpectation.expected,
+      activeTabId: shellTab!.id,
+    })
+
+  const secondPaneId = await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.getAppState().then((snapshot) => {
+        const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+          (candidate) => candidate.id === tabId,
+        )
+        return tab?.rootSplit.type === 'leaf' ? (tab.rootSplit.pane?.id ?? null) : null
+      })
+    },
+    { projectPath: tmpDir, tabId: secondTab!.id },
+  )
+  expect(secondPaneId).toBeTruthy()
+
+  await workspacePage.evaluate(
+    ({ projectPath, sourceTabId, targetTabId, targetPaneId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabMoveTabToSplit !== 'function') {
+        throw new Error('Missing tabMoveTabToSplit API')
+      }
+      return api.tabMoveTabToSplit(
+        projectPath,
+        sourceTabId,
+        targetTabId,
+        targetPaneId,
+        'vertical',
+        'second',
+      )
+    },
+    {
+      projectPath: tmpDir,
+      sourceTabId: secondTab!.id,
+      targetTabId: shellTab!.id,
+      targetPaneId: initialPaneId!,
+    },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, targetTabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              const targetTab = tabs.find((candidate) => candidate.id === targetTabId)
+              return {
+                tabIds: tabs.map((tab) => tab.id),
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                targetSplitType: targetTab?.rootSplit.type ?? null,
+                targetDirection:
+                  targetTab?.rootSplit.type === 'split'
+                    ? (targetTab.rootSplit.direction ?? null)
+                    : null,
+                focusedPaneId: targetTab?.focusedPaneId ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, targetTabId: shellTab!.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      tabIds: moveExpectation.expected.filter((id) => id !== secondTab!.id),
+      activeTabId: shellTab!.id,
+      targetSplitType: 'split',
+      targetDirection: 'vertical',
+      focusedPaneId: secondPaneId,
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId, sourcePaneId, targetPaneId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabMovePaneToTarget !== 'function') {
+        throw new Error('Missing tabMovePaneToTarget API')
+      }
+      return api.tabMovePaneToTarget(
+        projectPath,
+        tabId,
+        sourcePaneId,
+        tabId,
+        targetPaneId,
+        'horizontal',
+        'first',
+      )
+    },
+    {
+      projectPath: tmpDir,
+      tabId: shellTab!.id,
+      sourcePaneId: secondPaneId!,
+      targetPaneId: initialPaneId!,
+    },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const root = tab?.rootSplit as
+                | {
+                    type: 'split'
+                    direction?: 'horizontal' | 'vertical'
+                    first?: { type?: 'leaf'; pane?: { id: string } }
+                  }
+                | undefined
+              return {
+                splitType: tab?.rootSplit.type ?? null,
+                direction: root?.type === 'split' ? (root.direction ?? null) : null,
+                firstPaneId:
+                  root?.type === 'split' && root.first?.type === 'leaf'
+                    ? (root.first.pane?.id ?? null)
+                    : null,
+                focusedPaneId: tab?.focusedPaneId ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: shellTab!.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      splitType: 'split',
+      direction: 'horizontal',
+      firstPaneId: secondPaneId,
+      focusedPaneId: secondPaneId,
+    })
+
+  const detachedTab = await workspacePage.evaluate(
+    ({ projectPath, tabId, paneId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabDetachPaneToTab !== 'function') {
+        throw new Error('Missing tabDetachPaneToTab API')
+      }
+      return api
+        .tabDetachPaneToTab(projectPath, tabId, paneId)
+        .then((result) => result.openedTab ?? null)
+    },
+    { projectPath: tmpDir, tabId: shellTab!.id, paneId: secondPaneId! },
+  )
+  expect(detachedTab?.id).toBeTruthy()
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, sourceTabId, detachedTabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              const sourceTab = tabs.find((candidate) => candidate.id === sourceTabId)
+              const newTab = tabs.find((candidate) => candidate.id === detachedTabId)
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                sourceSplitType: sourceTab?.rootSplit.type ?? null,
+                sourcePaneId:
+                  sourceTab?.rootSplit.type === 'leaf'
+                    ? (sourceTab.rootSplit.pane?.id ?? null)
+                    : null,
+                detachedSplitType: newTab?.rootSplit.type ?? null,
+                detachedPaneId:
+                  newTab?.rootSplit.type === 'leaf' ? (newTab.rootSplit.pane?.id ?? null) : null,
+              }
+            })
+          },
+          { projectPath: tmpDir, sourceTabId: shellTab!.id, detachedTabId: detachedTab!.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: detachedTab!.id,
+      sourceSplitType: 'leaf',
+      sourcePaneId: initialPaneId,
+      detachedSplitType: 'leaf',
+      detachedPaneId: secondPaneId,
+    })
+
+  const diffTab = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabOpenDiff !== 'function') {
+      throw new Error('Missing tabOpenDiff API')
+    }
+    return api.tabOpenDiff(projectPath).then((result) => result.openedTab ?? null)
+  }, tmpDir)
+  expect(diffTab?.id).toBeTruthy()
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, diffTabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              const diffTabs = tabs.filter((tab) => tab.toolId === 'diff')
+              const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+              const activeTab = tabs.find((tab) => tab.id === activeTabId)
+              return {
+                diffTabIds: diffTabs.map((tab) => tab.id),
+                activeTabId,
+                activeToolId: activeTab?.toolId ?? null,
+                activePaneToolId:
+                  activeTab?.rootSplit.type === 'leaf'
+                    ? (activeTab.rootSplit.pane?.toolId ?? null)
+                    : null,
+                hasDiffTab: diffTabs.some((tab) => tab.id === diffTabId),
+              }
+            })
+          },
+          { projectPath: tmpDir, diffTabId: diffTab!.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      diffTabIds: [diffTab!.id],
+      activeTabId: diffTab!.id,
+      activeToolId: 'diff',
+      activePaneToolId: 'diff',
+      hasDiffTab: true,
+    })
+
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    return api.tabOpenDiff(projectPath)
+  }, tmpDir)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+            return {
+              diffTabIds: tabs.filter((tab) => tab.toolId === 'diff').map((tab) => tab.id),
+              activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+            }
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      diffTabIds: [diffTab!.id],
+      activeTabId: diffTab!.id,
+    })
+
+  const runConfigTab = await workspacePage.evaluate(async (projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabOpenSessionTab !== 'function') {
+      throw new Error('Missing tabOpenSessionTab API')
+    }
+    if (typeof api.runConfigSave !== 'function') {
+      throw new Error('Missing runConfigSave API')
+    }
+    if (typeof api.runConfigExecuteCommand !== 'function') {
+      throw new Error('Missing runConfigExecuteCommand API')
+    }
+    await api.runConfigSave(projectPath, {
+      configurations: [
+        {
+          name: 'E2E Command',
+          command: 'node',
+          args: '-e "setInterval(() => {}, 1000)"',
+        },
+      ],
+    })
+    const session = await api.runConfigExecuteCommand(projectPath, 'E2E Command', projectPath)
+    const result = await api.tabOpenSessionTab(projectPath, 'E2E Command', session.sessionId)
+    return { tab: result.openedTab ?? null, sessionId: session.sessionId, wsUrl: session.wsUrl }
+  }, tmpDir)
+  expect(runConfigTab.tab?.id).toBeTruthy()
+  expect(runConfigTab.wsUrl).toMatch(/^ws:\/\/127\.0\.0\.1:/)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              const tab = tabs.find((candidate) => candidate.id === tabId)
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                tabToolId: tab?.toolId ?? null,
+                tabToolName: tab?.toolName ?? null,
+                tabName: tab?.name ?? null,
+                paneSessionId: pane?.sessionId ?? null,
+                paneWsUrl: pane?.wsUrl ?? null,
+                paneToolId: pane?.toolId ?? null,
+                paneToolName: pane?.toolName ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: runConfigTab.tab!.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: runConfigTab.tab!.id,
+      tabToolId: 'shell',
+      tabToolName: 'E2E Command',
+      tabName: 'E2E Command',
+      paneSessionId: runConfigTab.sessionId,
+      paneWsUrl: runConfigTab.wsUrl,
+      paneToolId: 'shell',
+      paneToolName: 'Shell',
+    })
+
+  const tmuxTab = await openShellTabWithPane(workspacePage, tmpDir)
+
+  await workspacePage.evaluate(
+    ({ projectPath, sessionId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabHandlePtyExit !== 'function') {
+        throw new Error('Missing tabHandlePtyExit API')
+      }
+      return api.tabHandlePtyExit(projectPath, sessionId, 0, 'canopy-e2e')
+    },
+    { projectPath: tmpDir, sessionId: tmuxTab.sessionId },
+  )
+  expect(tmuxTab.id).toBeTruthy()
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              const tab = tabs.find((candidate) => candidate.id === tabId)
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                tabToolId: tab?.toolId ?? null,
+                paneSessionId: pane?.sessionId ?? null,
+                paneWsUrl: pane?.wsUrl ?? null,
+                paneTmuxSessionName: pane?.tmuxSessionName ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: tmuxTab.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: tmuxTab.id,
+      tabToolId: 'shell',
+      paneSessionId: tmuxTab.sessionId,
+      paneWsUrl: tmuxTab.wsUrl,
+      paneTmuxSessionName: 'canopy-e2e',
+    })
+
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabUpdateTmuxSessionName !== 'function') {
+      throw new Error('Missing tabUpdateTmuxSessionName API')
+    }
+    return api.tabUpdateTmuxSessionName(projectPath, 'canopy-e2e', 'canopy-e2e-renamed')
+  }, tmpDir)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                paneTmuxSessionName: pane?.tmuxSessionName ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: tmuxTab.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: tmuxTab.id,
+      paneTmuxSessionName: 'canopy-e2e-renamed',
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, sessionId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabHandlePtyExit !== 'function') {
+        throw new Error('Missing tabHandlePtyExit API')
+      }
+      return api.tabHandlePtyExit(projectPath, sessionId, 7, 'canopy-e2e-renamed')
+    },
+    { projectPath: tmpDir, sessionId: tmuxTab.sessionId },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                isRunning: pane?.isRunning ?? null,
+                exitCode: pane?.exitCode ?? null,
+                detached: pane?.detached ?? null,
+                paneTmuxSessionName: pane?.tmuxSessionName ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: tmuxTab.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: tmuxTab.id,
+      isRunning: false,
+      exitCode: 7,
+      detached: false,
+      paneTmuxSessionName: 'canopy-e2e-renamed',
+    })
+
+  const killTmuxTab = await openShellTabWithPane(workspacePage, tmpDir)
+
+  await workspacePage.evaluate(
+    ({ projectPath, sessionId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabHandlePtyExit !== 'function') {
+        throw new Error('Missing tabHandlePtyExit API')
+      }
+      return api.tabHandlePtyExit(projectPath, sessionId, 0, 'canopy-e2e-kill')
+    },
+    { projectPath: tmpDir, sessionId: killTmuxTab.sessionId },
+  )
+  expect(killTmuxTab.id).toBeTruthy()
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId, paneId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabKillTmuxPane !== 'function') {
+        throw new Error('Missing tabKillTmuxPane API')
+      }
+      return api.tabKillTmuxPane(projectPath, tabId, paneId)
+    },
+    { projectPath: tmpDir, tabId: killTmuxTab.id, paneId: killTmuxTab.paneId },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                isRunning: pane?.isRunning ?? null,
+                detached: pane?.detached ?? null,
+                paneTmuxSessionName: pane?.tmuxSessionName ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: killTmuxTab.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: killTmuxTab.id,
+      isRunning: false,
+      detached: false,
+      paneTmuxSessionName: null,
+    })
+
+  const reattachTmuxSessionName = 'canopy-e2e-reattach-missing'
+  const reattachTmuxTab = await openShellTabWithPane(workspacePage, tmpDir)
+  expect(reattachTmuxTab.id).toBeTruthy()
+
+  await workspacePage.evaluate(
+    ({ projectPath, sessionId, tmuxSessionName }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabHandlePtyExit !== 'function') {
+        throw new Error('Missing tabHandlePtyExit API')
+      }
+      return api.tabHandlePtyExit(projectPath, sessionId, 0, tmuxSessionName)
+    },
+    {
+      projectPath: tmpDir,
+      sessionId: reattachTmuxTab.sessionId,
+      tmuxSessionName: reattachTmuxSessionName,
+    },
+  )
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId, paneId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabReattachTmuxPane !== 'function') {
+        throw new Error('Missing tabReattachTmuxPane API')
+      }
+      return api.tabReattachTmuxPane(projectPath, tabId, paneId)
+    },
+    { projectPath: tmpDir, tabId: reattachTmuxTab.id, paneId: reattachTmuxTab.paneId },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId, previousSessionId, previousWsUrl }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                isRunning: pane?.isRunning ?? null,
+                exitCode: pane?.exitCode ?? null,
+                detached: pane?.detached ?? null,
+                replacedSessionId: pane?.sessionId !== previousSessionId,
+                replacedWsUrl:
+                  pane?.wsUrl !== previousWsUrl &&
+                  (pane?.wsUrl?.startsWith('ws://127.0.0.1:') ?? false),
+                retainedMissingTmux: pane?.tmuxSessionName === 'canopy-e2e-reattach-missing',
+              }
+            })
+          },
+          {
+            projectPath: tmpDir,
+            tabId: reattachTmuxTab.id,
+            previousSessionId: reattachTmuxTab.sessionId,
+            previousWsUrl: reattachTmuxTab.wsUrl,
+          },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: reattachTmuxTab.id,
+      isRunning: true,
+      exitCode: null,
+      detached: false,
+      replacedSessionId: true,
+      replacedWsUrl: true,
+      retainedMissingTmux: false,
+    })
+
+  const inspectorTab = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabOpenTool !== 'function') {
+      throw new Error('Missing tabOpenTool API')
+    }
+    return api.tabOpenTool('codex', projectPath).then((result) => result.openedTab ?? null)
+  }, tmpDir)
+  expect(inspectorTab?.id).toBeTruthy()
+  const inspectorTabId = inspectorTab!.id
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabToggleFocusedInspector !== 'function') {
+        throw new Error('Missing tabToggleFocusedInspector API')
+      }
+      return api.tabToggleFocusedInspector(projectPath, tabId)
+    },
+    { projectPath: tmpDir, tabId: inspectorTabId },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                inspectorOpen: pane?.inspectorOpen ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: inspectorTabId },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: inspectorTabId,
+      inspectorOpen: true,
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.tabToggleFocusedInspector(projectPath, tabId)
+    },
+    { projectPath: tmpDir, tabId: inspectorTabId },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return pane?.inspectorOpen ?? null
+            })
+          },
+          { projectPath: tmpDir, tabId: inspectorTabId },
+        ),
+      { timeout: 10_000 },
+    )
+    .toBe(false)
+
+  const focusSessionResult = await workspacePage.evaluate((sessionId) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabFocusSession !== 'function') {
+      throw new Error('Missing tabFocusSession API')
+    }
+    return api.tabFocusSession(sessionId)
+  }, runConfigTab.sessionId)
+
+  expect(focusSessionResult?.activeTabId).toBe(runConfigTab.tab!.id)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              const tab = tabs.find((candidate) => candidate.id === tabId)
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                focusedPaneId: tab?.focusedPaneId ?? null,
+                paneId: pane?.id ?? null,
+                paneSessionId: pane?.sessionId ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: runConfigTab.tab!.id },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: runConfigTab.tab!.id,
+      focusedPaneId: expect.any(String),
+      paneId: expect.any(String),
+      paneSessionId: runConfigTab.sessionId,
+    })
+
+  const closeAllResult = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabCloseAllForWorktree !== 'function') {
+      throw new Error('Missing tabCloseAllForWorktree API')
+    }
+    return api.tabCloseAllForWorktree(projectPath).then((result) => ({
+      tabCount: result.tabs.length,
+      activeTabId: result.activeTabId,
+    }))
+  }, tmpDir)
+
+  expect(closeAllResult).toEqual({
+    tabCount: 0,
+    activeTabId: null,
+  })
+
+  const killAllResult = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabKillAll !== 'function') {
+      throw new Error('Missing tabKillAll API')
+    }
+    if (typeof api.tabOpenTool !== 'function') {
+      throw new Error('Missing tabOpenTool API')
+    }
+    return api.tabOpenTool('shell', projectPath).then(() => api.tabKillAll())
+  }, tmpDir)
+
+  expect(killAllResult).toEqual({
+    tabsByWorktree: {},
+    activeTabIdByWorktree: {},
+  })
+
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabOpenTool !== 'function') {
+      throw new Error('Missing tabOpenTool API')
+    }
+    return api.tabOpenTool('shell', projectPath)
+  }, tmpDir)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+            const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+            const activeTab = tabs.find((tab) => tab.id === activeTabId)
+            return {
+              hasTabs: tabs.length > 0,
+              activeToolId: activeTab?.toolId ?? null,
+            }
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      hasTabs: true,
+      activeToolId: 'shell',
+    })
+
+  const restoreLayoutResult = await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    if (typeof api.tabRestoreLayout !== 'function') {
+      throw new Error('Missing tabRestoreLayout API')
+    }
+    return api.tabRestoreLayout(
+      projectPath,
+      JSON.stringify({
+        activeTabIndex: 0,
+        tabs: [
+          {
+            toolId: 'browser',
+            toolName: 'Browser',
+            rootSplit: {
+              type: 'leaf',
+              toolId: 'browser',
+              toolName: 'Browser',
+              browserUrl: 'https://example.test/restored',
+            },
+          },
+          {
+            toolId: 'shell',
+            toolName: 'Shell',
+            rootSplit: {
+              type: 'leaf',
+              toolId: 'shell',
+              toolName: 'Shell',
+            },
+          },
+          {
+            toolId: 'shell',
+            toolName: 'Shell',
+            rootSplit: {
+              type: 'leaf',
+              toolId: 'shell',
+              toolName: 'Shell',
+            },
+          },
+        ],
+      }),
+    )
+  }, tmpDir)
+
+  expect(restoreLayoutResult.restored).toBe(true)
+  expect(restoreLayoutResult.tabs).toHaveLength(3)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+            const activeTabId = snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null
+            const activeTab = tabs.find((tab) => tab.id === activeTabId)
+            const suspendedTab = tabs.find((tab) => tab.id !== activeTabId)
+            const activePane =
+              activeTab?.rootSplit.type === 'leaf' ? activeTab.rootSplit.pane : null
+            const suspendedPane =
+              suspendedTab?.rootSplit.type === 'leaf' ? suspendedTab.rootSplit.pane : null
+
+            return {
+              tabCount: tabs.length,
+              activeToolId: activeTab?.toolId ?? null,
+              activePaneType: activePane?.paneType ?? null,
+              activeUrl: activePane?.url ?? null,
+              suspendedCount: tabs.filter((tab) => Boolean(tab.suspended)).length,
+              firstSuspendedToolId: suspendedTab?.toolId ?? null,
+              firstSuspended: Boolean(suspendedTab?.suspended),
+              firstSuspendedRunning: suspendedPane?.isRunning ?? null,
+            }
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      tabCount: 3,
+      activeToolId: 'browser',
+      activePaneType: 'browser',
+      activeUrl: 'https://example.test/restored',
+      suspendedCount: 2,
+      firstSuspendedToolId: 'shell',
+      firstSuspended: true,
+      firstSuspendedRunning: false,
+    })
+
+  const suspendedRestoreTabIds = restoreLayoutResult.tabs
+    .filter((tab) => Boolean(tab.suspended))
+    .map((tab) => tab.id)
+  const suspendedCloseTabId = suspendedRestoreTabIds[0] ?? null
+  const suspendedRestoreTabId = suspendedRestoreTabIds[1] ?? null
+  expect(suspendedCloseTabId).toBeTruthy()
+  expect(suspendedRestoreTabId).toBeTruthy()
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabCloseTab !== 'function') {
+        throw new Error('Missing tabCloseTab API')
+      }
+      return api.tabCloseTab(projectPath, tabId)
+    },
+    { projectPath: tmpDir, tabId: suspendedCloseTabId! },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, closedTabId, remainingSuspendedTabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              return {
+                tabCount: tabs.length,
+                activeToolId:
+                  tabs.find((tab) => tab.id === snapshot.tabs?.activeTabIdByWorktree[projectPath])
+                    ?.toolId ?? null,
+                closedTabPresent: tabs.some((tab) => tab.id === closedTabId),
+                remainingSuspended: Boolean(
+                  tabs.find((tab) => tab.id === remainingSuspendedTabId)?.suspended,
+                ),
+              }
+            })
+          },
+          {
+            projectPath: tmpDir,
+            closedTabId: suspendedCloseTabId!,
+            remainingSuspendedTabId: suspendedRestoreTabId!,
+          },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      tabCount: 2,
+      activeToolId: 'browser',
+      closedTabPresent: false,
+      remainingSuspended: true,
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabResumeSuspendedTab !== 'function') {
+        throw new Error('Missing tabResumeSuspendedTab API')
+      }
+      return api.tabResumeSuspendedTab(projectPath, tabId)
+    },
+    { projectPath: tmpDir, tabId: suspendedRestoreTabId! },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                suspended: Boolean(tab?.suspended),
+                isRunning: pane?.isRunning ?? null,
+                wsUrlIsRuntime: pane?.wsUrl?.startsWith('ws://127.0.0.1:') ?? false,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: suspendedRestoreTabId! },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      suspended: false,
+      isRunning: true,
+      wsUrlIsRuntime: true,
+    })
+
+  const editorFilePath = join(tmpDir, 'README.md')
+  const secondEditorFilePath = join(tmpDir, 'DIRTY.txt')
+  const editorTab = await workspacePage.evaluate(
+    ({ projectPath, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabOpenEditorFile !== 'function') {
+        throw new Error('Missing tabOpenEditorFile API')
+      }
+      return api.tabOpenEditorFile(projectPath, filePath).then((result) => ({
+        openedTabId: result.openedTab?.id ?? null,
+        activeTabId: result.activeTabId,
+      }))
+    },
+    { projectPath: tmpDir, filePath: editorFilePath },
+  )
+
+  expect(editorTab.openedTabId).toBeTruthy()
+  expect(editorTab.activeTabId).toBe(editorTab.openedTabId)
+
+  const secondOpenResult = await workspacePage.evaluate(
+    ({ projectPath, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.tabOpenEditorFile(projectPath, filePath).then((result) => ({
+        openedTabId: result.openedTab?.id ?? null,
+        activeTabId: result.activeTabId,
+      }))
+    },
+    { projectPath: tmpDir, filePath: secondEditorFilePath },
+  )
+
+  expect(secondOpenResult.openedTabId).toBeNull()
+  expect(secondOpenResult.activeTabId).toBe(editorTab.openedTabId)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              const editorTabs = tabs.filter((tab) => tab.toolId === 'editor')
+              const tab = editorTabs.find((candidate) => candidate.id === tabId)
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                editorTabIds: editorTabs.map((candidate) => candidate.id),
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                paneToolId: pane?.toolId ?? null,
+                filePath: pane?.filePath ?? null,
+                editorActiveFile: pane?.editorActiveFile ?? null,
+                editorFiles: pane?.editorFiles?.map((file) => file.filePath) ?? [],
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: editorTab.openedTabId },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      editorTabIds: [editorTab.openedTabId],
+      activeTabId: editorTab.openedTabId,
+      paneToolId: 'editor',
+      filePath: secondEditorFilePath,
+      editorActiveFile: secondEditorFilePath,
+      editorFiles: [editorFilePath, secondEditorFilePath],
+    })
+
+  const editorPaneId = await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.getAppState().then((snapshot) => {
+        const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+          (candidate) => candidate.id === tabId,
+        )
+        return tab?.rootSplit.type === 'leaf' ? (tab.rootSplit.pane?.id ?? null) : null
+      })
+    },
+    { projectPath: tmpDir, tabId: editorTab.openedTabId },
+  )
+  expect(editorPaneId).toBeTruthy()
+
+  const loadedEditorFile = await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabLoadEditorFile !== 'function') {
+        throw new Error('Missing tabLoadEditorFile API')
+      }
+      return api.tabLoadEditorFile(projectPath, paneId, filePath, { maxBytes: 2_097_152 })
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: editorFilePath },
+  )
+  expect(loadedEditorFile).toMatchObject({
+    ok: true,
+    binary: false,
+    content: '# Test Project\n',
+    truncated: false,
+    size: 15,
+    canWrite: true,
+    fileLineEnding: 'LF',
+  })
+  if (loadedEditorFile.ok) {
+    expect(loadedEditorFile.mtimeMs).toBeGreaterThan(0)
+  }
+
+  const detachedEditorTab = await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabDetachEditorFile !== 'function') {
+        throw new Error('Missing tabDetachEditorFile API')
+      }
+      return api.tabDetachEditorFile(projectPath, paneId, filePath).then((result) => ({
+        openedTabId: result.openedTab?.id ?? null,
+        activeTabId: result.activeTabId,
+      }))
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: secondEditorFilePath },
+  )
+  expect(detachedEditorTab.openedTabId).toBeTruthy()
+  expect(detachedEditorTab.activeTabId).toBe(detachedEditorTab.openedTabId)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, sourceTabId, detachedTabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              const sourceTab = tabs.find((candidate) => candidate.id === sourceTabId)
+              const detachedTab = tabs.find((candidate) => candidate.id === detachedTabId)
+              const sourcePane =
+                sourceTab?.rootSplit.type === 'leaf' ? sourceTab.rootSplit.pane : null
+              const detachedPane =
+                detachedTab?.rootSplit.type === 'leaf' ? detachedTab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                editorTabIds: tabs.filter((tab) => tab.toolId === 'editor').map((tab) => tab.id),
+                sourceFiles: sourcePane?.editorFiles?.map((file) => file.filePath) ?? [],
+                sourceActiveFile: sourcePane?.editorActiveFile ?? null,
+                detachedFiles: detachedPane?.editorFiles?.map((file) => file.filePath) ?? [],
+                detachedActiveFile: detachedPane?.editorActiveFile ?? null,
+              }
+            })
+          },
+          {
+            projectPath: tmpDir,
+            sourceTabId: editorTab.openedTabId,
+            detachedTabId: detachedEditorTab.openedTabId,
+          },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: detachedEditorTab.openedTabId,
+      editorTabIds: [editorTab.openedTabId, detachedEditorTab.openedTabId],
+      sourceFiles: [editorFilePath],
+      sourceActiveFile: editorFilePath,
+      detachedFiles: [secondEditorFilePath],
+      detachedActiveFile: secondEditorFilePath,
+    })
+
+  const detachedEditorPaneId = await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.getAppState().then((snapshot) => {
+        const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+          (candidate) => candidate.id === tabId,
+        )
+        return tab?.rootSplit.type === 'leaf' ? (tab.rootSplit.pane?.id ?? null) : null
+      })
+    },
+    { projectPath: tmpDir, tabId: detachedEditorTab.openedTabId },
+  )
+  expect(detachedEditorPaneId).toBeTruthy()
+
+  const closeEditorFileResult = await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabCloseEditorFile !== 'function') {
+        throw new Error('Missing tabCloseEditorFile API')
+      }
+      return api.tabCloseEditorFile(projectPath, paneId, filePath)
+    },
+    { projectPath: tmpDir, paneId: detachedEditorPaneId, filePath: secondEditorFilePath },
+  )
+  expect(closeEditorFileResult.closedTabId).toBe(detachedEditorTab.openedTabId)
+  expect(closeEditorFileResult.activeTabId).toBe(editorTab.openedTabId)
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate((projectPath) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.getAppState().then((snapshot) => {
+            const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+            return {
+              activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+              editorTabIds: tabs.filter((tab) => tab.toolId === 'editor').map((tab) => tab.id),
+            }
+          })
+        }, tmpDir),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: editorTab.openedTabId,
+      editorTabIds: [editorTab.openedTabId],
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.tabOpenEditorFile(projectPath, filePath)
+    },
+    { projectPath: tmpDir, filePath: secondEditorFilePath },
+  )
+
+  await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabMoveEditorFile !== 'function') {
+        throw new Error('Missing tabMoveEditorFile API')
+      }
+      return api.tabMoveEditorFile(projectPath, paneId, filePath, 2)
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: editorFilePath },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                editorFiles: pane?.editorFiles?.map((file) => file.filePath) ?? [],
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: editorTab.openedTabId },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: editorTab.openedTabId,
+      editorFiles: [secondEditorFilePath, editorFilePath],
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabSetActiveEditorFile !== 'function') {
+        throw new Error('Missing tabSetActiveEditorFile API')
+      }
+      return api.tabSetActiveEditorFile(projectPath, paneId, filePath)
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: secondEditorFilePath },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                editorActiveFile: pane?.editorActiveFile ?? null,
+                filePath: pane?.filePath ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: editorTab.openedTabId },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: editorTab.openedTabId,
+      editorActiveFile: secondEditorFilePath,
+      filePath: secondEditorFilePath,
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabUpdateEditorFileState !== 'function') {
+        throw new Error('Missing tabUpdateEditorFileState API')
+      }
+      return api.tabUpdateEditorFileState(projectPath, paneId, filePath, {
+        dirty: true,
+        currentContent: 'changed in main',
+        externalChangeDetected: true,
+      })
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: secondEditorFilePath },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId, filePath }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              const editorFiles = pane?.editorFiles as Array<Record<string, unknown>> | undefined
+              const file = editorFiles?.find((candidate) => candidate.filePath === filePath)
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                filePath: file?.filePath ?? null,
+                dirty: file?.dirty ?? null,
+                currentContent: file?.currentContent ?? null,
+                externalChangeDetected: file?.externalChangeDetected ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: editorTab.openedTabId, filePath: secondEditorFilePath },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: editorTab.openedTabId,
+      filePath: secondEditorFilePath,
+      dirty: true,
+      currentContent: 'changed in main',
+      externalChangeDetected: true,
+    })
+
+  const saveEditorFileResult = await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabSaveEditorFile !== 'function') {
+        throw new Error('Missing tabSaveEditorFile API')
+      }
+      return api.tabSaveEditorFile(projectPath, paneId, filePath, {
+        content: 'changed in main',
+        fileLineEnding: 'LF',
+      })
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: secondEditorFilePath },
+  )
+  expect(saveEditorFileResult.ok).toBe(true)
+  expect(await readFile(secondEditorFilePath, 'utf8')).toBe('changed in main')
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId, filePath }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              const editorFiles = pane?.editorFiles as Array<Record<string, unknown>> | undefined
+              const file = editorFiles?.find((candidate) => candidate.filePath === filePath)
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                dirty: file?.dirty ?? null,
+                currentContent: file?.currentContent ?? null,
+                originalContent: file?.originalContent ?? null,
+                externalChangeDetected: file?.externalChangeDetected ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: editorTab.openedTabId, filePath: secondEditorFilePath },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: editorTab.openedTabId,
+      dirty: false,
+      currentContent: 'changed in main',
+      originalContent: 'changed in main',
+      externalChangeDetected: false,
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.tabUpdateEditorFileState(projectPath, paneId, filePath, {
+        dirty: true,
+        currentContent: 'changed by tab preflight',
+      })
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: secondEditorFilePath },
+  )
+
+  await electronApp.evaluate(({ dialog }) => {
+    const globals = globalThis as typeof globalThis & {
+      __canopyE2eShowMessageBox?: typeof dialog.showMessageBox
+    }
+    globals.__canopyE2eShowMessageBox ??= dialog.showMessageBox
+    dialog.showMessageBox = async () => ({ response: 0, checkboxChecked: false })
+  })
+
+  const closeTabPreflight = await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabPrepareCloseTab !== 'function') {
+        throw new Error('Missing tabPrepareCloseTab API')
+      }
+      return api.tabPrepareCloseTab(projectPath, tabId)
+    },
+    { projectPath: tmpDir, tabId: editorTab.openedTabId },
+  )
+
+  await electronApp.evaluate(({ dialog }) => {
+    const globals = globalThis as typeof globalThis & {
+      __canopyE2eShowMessageBox?: typeof dialog.showMessageBox
+    }
+    if (globals.__canopyE2eShowMessageBox) {
+      dialog.showMessageBox = globals.__canopyE2eShowMessageBox
+      delete globals.__canopyE2eShowMessageBox
+    }
+  })
+
+  expect(closeTabPreflight).toEqual({ ok: true })
+  expect(await readFile(secondEditorFilePath, 'utf8')).toBe('changed by tab preflight')
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId, filePath }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              const editorFiles = pane?.editorFiles as Array<Record<string, unknown>> | undefined
+              const file = editorFiles?.find((candidate) => candidate.filePath === filePath)
+              return {
+                dirty: file?.dirty ?? null,
+                currentContent: file?.currentContent ?? null,
+                originalContent: file?.originalContent ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: editorTab.openedTabId, filePath: secondEditorFilePath },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      dirty: false,
+      currentContent: 'changed by tab preflight',
+      originalContent: 'changed by tab preflight',
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.tabUpdateEditorFileState(projectPath, paneId, filePath, {
+        dirty: true,
+        currentContent: 'changed for move',
+      })
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: secondEditorFilePath },
+  )
+
+  await electronApp.evaluate(({ dialog }) => {
+    const globals = globalThis as typeof globalThis & {
+      __canopyE2eShowMessageBox?: typeof dialog.showMessageBox
+    }
+    globals.__canopyE2eShowMessageBox ??= dialog.showMessageBox
+    dialog.showMessageBox = async () => ({ response: 0, checkboxChecked: false })
+  })
+
+  const closeEditorFilePreflight = await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabPrepareCloseEditorFile !== 'function') {
+        throw new Error('Missing tabPrepareCloseEditorFile API')
+      }
+      return api.tabPrepareCloseEditorFile(projectPath, paneId, filePath)
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: secondEditorFilePath },
+  )
+
+  await electronApp.evaluate(({ dialog }) => {
+    const globals = globalThis as typeof globalThis & {
+      __canopyE2eShowMessageBox?: typeof dialog.showMessageBox
+    }
+    if (globals.__canopyE2eShowMessageBox) {
+      dialog.showMessageBox = globals.__canopyE2eShowMessageBox
+      delete globals.__canopyE2eShowMessageBox
+    }
+  })
+
+  expect(closeEditorFilePreflight).toEqual({ ok: true })
+  expect(await readFile(secondEditorFilePath, 'utf8')).toBe('changed for move')
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId, filePath }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+                (candidate) => candidate.id === tabId,
+              )
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              const editorFiles = pane?.editorFiles as Array<Record<string, unknown>> | undefined
+              const file = editorFiles?.find((candidate) => candidate.filePath === filePath)
+              return {
+                dirty: file?.dirty ?? null,
+                currentContent: file?.currentContent ?? null,
+                originalContent: file?.originalContent ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: editorTab.openedTabId, filePath: secondEditorFilePath },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      dirty: false,
+      currentContent: 'changed for move',
+      originalContent: 'changed for move',
+    })
+
+  await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.tabUpdateEditorFileState(projectPath, paneId, filePath, {
+        dirty: true,
+        currentContent: 'changed for move',
+      })
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: secondEditorFilePath },
+  )
+
+  const detachedForMove = await workspacePage.evaluate(
+    ({ projectPath, paneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api
+        .tabDetachEditorFile(projectPath, paneId, filePath)
+        .then((result) => result.openedTab ?? null)
+    },
+    { projectPath: tmpDir, paneId: editorPaneId, filePath: secondEditorFilePath },
+  )
+  expect(detachedForMove?.id).toBeTruthy()
+
+  const sourceEditorPaneId = await workspacePage.evaluate(
+    ({ projectPath, tabId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.getAppState().then((snapshot) => {
+        const tab = snapshot.tabs?.tabsByWorktree[projectPath]?.find(
+          (candidate) => candidate.id === tabId,
+        )
+        return tab?.rootSplit.type === 'leaf' ? (tab.rootSplit.pane?.id ?? null) : null
+      })
+    },
+    { projectPath: tmpDir, tabId: detachedForMove!.id },
+  )
+  expect(sourceEditorPaneId).toBeTruthy()
+
+  await workspacePage.evaluate(
+    ({ projectPath, sourceTabId, targetTabId, targetPaneId }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.tabMoveTabToSplit(
+        projectPath,
+        sourceTabId,
+        targetTabId,
+        targetPaneId,
+        'horizontal',
+        'second',
+      )
+    },
+    {
+      projectPath: tmpDir,
+      sourceTabId: detachedForMove!.id,
+      targetTabId: editorTab.openedTabId!,
+      targetPaneId: editorPaneId,
+    },
+  )
+
+  await workspacePage.evaluate(
+    ({ projectPath, sourcePaneId, targetPaneId, filePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      if (typeof api.tabMoveEditorFileBetweenPanes !== 'function') {
+        throw new Error('Missing tabMoveEditorFileBetweenPanes API')
+      }
+      return api.tabMoveEditorFileBetweenPanes(projectPath, sourcePaneId, targetPaneId, filePath, 0)
+    },
+    {
+      projectPath: tmpDir,
+      sourcePaneId: sourceEditorPaneId!,
+      targetPaneId: editorPaneId,
+      filePath: secondEditorFilePath,
+    },
+  )
+
+  await expect
+    .poll(
+      () =>
+        workspacePage.evaluate(
+          ({ projectPath, tabId }) => {
+            const api = (window as unknown as { api: Required<AppStateApi> }).api
+            return api.getAppState().then((snapshot) => {
+              const tabs = snapshot.tabs?.tabsByWorktree[projectPath] ?? []
+              const tab = tabs.find((candidate) => candidate.id === tabId)
+              const pane = tab?.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+              const editorFiles = pane?.editorFiles as Array<Record<string, unknown>> | undefined
+              return {
+                activeTabId: snapshot.tabs?.activeTabIdByWorktree[projectPath] ?? null,
+                tabIds: tabs
+                  .filter((candidate) => candidate.toolId === 'editor')
+                  .map((candidate) => candidate.id),
+                splitType: tab?.rootSplit.type ?? null,
+                editorFiles: editorFiles?.map((file) => file.filePath) ?? [],
+                movedDirty: editorFiles?.[0]?.dirty ?? null,
+              }
+            })
+          },
+          { projectPath: tmpDir, tabId: editorTab.openedTabId },
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual({
+      activeTabId: editorTab.openedTabId,
+      tabIds: [editorTab.openedTabId],
+      splitType: 'leaf',
+      editorFiles: [secondEditorFilePath, editorFilePath],
+      movedDirty: true,
+    })
+
+  const changedStatePromise = workspacePage.evaluate(
+    (projectPath) =>
+      new Promise<AppStateSnapshot>((resolve, reject) => {
+        const api = (window as unknown as { api: AppStateApi }).api
+        if (typeof api.onAppStateChanged !== 'function') {
+          reject(new Error('Missing app state subscription API'))
+          return
+        }
+
+        const cleanupRef: { current?: () => void } = {}
+        const timeoutId = window.setTimeout(() => {
+          cleanupRef.current?.()
+          reject(new Error('Timed out waiting for app state change'))
+        }, 10_000)
+
+        cleanupRef.current = api.onAppStateChanged((snapshot) => {
+          const projectAttached = snapshot.workspace.projects.some(
+            (project) => project.workspace.path === projectPath || project.repoRoot === projectPath,
+          )
+          if (!projectAttached) return
+          window.clearTimeout(timeoutId)
+          cleanupRef.current?.()
+          resolve(snapshot)
+        })
+      }),
+    tmpDir,
+  )
+
+  await workspacePage.evaluate((projectPath) => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    return api.workspaceSelectWorktree(projectPath)
+  }, tmpDir)
+
+  const changedState = await changedStatePromise
+  expect(hasProject(changedState, tmpDir)).toBe(true)
+  expect(changedState.workspace.workspaceState.selectedWorktreePath).toBe(tmpDir)
+  expect(changedState.workspace.workspaceState.isDirty).toBe(true)
+
+  const currentState = await workspacePage.evaluate(() => {
+    const api = (window as unknown as { api: Required<AppStateApi> }).api
+    return api.getAppState()
+  })
+
+  expect(hasProject(currentState, tmpDir)).toBe(true)
+  expect(currentState.workspace.workspaceState.selectedWorktreePath).toBe(tmpDir)
+  expect(currentState.workspace.workspaceState.isDirty).toBe(true)
+})

--- a/e2e/window-restore.spec.ts
+++ b/e2e/window-restore.spec.ts
@@ -1,0 +1,350 @@
+import { test, expect, type ElectronApplication, type Page, _electron } from '@playwright/test'
+import { realpathSync } from 'fs'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+
+const appDir = resolve(__dirname, '..')
+
+interface AppStateSnapshot {
+  workspace: {
+    projects: Array<{
+      workspace: { path: string }
+    }>
+  }
+  tabs?: {
+    tabsByWorktree: Record<string, unknown[]>
+  }
+}
+
+interface CanopyWindow extends Window {
+  api: {
+    getAppState: () => Promise<AppStateSnapshot>
+    getPref: (key: string) => Promise<string | null>
+    perfOpenProject?: (path: string) => Promise<void>
+    tabOpenTool?: (toolId: string, worktreePath: string) => Promise<unknown>
+    newWindow?: () => Promise<void>
+  }
+}
+
+interface WindowConfig {
+  paths: string[]
+}
+
+async function launchApp(
+  userDataDir: string,
+  options?: { closeLastWindowQuits?: boolean },
+): Promise<ElectronApplication> {
+  return _electron.launch({
+    args: [resolve(appDir, 'out/main/index.js')],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      CANOPY_E2E: '1',
+      CANOPY_PERF: '1',
+      ...(options?.closeLastWindowQuits ? { CANOPY_E2E_CLOSE_LAST_WINDOW_QUITS: '1' } : {}),
+      CANOPY_TEST_USER_DATA: userDataDir,
+    },
+  })
+}
+
+async function waitForExit(app: ElectronApplication, label: string): Promise<void> {
+  const proc = app.process()
+  if (proc.exitCode !== null || proc.signalCode !== null) return
+  await Promise.race([
+    new Promise<void>((resolve) => proc.once('exit', () => resolve())),
+    new Promise<void>((_resolve, reject) =>
+      setTimeout(() => reject(new Error(`${label} did not exit`)), 10_000),
+    ),
+  ])
+}
+
+async function quitApp(app: ElectronApplication, label: string): Promise<void> {
+  await app.evaluate(({ app }) => app.quit()).catch(() => {})
+  await waitForExit(app, label)
+}
+
+async function closeApp(app: ElectronApplication | null): Promise<void> {
+  if (!app) return
+  const proc = app.process()
+  if (proc.exitCode !== null || proc.signalCode !== null) return
+
+  await Promise.race([
+    app.close().catch(() => {}),
+    new Promise<void>((resolve) =>
+      setTimeout(() => {
+        if (proc.pid) {
+          try {
+            process.kill(proc.pid)
+          } catch {
+            // Process already exited.
+          }
+        }
+        resolve()
+      }, 5_000),
+    ),
+  ])
+}
+
+async function getAppState(page: Page): Promise<AppStateSnapshot> {
+  return page.evaluate(() => (window as unknown as CanopyWindow).api.getAppState())
+}
+
+async function waitForProjectCount(page: Page, expectedCount: number): Promise<AppStateSnapshot> {
+  const startedAt = Date.now()
+  let lastState: AppStateSnapshot | null = null
+
+  while (Date.now() - startedAt < 8_000) {
+    lastState = await getAppState(page)
+    if (lastState.workspace.projects.length === expectedCount) return lastState
+    await page.waitForTimeout(100)
+  }
+
+  throw new Error(
+    `Expected ${expectedCount} restored projects, got ${lastState?.workspace.projects.length ?? 0}`,
+  )
+}
+
+async function waitForTabCount(
+  page: Page,
+  worktreePath: string,
+  expectedCount: number,
+): Promise<void> {
+  const startedAt = Date.now()
+  let lastCount = 0
+
+  while (Date.now() - startedAt < 8_000) {
+    const state = await getAppState(page)
+    lastCount = state.tabs?.tabsByWorktree[worktreePath]?.length ?? 0
+    if (lastCount >= expectedCount) return
+    await page.waitForTimeout(100)
+  }
+
+  throw new Error(`Expected ${expectedCount} tab(s) for ${worktreePath}, got ${lastCount}`)
+}
+
+async function openProject(page: Page, projectPath: string): Promise<void> {
+  await page.evaluate(async (path) => {
+    const api = (window as unknown as CanopyWindow).api
+    if (!api.perfOpenProject) throw new Error('perfOpenProject is unavailable')
+    await api.perfOpenProject(path)
+  }, projectPath)
+}
+
+async function openShellTab(page: Page, worktreePath: string): Promise<void> {
+  await page.evaluate(async (path) => {
+    const api = (window as unknown as CanopyWindow).api
+    if (!api.tabOpenTool) throw new Error('tabOpenTool is unavailable')
+    await api.tabOpenTool('shell', path)
+  }, worktreePath)
+}
+
+async function getOpenWindowConfigs(page: Page): Promise<WindowConfig[]> {
+  const raw = await page.evaluate(() =>
+    (window as unknown as CanopyWindow).api.getPref('openWindowConfigs'),
+  )
+  return raw ? (JSON.parse(raw) as WindowConfig[]) : []
+}
+
+function expectSingleWindowConfigWithPaths(configs: WindowConfig[], paths: string[]): void {
+  expect(configs).toHaveLength(1)
+  expect(new Set(configs[0].paths)).toEqual(new Set(paths))
+}
+
+function sortedConfigPathSets(configs: WindowConfig[]): string[][] {
+  return configs
+    .map((config) => [...config.paths].sort())
+    .sort((a, b) => a.join('\0').localeCompare(b.join('\0')))
+}
+
+test('restores multiple projects in the same window after quit', async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), 'canopy-e2e-window-restore-data-'))
+  const rawProjectA = await mkdtemp(join(tmpdir(), 'canopy-e2e-window-restore-a-'))
+  const rawProjectB = await mkdtemp(join(tmpdir(), 'canopy-e2e-window-restore-b-'))
+  const projectA = realpathSync(rawProjectA)
+  const projectB = realpathSync(rawProjectB)
+  const projectPaths = [projectA, projectB]
+  let app: ElectronApplication | null = null
+
+  try {
+    await writeFile(join(rawProjectA, 'README.md'), 'A\n')
+    await writeFile(join(rawProjectB, 'README.md'), 'B\n')
+
+    app = await launchApp(userDataDir)
+    let page = await app.firstWindow()
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForFunction(() => {
+      const api = (window as unknown as CanopyWindow).api
+      return Boolean(api?.perfOpenProject && api?.getAppState && api?.tabOpenTool)
+    })
+
+    await openProject(page, projectA)
+    await waitForProjectCount(page, 1)
+    await openProject(page, projectB)
+    await waitForProjectCount(page, 2)
+
+    await openShellTab(page, projectA)
+    await waitForTabCount(page, projectA, 1)
+    expectSingleWindowConfigWithPaths(await getOpenWindowConfigs(page), projectPaths)
+
+    await app.evaluate(({ dialog }) => {
+      dialog.showMessageBox = async () => ({ response: 0, checkboxChecked: false })
+    })
+    await quitApp(app, 'initial application')
+    app = null
+
+    app = await launchApp(userDataDir)
+    page = await app.firstWindow()
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForFunction(() => Boolean((window as unknown as CanopyWindow).api?.getAppState))
+
+    const restoredState = await waitForProjectCount(page, 2)
+    expect(
+      new Set(restoredState.workspace.projects.map((project) => project.workspace.path)),
+    ).toEqual(new Set(projectPaths))
+
+    const windowCount = await app.evaluate(
+      ({ BrowserWindow }) => BrowserWindow.getAllWindows().length,
+    )
+    expect(windowCount).toBe(1)
+    expectSingleWindowConfigWithPaths(await getOpenWindowConfigs(page), projectPaths)
+
+    await quitApp(app, 'restored application')
+    app = null
+  } finally {
+    await closeApp(app)
+    await rm(userDataDir, { recursive: true, force: true })
+    await rm(rawProjectA, { recursive: true, force: true })
+    await rm(rawProjectB, { recursive: true, force: true })
+  }
+})
+
+test('restores multiple projects after closing the last app window', async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), 'canopy-e2e-window-close-data-'))
+  const rawProjectA = await mkdtemp(join(tmpdir(), 'canopy-e2e-window-close-a-'))
+  const rawProjectB = await mkdtemp(join(tmpdir(), 'canopy-e2e-window-close-b-'))
+  const projectA = realpathSync(rawProjectA)
+  const projectB = realpathSync(rawProjectB)
+  const projectPaths = [projectA, projectB]
+  let app: ElectronApplication | null = null
+
+  try {
+    await writeFile(join(rawProjectA, 'README.md'), 'A\n')
+    await writeFile(join(rawProjectB, 'README.md'), 'B\n')
+
+    app = await launchApp(userDataDir, { closeLastWindowQuits: true })
+    let page = await app.firstWindow()
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForFunction(() => {
+      const api = (window as unknown as CanopyWindow).api
+      return Boolean(api?.perfOpenProject && api?.getAppState && api?.tabOpenTool)
+    })
+
+    await openProject(page, projectA)
+    await waitForProjectCount(page, 1)
+    await openProject(page, projectB)
+    await waitForProjectCount(page, 2)
+
+    await openShellTab(page, projectA)
+    await waitForTabCount(page, projectA, 1)
+    expectSingleWindowConfigWithPaths(await getOpenWindowConfigs(page), projectPaths)
+
+    await app.evaluate(({ BrowserWindow, dialog }) => {
+      dialog.showMessageBox = async () => ({ response: 0, checkboxChecked: false })
+      BrowserWindow.getAllWindows()[0].close()
+    })
+    await waitForExit(app, 'window close application')
+    app = null
+
+    app = await launchApp(userDataDir, { closeLastWindowQuits: true })
+    page = await app.firstWindow()
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForFunction(() => Boolean((window as unknown as CanopyWindow).api?.getAppState))
+
+    const restoredState = await waitForProjectCount(page, 2)
+    expect(
+      new Set(restoredState.workspace.projects.map((project) => project.workspace.path)),
+    ).toEqual(new Set(projectPaths))
+
+    const windowCount = await app.evaluate(
+      ({ BrowserWindow }) => BrowserWindow.getAllWindows().length,
+    )
+    expect(windowCount).toBe(1)
+    expectSingleWindowConfigWithPaths(await getOpenWindowConfigs(page), projectPaths)
+
+    await quitApp(app, 'restored window close application')
+    app = null
+  } finally {
+    await closeApp(app)
+    await rm(userDataDir, { recursive: true, force: true })
+    await rm(rawProjectA, { recursive: true, force: true })
+    await rm(rawProjectB, { recursive: true, force: true })
+  }
+})
+
+test('persists remaining window configs after closing one of multiple windows', async () => {
+  const userDataDir = await mkdtemp(join(tmpdir(), 'canopy-e2e-window-close-one-data-'))
+  const rawProjectA = await mkdtemp(join(tmpdir(), 'canopy-e2e-window-close-one-a-'))
+  const rawProjectB = await mkdtemp(join(tmpdir(), 'canopy-e2e-window-close-one-b-'))
+  const projectA = realpathSync(rawProjectA)
+  const projectB = realpathSync(rawProjectB)
+  let app: ElectronApplication | null = null
+
+  try {
+    await writeFile(join(rawProjectA, 'README.md'), 'A\n')
+    await writeFile(join(rawProjectB, 'README.md'), 'B\n')
+
+    app = await launchApp(userDataDir)
+    const pageA = await app.firstWindow()
+    await pageA.waitForLoadState('domcontentloaded')
+    await pageA.waitForFunction(() => {
+      const api = (window as unknown as CanopyWindow).api
+      return Boolean(api?.perfOpenProject && api?.getAppState && api?.newWindow)
+    })
+
+    await openProject(pageA, projectA)
+    await waitForProjectCount(pageA, 1)
+
+    const pageBPromise = app.waitForEvent('window')
+    await pageA.evaluate(() => (window as unknown as CanopyWindow).api.newWindow?.())
+    const pageB = await pageBPromise
+    await pageB.waitForLoadState('domcontentloaded')
+    await pageB.waitForFunction(() => {
+      const api = (window as unknown as CanopyWindow).api
+      return Boolean(api?.perfOpenProject && api?.getAppState)
+    })
+
+    await openProject(pageB, projectB)
+    await waitForProjectCount(pageB, 1)
+
+    await expect
+      .poll(async () => sortedConfigPathSets(await getOpenWindowConfigs(pageA)), {
+        timeout: 8_000,
+      })
+      .toEqual([[projectA], [projectB]])
+
+    const pageBClosed = pageB.waitForEvent('close')
+    await pageB.evaluate(() => window.close())
+    await pageBClosed
+
+    await expect
+      .poll(() => app!.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length), {
+        timeout: 8_000,
+      })
+      .toBe(1)
+
+    await expect
+      .poll(async () => sortedConfigPathSets(await getOpenWindowConfigs(pageA)), {
+        timeout: 8_000,
+      })
+      .toEqual([[projectA]])
+
+    await quitApp(app, 'remaining window application')
+    app = null
+  } finally {
+    await closeApp(app)
+    await rm(userDataDir, { recursive: true, force: true })
+    await rm(rawProjectA, { recursive: true, force: true })
+    await rm(rawProjectB, { recursive: true, force: true })
+  }
+})

--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -12,10 +12,22 @@ import { TmuxManager } from './pty/TmuxManager'
 import { isSafeExternalUrl } from './security/validateUrl'
 import type { WindowBounds, WindowConfig, WindowState } from './windowBounds'
 
+interface CreateWindowOptions {
+  bounds?: WindowBounds
+  windowState?: WindowState
+  startupRestore?: boolean
+}
+
+interface WindowCloseSnapshot {
+  configs: WindowConfig[]
+  isLastWindow: boolean
+}
+
 export class WindowManager {
   private windows = new Map<number, BrowserWindow>()
   private workspacePaths = new Map<number, Set<string>>()
   private activeWorktreePaths = new Map<number, string>()
+  private startupRestoreWindows = new Map<number, boolean>()
   private gitWatchers = new Map<number, Map<string, GitWatcher>>()
   private fileWatchers = new Map<number, FileTreeWatcher>()
   private ptySessions = new Map<number, Set<string>>()
@@ -26,6 +38,8 @@ export class WindowManager {
   private tmuxManager: TmuxManager | null = null
   private allWindowsClosedCallback: (() => void) | null = null
   private windowDisposeCallback: ((paths: string[]) => void) | null = null
+  private windowCloseSnapshotCallback: ((snapshot: WindowCloseSnapshot) => void) | null = null
+  private windowConfigChangedCallback: ((configs: WindowConfig[]) => void) | null = null
 
   private ptyManager: PtyManager
   private wsBridge: WsBridge
@@ -52,7 +66,15 @@ export class WindowManager {
     this.windowDisposeCallback = cb
   }
 
-  createWindow(options?: { bounds?: WindowBounds; windowState?: WindowState }): BrowserWindow {
+  setOnWindowCloseSnapshot(cb: (snapshot: WindowCloseSnapshot) => void): void {
+    this.windowCloseSnapshotCallback = cb
+  }
+
+  setOnWindowConfigChanged(cb: (configs: WindowConfig[]) => void): void {
+    this.windowConfigChangedCallback = cb
+  }
+
+  createWindow(options?: CreateWindowOptions): BrowserWindow {
     const sizeDefaults = { width: 1200, height: 800 }
     const boundsOpts = options?.bounds
       ? {
@@ -94,6 +116,7 @@ export class WindowManager {
     const wcId = win.webContents.id
     this.windows.set(wcId, win)
     this.ptySessions.set(wcId, new Set())
+    this.startupRestoreWindows.set(wcId, options?.startupRestore === true)
 
     // Track webview guest webContents for keyboard interception + DevTools
     if (this.browserManager) {
@@ -119,13 +142,17 @@ export class WindowManager {
     win.on('close', (event) => {
       if (this.isQuitting || this.forceClosing.has(wcId)) {
         this.forceClosing.delete(wcId)
+        this.captureWindowCloseSnapshot()
         return
       }
 
       // Fast sync check: nothing tracked → allow the close to proceed without
       // spawning helper processes. Only when this window owns PTY sessions do
       // we preventDefault and run the (async) busy-check + confirmation dialog.
-      if (!this.hasTrackedPtySessions(wcId)) return
+      if (!this.hasTrackedPtySessions(wcId)) {
+        this.captureWindowCloseSnapshot()
+        return
+      }
 
       event.preventDefault()
 
@@ -212,6 +239,10 @@ export class WindowManager {
 
   clearActiveWorktree(wcId: number): void {
     this.activeWorktreePaths.delete(wcId)
+  }
+
+  shouldQuitOnLastWindowClose(): boolean {
+    return process.platform !== 'darwin' || process.env.CANOPY_E2E_CLOSE_LAST_WINDOW_QUITS === '1'
   }
 
   setFocusedAgentSession(wcId: number, ptySessionId: string | null): void {
@@ -331,6 +362,14 @@ export class WindowManager {
     return result
   }
 
+  hasStartupRestore(wcId: number): boolean {
+    return this.startupRestoreWindows.get(wcId) ?? false
+  }
+
+  completeStartupRestore(wcId: number): void {
+    this.startupRestoreWindows.set(wcId, false)
+  }
+
   getLastFocusedBounds(): WindowBounds | null {
     const focused = BrowserWindow.getFocusedWindow()
     if (focused && !focused.isDestroyed()) return focused.getBounds()
@@ -396,6 +435,10 @@ export class WindowManager {
   }
 
   private disposeWindow(wcId: number): void {
+    const closesApplication =
+      !this.isQuitting && this.shouldQuitOnLastWindowClose() && this.windows.size === 1
+    const shouldPersistWindowConfigs = !this.isQuitting && !closesApplication
+
     // Stop all git watchers for this window
     this.disposeAllGitWatchers(wcId)
     this.gitWatchers.delete(wcId)
@@ -420,12 +463,14 @@ export class WindowManager {
           }
         }
         this.wsBridge.destroy(sid)
-        this.ptyManager.kill(sid)
+        this.ptyManager.kill(sid, { killProcessTree: this.isQuitting })
       }
     }
 
-    // Delete workspace layouts when window is manually closed (not during quit)
-    if (!this.isQuitting && this.windowDisposeCallback) {
+    // Delete workspace layouts when a non-quitting window is manually closed.
+    // Closing the last window quits the app on Windows/Linux, so keep layouts
+    // for startup restore in that path.
+    if (!this.isQuitting && !closesApplication && this.windowDisposeCallback) {
       const paths = this.workspacePaths.get(wcId)
       if (paths && paths.size > 0) {
         this.windowDisposeCallback([...paths])
@@ -435,8 +480,25 @@ export class WindowManager {
     this.windows.delete(wcId)
     this.workspacePaths.delete(wcId)
     this.activeWorktreePaths.delete(wcId)
+    this.startupRestoreWindows.delete(wcId)
     this.focusedAgentSessions.delete(wcId)
     this.ptySessions.delete(wcId)
+
+    if (shouldPersistWindowConfigs && this.windowConfigChangedCallback) {
+      this.windowConfigChangedCallback(this.getAllWindowConfigs())
+    }
+  }
+
+  private captureWindowCloseSnapshot(): void {
+    if (this.isQuitting || !this.windowCloseSnapshotCallback) return
+
+    const configs = this.getAllWindowConfigs()
+    if (configs.length === 0) return
+
+    this.windowCloseSnapshotCallback({
+      configs,
+      isLastWindow: this.windows.size === 1,
+    })
   }
 
   disposeAll(): void {

--- a/src/main/agents/AgentSessionManager.ts
+++ b/src/main/agents/AgentSessionManager.ts
@@ -17,7 +17,8 @@ import { codexAdapter } from './adapters/codex'
 interface AgentSession {
   agentType: AgentType
   adapter: AgentAdapter
-  agentSessionId: string
+  hookSessionId: string
+  agentSessionId?: string
   ptySessionId: string
   settingsSetup: SettingsSetup
   hookPort: number
@@ -84,8 +85,8 @@ export class AgentSessionManager extends EventEmitter {
     const adapter = getAdapter(toolId)
     if (!adapter) throw new Error(`No agent adapter for tool: ${toolId}`)
 
-    const agentSessionId = randomUUID()
-    const tempId = `_agent_${agentSessionId}`
+    const hookSessionId = randomUUID()
+    const tempId = `_agent_${hookSessionId}`
     const sessionRef = { ptySessionId: tempId }
 
     const {
@@ -93,9 +94,10 @@ export class AgentSessionManager extends EventEmitter {
       path: hookPath,
       authToken: hookAuthToken,
     } = await this.router.addSession(
-      agentSessionId,
+      hookSessionId,
       (rawEvent: Record<string, unknown>): Record<string, unknown> | void => {
         const normalized = adapter.normalizeEvent(rawEvent)
+        this.updateAgentSessionId(sessionRef.ptySessionId, normalized.sessionId)
 
         // Track busy state
         const rawName = (rawEvent.hook_event_name as string) ?? ''
@@ -179,7 +181,7 @@ export class AgentSessionManager extends EventEmitter {
       }
     }
 
-    const settingsPath = join(this.hooksDir, `session-${agentSessionId}.json`)
+    const settingsPath = join(this.hooksDir, `session-${hookSessionId}.json`)
     const settingsSetup = adapter.setupSettings(
       settingsPath,
       worktreePath,
@@ -191,7 +193,7 @@ export class AgentSessionManager extends EventEmitter {
     const session: AgentSession = {
       agentType: adapter.agentType,
       adapter,
-      agentSessionId,
+      hookSessionId,
       ptySessionId: tempId,
       settingsSetup,
       hookPort,
@@ -232,6 +234,13 @@ export class AgentSessionManager extends EventEmitter {
     return adapter?.buildResumeArgs?.(resumeSessionId) ?? []
   }
 
+  updateAgentSessionId(ptySessionId: string, agentSessionId: string): void {
+    if (!agentSessionId) return
+    const session = this.sessions.get(ptySessionId)
+    if (!session) return
+    session.agentSessionId = agentSessionId
+  }
+
   rekey(tempId: string, realPtySessionId: string): void {
     const session = this.sessions.get(tempId)
     if (!session) return
@@ -257,7 +266,7 @@ export class AgentSessionManager extends EventEmitter {
     const session = this.sessions.get(ptySessionId)
     if (!session) return
 
-    this.router.removeSession(session.agentSessionId)
+    this.router.removeSession(session.hookSessionId)
     session.settingsSetup.cleanup()
     this.busySessions.delete(ptySessionId)
     this.emit('sessionDestroyed', ptySessionId)

--- a/src/main/commands/tabCommands.ts
+++ b/src/main/commands/tabCommands.ts
@@ -25,6 +25,7 @@ import type {
   SerializedLayout,
   SerializedSplitNode,
   SplitSnapshot,
+  TabCloseAllPreflightResult,
   TabClosePreflightResult,
   TabCommandResult,
   TabSnapshot,
@@ -473,6 +474,10 @@ interface CloseTabPayload extends TabCommandPayloadBase {
 
 interface PrepareCloseTabPayload extends TabCommandPayloadBase {
   tabId: string
+}
+
+interface PrepareCloseAllForWorktreePayload extends TabCommandPayloadBase {
+  confirmedActiveProcesses?: boolean
 }
 
 interface GetCloseWarningPayload extends TabCommandPayloadBase {
@@ -1243,6 +1248,11 @@ function emptyResult(
   return { worktreePath, tabs, activeTabId }
 }
 
+function getTabDisplayName(tab: TabSnapshot): string {
+  const focused = allPaneSnapshots(tab.rootSplit).find((pane) => pane.id === tab.focusedPaneId)
+  return focused?.title || tab.name
+}
+
 function reconcileTabSnapshotIdentity(tab: TabSnapshot, tabs: TabSnapshot[]): TabSnapshot {
   const focused = allPaneSnapshots(tab.rootSplit).find((pane) => pane.id === tab.focusedPaneId)
   if (!focused || tab.toolId === focused.toolId) return tab
@@ -1486,12 +1496,12 @@ export class TabCommandService {
     this.trackSender(sender)
     this.assertSenderOwnsWorktree(sender, payload.worktreePath)
     const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
     const tabIndex = tabs.findIndex((tab) =>
       allPaneSnapshots(tab.rootSplit).some(
         (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
       ),
     )
-    const activeId = this.getCommandActiveTabId(sender.id, payload)
     if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
 
     const tab = tabs[tabIndex]
@@ -1831,7 +1841,6 @@ export class TabCommandService {
     this.trackSender(sender)
     this.assertSenderOwnsWorktree(sender, payload.worktreePath)
     const tabs = this.getCommandTabs(sender.id, payload)
-    const activeId = this.getCommandActiveTabId(sender.id, payload)
     const tabIndex = tabs.findIndex((tab) =>
       allPaneSnapshots(tab.rootSplit).some(
         (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
@@ -1840,12 +1849,6 @@ export class TabCommandService {
     if (tabIndex < 0) {
       return { ok: false, tag: 'ReadFailed', message: 'Editor file is not open' }
     }
-
-    const tab = tabs[tabIndex]
-    const pane = allPaneSnapshots(tab.rootSplit).find(
-      (candidate) => candidate.id === payload.paneId,
-    )
-    if (!pane) return { ok: false, tag: 'ReadFailed', message: 'Editor pane is not open' }
 
     const loadResult = await this.deps.loadEditorFile(
       sender,
@@ -1872,21 +1875,38 @@ export class TabCommandService {
           externalChangeDetected: false,
         }
 
-    const updatedPane = paneWithUpdatedEditorFileState(pane, payload.filePath, patch)
+    const currentTabs = this.getCommandTabs(sender.id, payload)
+    const currentActiveId = this.getCommandActiveTabId(sender.id, payload)
+    const currentTabIndex = currentTabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
+    if (currentTabIndex < 0) {
+      return { ok: false, tag: 'ReadFailed', message: 'Editor file is not open' }
+    }
+
+    const currentTab = currentTabs[currentTabIndex]
+    const currentPane = allPaneSnapshots(currentTab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!currentPane) return { ok: false, tag: 'ReadFailed', message: 'Editor pane is not open' }
+
+    const updatedPane = paneWithUpdatedEditorFileState(currentPane, payload.filePath, patch)
     if (!updatedPane) {
       return { ok: false, tag: 'ReadFailed', message: 'Editor file is not open' }
     }
 
-    tabs[tabIndex] = {
-      ...tab,
-      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+    currentTabs[currentTabIndex] = {
+      ...currentTab,
+      rootSplit: updatePaneSnapshot(currentTab.rootSplit, payload.paneId, () => updatedPane),
     }
     const result = {
       worktreePath: payload.worktreePath,
-      tabs,
-      activeTabId: activeId,
+      tabs: currentTabs,
+      activeTabId: currentActiveId,
     }
-    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    this.setTabState(sender, payload.worktreePath, currentTabs, currentActiveId)
     return { ...loadResult, result }
   }
 
@@ -1897,7 +1917,6 @@ export class TabCommandService {
     this.trackSender(sender)
     this.assertSenderOwnsWorktree(sender, payload.worktreePath)
     const tabs = this.getCommandTabs(sender.id, payload)
-    const activeId = this.getCommandActiveTabId(sender.id, payload)
     const tabIndex = tabs.findIndex((tab) =>
       allPaneSnapshots(tab.rootSplit).some(
         (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
@@ -1906,12 +1925,6 @@ export class TabCommandService {
     if (tabIndex < 0) {
       return { ok: false, tag: 'WriteFailed', message: 'Editor file is not open' }
     }
-
-    const tab = tabs[tabIndex]
-    const pane = allPaneSnapshots(tab.rootSplit).find(
-      (candidate) => candidate.id === payload.paneId,
-    )
-    if (!pane) return { ok: false, tag: 'WriteFailed', message: 'Editor pane is not open' }
 
     const content = payload.options.content
     const normalized =
@@ -1924,7 +1937,24 @@ export class TabCommandService {
     )
     if (!writeResult.ok) return writeResult
 
-    const updatedPane = paneWithUpdatedEditorFileState(pane, payload.filePath, {
+    const currentTabs = this.getCommandTabs(sender.id, payload)
+    const currentActiveId = this.getCommandActiveTabId(sender.id, payload)
+    const currentTabIndex = currentTabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
+    if (currentTabIndex < 0) {
+      return { ok: false, tag: 'WriteFailed', message: 'Editor file is not open' }
+    }
+
+    const currentTab = currentTabs[currentTabIndex]
+    const currentPane = allPaneSnapshots(currentTab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!currentPane) return { ok: false, tag: 'WriteFailed', message: 'Editor pane is not open' }
+
+    const updatedPane = paneWithUpdatedEditorFileState(currentPane, payload.filePath, {
       dirty: false,
       originalContent: content,
       currentContent: content,
@@ -1935,16 +1965,16 @@ export class TabCommandService {
       return { ok: false, tag: 'WriteFailed', message: 'Editor file is not open' }
     }
 
-    tabs[tabIndex] = {
-      ...tab,
-      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+    currentTabs[currentTabIndex] = {
+      ...currentTab,
+      rootSplit: updatePaneSnapshot(currentTab.rootSplit, payload.paneId, () => updatedPane),
     }
     const result = {
       worktreePath: payload.worktreePath,
-      tabs,
-      activeTabId: activeId,
+      tabs: currentTabs,
+      activeTabId: currentActiveId,
     }
-    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    this.setTabState(sender, payload.worktreePath, currentTabs, currentActiveId)
     return { ok: true, mtimeMs: writeResult.mtimeMs, size: writeResult.size, result }
   }
 
@@ -2314,6 +2344,65 @@ export class TabCommandService {
     if (!tab || tab.suspended) return { ok: true }
 
     const dirtyFiles = this.dirtyEditorFiles(tab)
+    if (dirtyFiles.length === 0) return { ok: true }
+
+    const choice = await this.deps.confirmUnsavedChanges(
+      sender,
+      dirtyFiles.map((file) => file.filePath),
+    )
+    if (choice === 'cancel') return { ok: false, reason: 'cancelled' }
+    if (choice === 'discard') return { ok: true }
+
+    let failedCount = 0
+    for (const file of dirtyFiles) {
+      try {
+        const result = await this.saveEditorFile(sender, {
+          worktreePath: payload.worktreePath,
+          paneId: file.paneId,
+          filePath: file.filePath,
+          options: {
+            content: file.currentContent ?? '',
+            fileLineEnding: file.fileLineEnding,
+            expectedMtimeMs: file.fileMtimeMs,
+          },
+        })
+        if (!result.ok) failedCount += 1
+      } catch {
+        failedCount += 1
+      }
+    }
+    if (failedCount > 0) return { ok: false, reason: 'save-failed', failedCount }
+
+    return { ok: true }
+  }
+
+  async prepareCloseAllForWorktree(
+    sender: WebContents,
+    payload: PrepareCloseAllForWorktreePayload,
+  ): Promise<TabCloseAllPreflightResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const openTabs = tabs.filter((tab) => !tab.suspended)
+
+    if (!payload.confirmedActiveProcesses) {
+      const warnings = (
+        await Promise.all(
+          openTabs.map(async (tab) => {
+            const description = await this.getActiveProcessDescription(
+              allPaneSnapshots(tab.rootSplit),
+            )
+            return description ? { tabName: getTabDisplayName(tab), description } : null
+          }),
+        )
+      ).filter((entry): entry is { tabName: string; description: string } => entry !== null)
+
+      if (warnings.length > 0) {
+        return { ok: false, reason: 'active-processes', warnings }
+      }
+    }
+
+    const dirtyFiles = openTabs.flatMap((tab) => this.dirtyEditorFiles(tab))
     if (dirtyFiles.length === 0) return { ok: true }
 
     const choice = await this.deps.confirmUnsavedChanges(

--- a/src/main/commands/tabCommands.ts
+++ b/src/main/commands/tabCommands.ts
@@ -14,7 +14,22 @@ import type { ProfileStore } from '../profiles/ProfileStore'
 import { profileToReader } from '../profiles/ProfileStore'
 import { profileErrorMessage } from '../profiles/errors'
 import type { PreferencesReader } from '../agents/types'
-import type { PaneSnapshot, SplitSnapshot, TabCommandResult, TabSnapshot } from './types'
+import type {
+  CloseWarningResult,
+  CloseWarningTarget,
+  EditorFileLoadResult,
+  EditorFileReadResult,
+  EditorFileSaveResult,
+  EditorFileSnapshot,
+  PaneSnapshot,
+  SerializedLayout,
+  SerializedSplitNode,
+  SplitSnapshot,
+  TabClosePreflightResult,
+  TabCommandResult,
+  TabSnapshot,
+  TabStateSnapshot,
+} from './types'
 
 export interface ToolSpawnPayload {
   toolId: string
@@ -242,6 +257,14 @@ export class ToolSessionService {
     return this.deps.agentSessionManager.isAgentTool(toolId)
   }
 
+  isAgentBusy(sessionId: string): boolean {
+    return this.deps.agentSessionManager.isBusy(sessionId)
+  }
+
+  hasChildProcess(sessionId: string): Promise<boolean> {
+    return this.deps.ptyManager.hasChildProcess(sessionId)
+  }
+
   destroyAgentSession(sessionId: string): void {
     this.deps.agentSessionManager.destroySession(sessionId)
   }
@@ -255,9 +278,38 @@ export class ToolSessionService {
     return result.isOk() ? result.value.name : undefined
   }
 
+  getAgentSessionId(ptySessionId: string): string | undefined {
+    return this.deps.agentSessionManager.getSession(ptySessionId)?.agentSessionId
+  }
+
+  getOwnedSessionConnection(
+    sender: WebContents,
+    sessionId: string,
+  ): { wsUrl: string; tmuxSessionName?: string } {
+    if (!this.deps.windowManager.ownsPtySession(sender.id, sessionId)) {
+      throw new Error('PTY session is not owned by this window')
+    }
+
+    const wsUrl = this.deps.wsBridge.getUrl(sessionId)
+    if (!wsUrl) {
+      throw new Error('PTY session is not available')
+    }
+
+    return {
+      wsUrl,
+      tmuxSessionName: this.deps.ptyManager.getTmuxSessionName(sessionId),
+    }
+  }
+
   async hasTmuxSession(name: string): Promise<boolean> {
     validateTmuxName(name)
     return this.deps.tmuxManager.hasSession(name)
+  }
+
+  async killTmuxSession(name: string): Promise<void> {
+    validateTmuxName(name)
+    if (!TmuxManagerStatics.isCanopySession(name)) return
+    await this.deps.tmuxManager.killSession(name)
   }
 }
 
@@ -266,13 +318,27 @@ interface TabCommandServiceDeps {
   layoutStore: LayoutStore
   browserManager: BrowserManager
   windowManager: WindowManager
+  confirmUnsavedChanges: (
+    sender: WebContents,
+    filePaths: string[],
+  ) => Promise<'save' | 'discard' | 'cancel'>
+  writeEditorFile: (
+    sender: WebContents,
+    filePath: string,
+    content: string,
+    expectedMtimeMs?: number,
+  ) => Promise<EditorWriteFileResult>
+  loadEditorFile: (
+    sender: WebContents,
+    filePath: string,
+    maxBytes?: number,
+  ) => Promise<EditorFileReadResult>
   resolveWorkspaceIdForWorktree: (webContentsId: number, worktreePath: string) => string | null
+  emitAppStateChanged: (sender: WebContents) => void
 }
 
 interface TabCommandPayloadBase {
   worktreePath: string
-  tabs?: TabSnapshot[]
-  activeTabId?: string | null
 }
 
 interface OpenToolPayload extends TabCommandPayloadBase {
@@ -283,6 +349,113 @@ interface OpenToolPayload extends TabCommandPayloadBase {
     workspaceName?: string
     branch?: string
   }
+}
+
+interface OpenDiffPayload extends TabCommandPayloadBase {}
+
+interface OpenSessionTabPayload extends TabCommandPayloadBase {
+  name: string
+  sessionId: string
+}
+
+interface OpenEditorFilePayload extends TabCommandPayloadBase {
+  filePath: string
+}
+
+interface DetachEditorFilePayload extends TabCommandPayloadBase {
+  paneId: string
+  filePath: string
+}
+
+interface CloseEditorFilePayload extends TabCommandPayloadBase {
+  paneId: string
+  filePath: string
+}
+
+interface PrepareCloseEditorFilePayload extends TabCommandPayloadBase {
+  paneId: string
+  filePath: string
+}
+
+interface MoveEditorFilePayload extends TabCommandPayloadBase {
+  paneId: string
+  filePath: string
+  toIndex: number
+}
+
+interface MoveEditorFileBetweenPanesPayload extends TabCommandPayloadBase {
+  sourcePaneId: string
+  targetPaneId: string
+  filePath: string
+  toIndex: number
+}
+
+interface SetActiveEditorFilePayload extends TabCommandPayloadBase {
+  paneId: string
+  filePath: string
+}
+
+interface UpdateEditorFileStatePayload extends TabCommandPayloadBase {
+  paneId: string
+  filePath: string
+  patch: Partial<EditorFileSnapshot>
+}
+
+interface SaveEditorFilePayload extends TabCommandPayloadBase {
+  paneId: string
+  filePath: string
+  options: {
+    content: string
+    fileLineEnding?: 'LF' | 'CRLF'
+    expectedMtimeMs?: number
+  }
+}
+
+interface LoadEditorFilePayload extends TabCommandPayloadBase {
+  paneId: string
+  filePath: string
+  options?: {
+    maxBytes?: number
+  }
+}
+
+interface UpdatePaneTitlePayload extends TabCommandPayloadBase {
+  sessionId: string
+  title: string
+}
+
+interface UpdatePaneUrlPayload extends TabCommandPayloadBase {
+  sessionId: string
+  url: string
+}
+
+interface UpdateTmuxSessionNamePayload extends TabCommandPayloadBase {
+  oldName: string
+  newName: string
+}
+
+interface HandlePtyExitPayload extends TabCommandPayloadBase {
+  sessionId: string
+  exitCode: number
+  tmuxSessionName?: string
+}
+
+interface KillTmuxPanePayload extends TabCommandPayloadBase {
+  tabId: string
+  paneId: string
+}
+
+interface ReattachTmuxPanePayload extends TabCommandPayloadBase {
+  tabId: string
+  paneId: string
+  options?: {
+    workspaceName?: string
+    branch?: string
+  }
+}
+
+interface ToggleFocusedInspectorPayload extends TabCommandPayloadBase {
+  tabId: string
 }
 
 interface RestartPanePayload extends TabCommandPayloadBase {
@@ -298,6 +471,59 @@ interface CloseTabPayload extends TabCommandPayloadBase {
   tabId: string
 }
 
+interface PrepareCloseTabPayload extends TabCommandPayloadBase {
+  tabId: string
+}
+
+interface GetCloseWarningPayload extends TabCommandPayloadBase {
+  target: CloseWarningTarget
+}
+
+interface ClosePanePayload extends TabCommandPayloadBase {
+  tabId: string
+  paneId: string
+}
+
+interface CloseAllForWorktreePayload extends TabCommandPayloadBase {}
+
+interface ReopenClosedTabPayload extends TabCommandPayloadBase {
+  options?: {
+    workspaceName?: string
+    branch?: string
+  }
+}
+
+interface SetActiveTabPayload extends TabCommandPayloadBase {
+  tabId: string
+}
+
+interface MoveTabPayload extends TabCommandPayloadBase {
+  fromIndex: number
+  toIndex: number
+}
+
+interface MoveTabToSplitPayload extends TabCommandPayloadBase {
+  sourceTabId: string
+  targetTabId: string
+  targetPaneId: string
+  direction: 'horizontal' | 'vertical'
+  position: 'first' | 'second'
+}
+
+interface MovePaneToTargetPayload extends TabCommandPayloadBase {
+  sourceTabId: string
+  sourcePaneId: string
+  targetTabId: string
+  targetPaneId: string
+  direction: 'horizontal' | 'vertical'
+  position: 'first' | 'second'
+}
+
+interface DetachPaneToTabPayload extends TabCommandPayloadBase {
+  sourceTabId: string
+  sourcePaneId: string
+}
+
 interface SpawnPanePayload extends TabCommandPayloadBase {
   toolId: string
   options?: {
@@ -309,19 +535,221 @@ interface SpawnPanePayload extends TabCommandPayloadBase {
   }
 }
 
-interface SaveLayoutPayload {
-  worktreePath: string
-  layoutJson: string
+interface SplitPanePayload extends TabCommandPayloadBase {
+  tabId: string
+  paneId: string
+  direction: 'horizontal' | 'vertical'
 }
 
-interface DeleteLayoutPayload {
+interface FocusPanePayload extends TabCommandPayloadBase {
+  tabId: string
+  paneId: string
+}
+
+interface NavigatePaneFocusPayload extends TabCommandPayloadBase {
+  tabId: string
+  direction: 'left' | 'right' | 'up' | 'down'
+}
+
+interface UpdateSplitRatioPayload extends TabCommandPayloadBase {
+  tabId: string
+  splitId: string
+  ratio: number
+}
+
+interface RestoreLayoutPayload extends TabCommandPayloadBase {
+  layoutJson: string
+  options?: {
+    workspaceName?: string
+    branch?: string
+  }
+}
+
+interface ResumeSuspendedTabPayload extends TabCommandPayloadBase {
+  tabId: string
+  options?: {
+    workspaceName?: string
+    branch?: string
+  }
+}
+
+interface SaveCurrentLayoutPayload {
   worktreePath: string
+}
+
+interface FocusSessionPayload {
+  sessionId: string
+}
+
+interface ClosedTabEntry {
+  toolId: string
+  toolName: string
+  profileId?: string
+}
+
+type EditorWriteFileResult =
+  | { ok: true; mtimeMs: number; size: number }
+  | { ok: false; tag: 'StaleWrite'; actualMtimeMs: number }
+  | { ok: false; tag: 'WriteFailed' | 'StatFailed'; message: string }
+
+interface DirtyEditorFile {
+  paneId: string
+  filePath: string
+  currentContent?: string
+  fileLineEnding?: 'LF' | 'CRLF'
+  fileMtimeMs?: number
 }
 
 function allPaneSnapshots(split: SplitSnapshot): PaneSnapshot[] {
   validateSplitSnapshot(split)
   if (split.type === 'leaf') return [split.pane]
   return [...allPaneSnapshots(split.first), ...allPaneSnapshots(split.second)]
+}
+
+function firstPaneSnapshot(split: SplitSnapshot): PaneSnapshot {
+  if (split.type === 'leaf') return split.pane
+  return firstPaneSnapshot(split.first)
+}
+
+function splitDepth(split: SplitSnapshot): number {
+  if (split.type === 'leaf') return 1
+  return 1 + Math.max(splitDepth(split.first), splitDepth(split.second))
+}
+
+const MAX_SPLIT_DEPTH = 4
+const MAX_CLOSED_TABS = 20
+const AI_TOOL_IDS = new Set(['claude', 'codex', 'opencode', 'gemini'])
+const NO_SPLIT_TOOLS = new Set(['claude', 'codex', 'opencode', 'gemini'])
+
+function splitPaneSnapshot(
+  split: SplitSnapshot,
+  paneId: string,
+  direction: 'horizontal' | 'vertical',
+  pane: PaneSnapshot,
+): SplitSnapshot | null {
+  if (splitDepth(split) >= MAX_SPLIT_DEPTH) return null
+  return splitPaneSnapshotInner(split, paneId, direction, pane)
+}
+
+function splitPaneSnapshotInner(
+  split: SplitSnapshot,
+  paneId: string,
+  direction: 'horizontal' | 'vertical',
+  pane: PaneSnapshot,
+): SplitSnapshot | null {
+  if (split.type === 'leaf') {
+    if (split.pane.id !== paneId) return null
+    return {
+      type: 'split',
+      id: splitId(),
+      direction,
+      ratio: 0.5,
+      first: split,
+      second: { type: 'leaf', pane },
+    }
+  }
+
+  const first = splitPaneSnapshotInner(split.first, paneId, direction, pane)
+  if (first) return { ...split, first }
+
+  const second = splitPaneSnapshotInner(split.second, paneId, direction, pane)
+  if (second) return { ...split, second }
+
+  return null
+}
+
+function removePaneSnapshot(
+  split: SplitSnapshot,
+  paneId: string,
+): { tree: SplitSnapshot | null; removed: PaneSnapshot } | null {
+  if (split.type === 'leaf') {
+    if (split.pane.id !== paneId) return null
+    return { tree: null, removed: split.pane }
+  }
+
+  const first = removePaneSnapshot(split.first, paneId)
+  if (first) {
+    return {
+      tree: first.tree ? { ...split, first: first.tree } : split.second,
+      removed: first.removed,
+    }
+  }
+
+  const second = removePaneSnapshot(split.second, paneId)
+  if (second) {
+    return {
+      tree: second.tree ? { ...split, second: second.tree } : split.first,
+      removed: second.removed,
+    }
+  }
+
+  return null
+}
+
+function graftSplitSnapshot(
+  split: SplitSnapshot,
+  targetPaneId: string,
+  direction: 'horizontal' | 'vertical',
+  subtree: SplitSnapshot,
+  position: 'first' | 'second',
+): SplitSnapshot | null {
+  return graftSplitSnapshotInner(
+    split,
+    targetPaneId,
+    direction,
+    subtree,
+    position,
+    splitDepth(subtree),
+    1,
+  )
+}
+
+function graftSplitSnapshotInner(
+  split: SplitSnapshot,
+  targetPaneId: string,
+  direction: 'horizontal' | 'vertical',
+  subtree: SplitSnapshot,
+  position: 'first' | 'second',
+  subtreeDepth: number,
+  currentDepth: number,
+): SplitSnapshot | null {
+  if (split.type === 'leaf') {
+    if (split.pane.id !== targetPaneId) return null
+    if (currentDepth + subtreeDepth > MAX_SPLIT_DEPTH) return null
+
+    return {
+      type: 'split',
+      id: splitId(),
+      direction,
+      ratio: 0.5,
+      first: position === 'first' ? subtree : split,
+      second: position === 'first' ? split : subtree,
+    }
+  }
+
+  const first = graftSplitSnapshotInner(
+    split.first,
+    targetPaneId,
+    direction,
+    subtree,
+    position,
+    subtreeDepth,
+    currentDepth + 1,
+  )
+  if (first) return { ...split, first }
+
+  const second = graftSplitSnapshotInner(
+    split.second,
+    targetPaneId,
+    direction,
+    subtree,
+    position,
+    subtreeDepth,
+    currentDepth + 1,
+  )
+  if (second) return { ...split, second }
+
+  return null
 }
 
 function updatePaneSnapshot(
@@ -338,6 +766,221 @@ function updatePaneSnapshot(
     first: updatePaneSnapshot(split.first, paneId, updater),
     second: updatePaneSnapshot(split.second, paneId, updater),
   }
+}
+
+function editorFileList(
+  list: EditorFileSnapshot[] | undefined,
+  filePath: string,
+  legacySingle: string | undefined,
+): EditorFileSnapshot[] {
+  const base = list ?? (legacySingle ? [{ filePath: legacySingle }] : [])
+  if (base.some((file) => file.filePath === filePath)) return base
+  return [...base, { filePath }]
+}
+
+function paneHasEditorFile(pane: PaneSnapshot, filePath: string): boolean {
+  return (
+    pane.paneType === 'editor' &&
+    (pane.filePath === filePath ||
+      (pane.editorFiles ?? []).some((file) => file.filePath === filePath))
+  )
+}
+
+function paneWithEditorFile(pane: PaneSnapshot, filePath: string): PaneSnapshot {
+  return {
+    ...pane,
+    filePath,
+    editorActiveFile: filePath,
+    editorFiles: editorFileList(pane.editorFiles, filePath, pane.filePath),
+  }
+}
+
+function paneWithoutEditorFile(pane: PaneSnapshot, filePath: string): PaneSnapshot | null {
+  const files = pane.editorFiles ?? (pane.filePath ? [{ filePath: pane.filePath }] : [])
+  if (!files.some((file) => file.filePath === filePath)) return pane
+
+  const remaining = files.filter((file) => file.filePath !== filePath)
+  if (remaining.length === 0) return null
+
+  const activeFile =
+    pane.editorActiveFile === filePath
+      ? remaining[Math.max(0, remaining.length - 1)].filePath
+      : (pane.editorActiveFile ?? remaining[0].filePath)
+
+  return {
+    ...pane,
+    editorFiles: remaining,
+    editorActiveFile: activeFile,
+    filePath: activeFile,
+  }
+}
+
+function paneWithMovedEditorFile(
+  pane: PaneSnapshot,
+  filePath: string,
+  toIndex: number,
+): PaneSnapshot | null {
+  const files = pane.editorFiles ?? (pane.filePath ? [{ filePath: pane.filePath }] : [])
+  const fromIndex = files.findIndex((file) => file.filePath === filePath)
+  if (fromIndex < 0) return null
+
+  const clamped = Math.max(0, Math.min(toIndex, files.length))
+  if (clamped === fromIndex || clamped === fromIndex + 1) return pane
+
+  const next = [...files]
+  const [moved] = next.splice(fromIndex, 1)
+  const insertAt = clamped > fromIndex ? clamped - 1 : clamped
+  next.splice(insertAt, 0, moved)
+
+  return {
+    ...pane,
+    editorFiles: next,
+  }
+}
+
+function paneWithActiveEditorFile(pane: PaneSnapshot, filePath: string): PaneSnapshot | null {
+  const files = pane.editorFiles ?? (pane.filePath ? [{ filePath: pane.filePath }] : [])
+  if (!files.some((file) => file.filePath === filePath)) return null
+
+  return {
+    ...pane,
+    editorActiveFile: filePath,
+    filePath,
+  }
+}
+
+function paneWithUpdatedEditorFileState(
+  pane: PaneSnapshot,
+  filePath: string,
+  patch: Partial<EditorFileSnapshot>,
+): PaneSnapshot | null {
+  const files = pane.editorFiles ?? (pane.filePath ? [{ filePath: pane.filePath }] : [])
+  if (!files.some((file) => file.filePath === filePath)) return null
+
+  return {
+    ...pane,
+    editorFiles: files.map((file) => (file.filePath === filePath ? { ...file, ...patch } : file)),
+  }
+}
+
+function paneWithInsertedEditorFile(
+  pane: PaneSnapshot,
+  file: EditorFileSnapshot,
+  toIndex: number,
+): PaneSnapshot {
+  const files = pane.editorFiles ?? (pane.filePath ? [{ filePath: pane.filePath }] : [])
+  if (files.some((candidate) => candidate.filePath === file.filePath)) {
+    return {
+      ...pane,
+      editorActiveFile: file.filePath,
+      filePath: file.filePath,
+    }
+  }
+
+  const clamped = Math.max(0, Math.min(toIndex, files.length))
+  const next = [...files]
+  next.splice(clamped, 0, file)
+
+  return {
+    ...pane,
+    editorFiles: next,
+    editorActiveFile: file.filePath,
+    filePath: file.filePath,
+  }
+}
+
+function updateSplitRatioSnapshot(
+  split: SplitSnapshot,
+  splitId: string,
+  ratio: number,
+): { split: SplitSnapshot; changed: boolean } {
+  if (split.type === 'leaf') return { split, changed: false }
+  if (split.id === splitId) {
+    return { split: { ...split, ratio }, changed: true }
+  }
+
+  const first = updateSplitRatioSnapshot(split.first, splitId, ratio)
+  if (first.changed) {
+    return { split: { ...split, first: first.split }, changed: true }
+  }
+
+  const second = updateSplitRatioSnapshot(split.second, splitId, ratio)
+  if (second.changed) {
+    return { split: { ...split, second: second.split }, changed: true }
+  }
+
+  return { split, changed: false }
+}
+
+interface LeafRectSnapshot {
+  paneId: string
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+function buildLeafRectSnapshots(
+  split: SplitSnapshot,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): LeafRectSnapshot[] {
+  if (split.type === 'leaf') return [{ paneId: split.pane.id, x, y, w, h }]
+
+  if (split.direction === 'vertical') {
+    const firstW = w * split.ratio
+    const secondW = w - firstW
+    return [
+      ...buildLeafRectSnapshots(split.first, x, y, firstW, h),
+      ...buildLeafRectSnapshots(split.second, x + firstW, y, secondW, h),
+    ]
+  }
+
+  const firstH = h * split.ratio
+  const secondH = h - firstH
+  return [
+    ...buildLeafRectSnapshots(split.first, x, y, w, firstH),
+    ...buildLeafRectSnapshots(split.second, x, y + firstH, w, secondH),
+  ]
+}
+
+function navigatePaneSnapshot(
+  split: SplitSnapshot,
+  fromPaneId: string,
+  direction: 'left' | 'right' | 'up' | 'down',
+): string | null {
+  const rects = buildLeafRectSnapshots(split, 0, 0, 1, 1)
+  const source = rects.find((rect) => rect.paneId === fromPaneId)
+  if (!source) return null
+
+  const sourceCenterX = source.x + source.w / 2
+  const sourceCenterY = source.y + source.h / 2
+  const eps = 0.001
+  const candidates = rects.filter((rect) => {
+    if (rect.paneId === fromPaneId) return false
+    const centerX = rect.x + rect.w / 2
+    const centerY = rect.y + rect.h / 2
+    if (direction === 'right') return centerX > sourceCenterX + eps
+    if (direction === 'left') return centerX < sourceCenterX - eps
+    if (direction === 'down') return centerY > sourceCenterY + eps
+    return centerY < sourceCenterY - eps
+  })
+
+  if (candidates.length === 0) return null
+
+  candidates.sort((a, b) => {
+    const aCenterX = a.x + a.w / 2
+    const aCenterY = a.y + a.h / 2
+    const bCenterX = b.x + b.w / 2
+    const bCenterY = b.y + b.h / 2
+    const distanceA = Math.abs(aCenterX - sourceCenterX) + Math.abs(aCenterY - sourceCenterY)
+    const distanceB = Math.abs(bCenterX - sourceCenterX) + Math.abs(bCenterY - sourceCenterY)
+    return distanceA - distanceB
+  })
+
+  return candidates[0].paneId
 }
 
 function computeDisplayName(
@@ -367,6 +1010,10 @@ function paneId(): string {
   return `pane-${randomUUID()}`
 }
 
+function splitId(): string {
+  return `split-${randomUUID()}`
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
@@ -379,6 +1026,83 @@ function assertOptionalString(value: unknown, label: string): asserts value is s
   if (value !== undefined && typeof value !== 'string') {
     throw new Error(`Invalid tab snapshot: ${label} must be a string`)
   }
+}
+
+function assertOptionalBoolean(
+  value: unknown,
+  label: string,
+): asserts value is boolean | undefined {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new Error(`Invalid tab snapshot: ${label} must be a boolean`)
+  }
+}
+
+function assertOptionalNumber(value: unknown, label: string): asserts value is number | undefined {
+  if (value !== undefined && typeof value !== 'number') {
+    throw new Error(`Invalid tab snapshot: ${label} must be a number`)
+  }
+}
+
+function assertOptionalLineEnding(
+  value: unknown,
+  label: string,
+): asserts value is 'LF' | 'CRLF' | undefined {
+  if (value !== undefined && value !== 'LF' && value !== 'CRLF') {
+    throw new Error(`Invalid tab snapshot: ${label} must be LF or CRLF`)
+  }
+}
+
+function assertOptionalStringArray(
+  value: unknown,
+  label: string,
+): asserts value is string[] | undefined {
+  if (value === undefined) return
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw new Error(`Invalid tab snapshot: ${label} must be an array of strings`)
+  }
+}
+
+function validateEditorFileSnapshot(value: unknown): asserts value is EditorFileSnapshot {
+  if (!isRecord(value)) throw new Error('Invalid tab snapshot: editor file must be an object')
+  assertString(value.filePath, 'editorFile.filePath')
+  assertOptionalBoolean(value.dirty, 'editorFile.dirty')
+  assertOptionalString(value.originalContent, 'editorFile.originalContent')
+  assertOptionalString(value.currentContent, 'editorFile.currentContent')
+  assertOptionalNumber(value.fileMtimeMs, 'editorFile.fileMtimeMs')
+  assertOptionalLineEnding(value.fileLineEnding, 'editorFile.fileLineEnding')
+  assertOptionalBoolean(value.externalChangeDetected, 'editorFile.externalChangeDetected')
+}
+
+function editorFileStatePatch(value: unknown): Partial<EditorFileSnapshot> {
+  if (!isRecord(value)) throw new Error('Invalid tab command: editor file patch must be an object')
+
+  const patch: Partial<EditorFileSnapshot> = {}
+  if ('dirty' in value) {
+    assertOptionalBoolean(value.dirty, 'editorFile.dirty')
+    patch.dirty = value.dirty
+  }
+  if ('originalContent' in value) {
+    assertOptionalString(value.originalContent, 'editorFile.originalContent')
+    patch.originalContent = value.originalContent
+  }
+  if ('currentContent' in value) {
+    assertOptionalString(value.currentContent, 'editorFile.currentContent')
+    patch.currentContent = value.currentContent
+  }
+  if ('fileMtimeMs' in value) {
+    assertOptionalNumber(value.fileMtimeMs, 'editorFile.fileMtimeMs')
+    patch.fileMtimeMs = value.fileMtimeMs
+  }
+  if ('fileLineEnding' in value) {
+    assertOptionalLineEnding(value.fileLineEnding, 'editorFile.fileLineEnding')
+    patch.fileLineEnding = value.fileLineEnding
+  }
+  if ('externalChangeDetected' in value) {
+    assertOptionalBoolean(value.externalChangeDetected, 'editorFile.externalChangeDetected')
+    patch.externalChangeDetected = value.externalChangeDetected
+  }
+
+  return patch
 }
 
 function validatePaneSnapshot(value: unknown): asserts value is PaneSnapshot {
@@ -404,8 +1128,92 @@ function validatePaneSnapshot(value: unknown): asserts value is PaneSnapshot {
   assertOptionalString(value.editorActiveFile, 'pane.editorActiveFile')
   assertOptionalString(value.profileId, 'pane.profileId')
   assertOptionalString(value.profileName, 'pane.profileName')
+  if (value.editorFiles !== undefined) {
+    if (!Array.isArray(value.editorFiles)) {
+      throw new Error('Invalid tab snapshot: pane.editorFiles must be an array')
+    }
+    value.editorFiles.forEach(validateEditorFileSnapshot)
+  }
   if (value.detached !== undefined && typeof value.detached !== 'boolean') {
     throw new Error('Invalid tab snapshot: pane.detached must be a boolean')
+  }
+  if (value.inspectorOpen !== undefined && typeof value.inspectorOpen !== 'boolean') {
+    throw new Error('Invalid tab snapshot: pane.inspectorOpen must be a boolean')
+  }
+}
+
+function validateSerializedSplitNode(value: unknown): asserts value is SerializedSplitNode {
+  if (!isRecord(value)) throw new Error('Invalid serialized layout: split node must be an object')
+
+  if (value.type === 'leaf') {
+    assertString(value.toolId, 'serializedLeaf.toolId')
+    assertString(value.toolName, 'serializedLeaf.toolName')
+    assertOptionalString(value.agentSessionId, 'serializedLeaf.agentSessionId')
+    assertOptionalString(value.claudeSessionId, 'serializedLeaf.claudeSessionId')
+    assertOptionalString(value.browserUrl, 'serializedLeaf.browserUrl')
+    if (
+      value.browserDevToolsMode !== undefined &&
+      value.browserDevToolsMode !== 'bottom' &&
+      value.browserDevToolsMode !== 'right'
+    ) {
+      throw new Error('Invalid serialized layout: browserDevToolsMode is invalid')
+    }
+    assertOptionalString(value.filePath, 'serializedLeaf.filePath')
+    assertOptionalStringArray(value.editorFiles, 'serializedLeaf.editorFiles')
+    assertOptionalString(value.editorActiveFile, 'serializedLeaf.editorActiveFile')
+    assertOptionalString(value.tmuxSessionName, 'serializedLeaf.tmuxSessionName')
+    assertOptionalString(value.profileId, 'serializedLeaf.profileId')
+    return
+  }
+
+  if (value.type !== 'hsplit' && value.type !== 'vsplit') {
+    throw new Error('Invalid serialized layout: split node type is invalid')
+  }
+  if (typeof value.ratio !== 'number' || !Number.isFinite(value.ratio)) {
+    throw new Error('Invalid serialized layout: split ratio must be a finite number')
+  }
+  validateSerializedSplitNode(value.first)
+  validateSerializedSplitNode(value.second)
+}
+
+function cloneSerializedSplitNode(node: SerializedSplitNode): SerializedSplitNode {
+  if (node.type === 'leaf') {
+    return {
+      type: 'leaf',
+      toolId: node.toolId,
+      toolName: node.toolName,
+      agentSessionId: node.agentSessionId,
+      claudeSessionId: node.claudeSessionId,
+      browserUrl: node.browserUrl,
+      browserDevToolsMode: node.browserDevToolsMode,
+      filePath: node.filePath,
+      editorFiles: node.editorFiles ? [...node.editorFiles] : undefined,
+      editorActiveFile: node.editorActiveFile,
+      tmuxSessionName: node.tmuxSessionName,
+      profileId: node.profileId,
+    }
+  }
+  return {
+    type: node.type,
+    first: cloneSerializedSplitNode(node.first),
+    second: cloneSerializedSplitNode(node.second),
+    ratio: node.ratio,
+  }
+}
+
+function validateSerializedLayout(value: unknown): asserts value is SerializedLayout {
+  if (!isRecord(value)) throw new Error('Invalid serialized layout: layout must be an object')
+  if (!Array.isArray(value.tabs)) {
+    throw new Error('Invalid serialized layout: tabs must be an array')
+  }
+  if (typeof value.activeTabIndex !== 'number' || !Number.isFinite(value.activeTabIndex)) {
+    throw new Error('Invalid serialized layout: activeTabIndex must be a finite number')
+  }
+  for (const tab of value.tabs) {
+    if (!isRecord(tab)) throw new Error('Invalid serialized layout: tab must be an object')
+    assertString(tab.toolId, 'serializedTab.toolId')
+    assertString(tab.toolName, 'serializedTab.toolName')
+    validateSerializedSplitNode(tab.rootSplit)
   }
 }
 
@@ -416,6 +1224,7 @@ function validateSplitSnapshot(value: unknown): asserts value is SplitSnapshot {
     return
   }
   if (value.type !== 'split') throw new Error('Invalid tab snapshot: split.type is invalid')
+  assertString(value.id, 'split.id')
   if (value.direction !== 'horizontal' && value.direction !== 'vertical') {
     throw new Error('Invalid tab snapshot: split.direction is invalid')
   }
@@ -426,21 +1235,6 @@ function validateSplitSnapshot(value: unknown): asserts value is SplitSnapshot {
   validateSplitSnapshot(value.second)
 }
 
-function validateTabSnapshots(value: unknown): TabSnapshot[] {
-  if (!Array.isArray(value)) return []
-  for (const tab of value) {
-    if (!isRecord(tab)) throw new Error('Invalid tab snapshot: tab must be an object')
-    assertString(tab.id, 'tab.id')
-    assertString(tab.toolId, 'tab.toolId')
-    assertString(tab.toolName, 'tab.toolName')
-    assertString(tab.name, 'tab.name')
-    assertString(tab.worktreePath, 'tab.worktreePath')
-    assertString(tab.focusedPaneId, 'tab.focusedPaneId')
-    validateSplitSnapshot(tab.rootSplit)
-  }
-  return value
-}
-
 function emptyResult(
   worktreePath: string,
   tabs: TabSnapshot[],
@@ -449,12 +1243,33 @@ function emptyResult(
   return { worktreePath, tabs, activeTabId }
 }
 
+function reconcileTabSnapshotIdentity(tab: TabSnapshot, tabs: TabSnapshot[]): TabSnapshot {
+  const focused = allPaneSnapshots(tab.rootSplit).find((pane) => pane.id === tab.focusedPaneId)
+  if (!focused || tab.toolId === focused.toolId) return tab
+
+  const sameCount = tabs.filter(
+    (candidate) => candidate.id !== tab.id && candidate.toolId === focused.toolId,
+  ).length
+  return {
+    ...tab,
+    toolId: focused.toolId,
+    toolName: focused.toolName,
+    name: sameCount === 0 ? focused.toolName : `${focused.toolName} #${sameCount + 1}`,
+  }
+}
+
 export class TabCommandService {
+  private tabsByWorktreeByWindow = new Map<number, Map<string, TabSnapshot[]>>()
+  private activeTabIdByWorktreeByWindow = new Map<number, Map<string, string | null>>()
+  private closedTabsByWorktreeByWindow = new Map<number, Map<string, ClosedTabEntry[]>>()
+  private trackedWebContents = new Set<number>()
+
   constructor(private deps: TabCommandServiceDeps) {}
 
   async openTool(sender: WebContents, payload: OpenToolPayload): Promise<TabCommandResult> {
+    this.trackSender(sender)
     this.assertSenderOwnsWorktree(sender, payload.worktreePath)
-    const tabs = [...validateTabSnapshots(payload.tabs)]
+    const tabs = this.getCommandTabs(sender.id, payload)
     const pane = await this.createPane(sender, payload.toolId, payload.worktreePath, {
       ...payload.options,
     })
@@ -476,27 +1291,968 @@ export class TabCommandService {
     }
 
     tabs.push(openedTab)
-    return {
+    const result = {
       worktreePath: payload.worktreePath,
       tabs,
       activeTabId: id,
       openedTab,
     }
+    this.setTabState(sender, payload.worktreePath, tabs, id)
+    return result
   }
 
-  async restartPane(sender: WebContents, payload: RestartPanePayload): Promise<TabCommandResult> {
+  openDiffTab(sender: WebContents, payload: OpenDiffPayload): TabCommandResult {
+    this.trackSender(sender)
     this.assertSenderOwnsWorktree(sender, payload.worktreePath)
-    const tabs = [...validateTabSnapshots(payload.tabs)]
-    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    const tabs = this.getCommandTabs(sender.id, payload)
+
+    for (const [tabIndex, tab] of tabs.entries()) {
+      const diffPane = allPaneSnapshots(tab.rootSplit).find((pane) => pane.paneType === 'diff')
+      if (!diffPane) continue
+
+      tabs[tabIndex] = { ...tab, focusedPaneId: diffPane.id }
+      const result = {
+        worktreePath: payload.worktreePath,
+        tabs,
+        activeTabId: tab.id,
+      }
+      this.setTabState(sender, payload.worktreePath, tabs, tab.id)
+      return result
+    }
+
+    const pane: PaneSnapshot = {
+      id: paneId(),
+      sessionId: '',
+      wsUrl: '',
+      toolId: 'diff',
+      toolName: 'Diff',
+      isRunning: false,
+      exitCode: null,
+      title: null,
+      paneType: 'diff',
+    }
+    const id = tabId()
+    const openedTab: TabSnapshot = {
+      id,
+      toolId: 'diff',
+      toolName: 'Diff',
+      name: computeDisplayName('Diff', payload.worktreePath, 'diff', tabs),
+      worktreePath: payload.worktreePath,
+      rootSplit: { type: 'leaf', pane },
+      focusedPaneId: pane.id,
+    }
+
+    tabs.push(openedTab)
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: id,
+      openedTab,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, id)
+    return result
+  }
+
+  openSessionTab(sender: WebContents, payload: OpenSessionTabPayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const session = this.deps.toolSessions.getOwnedSessionConnection(sender, payload.sessionId)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const pane: PaneSnapshot = {
+      id: paneId(),
+      sessionId: payload.sessionId,
+      wsUrl: session.wsUrl,
+      toolId: 'shell',
+      toolName: 'Shell',
+      isRunning: true,
+      exitCode: null,
+      title: null,
+      tmuxSessionName: session.tmuxSessionName,
+    }
+    const id = tabId()
+    const openedTab: TabSnapshot = {
+      id,
+      toolId: 'shell',
+      toolName: payload.name,
+      name: computeDisplayName(payload.name, payload.worktreePath, 'shell', tabs),
+      worktreePath: payload.worktreePath,
+      rootSplit: { type: 'leaf', pane },
+      focusedPaneId: pane.id,
+    }
+
+    tabs.push(openedTab)
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: id,
+      openedTab,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, id)
+    return result
+  }
+
+  openEditorFile(sender: WebContents, payload: OpenEditorFilePayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+
+    for (const [tabIndex, tab] of tabs.entries()) {
+      if (tab.suspended) continue
+      const existing = allPaneSnapshots(tab.rootSplit).find((pane) =>
+        paneHasEditorFile(pane, payload.filePath),
+      )
+      if (!existing) continue
+
+      tabs[tabIndex] = {
+        ...tab,
+        rootSplit: updatePaneSnapshot(tab.rootSplit, existing.id, (pane) =>
+          paneWithEditorFile(pane, payload.filePath),
+        ),
+        focusedPaneId: existing.id,
+      }
+      const result = {
+        worktreePath: payload.worktreePath,
+        tabs,
+        activeTabId: tab.id,
+      }
+      this.setTabState(sender, payload.worktreePath, tabs, tab.id)
+      return result
+    }
+
+    const activeTabIndex = tabs.findIndex((tab) => tab.id === activeId && !tab.suspended)
+    if (activeTabIndex >= 0) {
+      const activeTab = tabs[activeTabIndex]
+      const panes = allPaneSnapshots(activeTab.rootSplit)
+      const editorPane =
+        panes.find((pane) => pane.id === activeTab.focusedPaneId && pane.paneType === 'editor') ??
+        panes.find((pane) => pane.paneType === 'editor')
+
+      if (editorPane) {
+        tabs[activeTabIndex] = {
+          ...activeTab,
+          rootSplit: updatePaneSnapshot(activeTab.rootSplit, editorPane.id, (pane) =>
+            paneWithEditorFile(pane, payload.filePath),
+          ),
+          focusedPaneId: editorPane.id,
+        }
+        const result = {
+          worktreePath: payload.worktreePath,
+          tabs,
+          activeTabId: activeTab.id,
+        }
+        this.setTabState(sender, payload.worktreePath, tabs, activeTab.id)
+        return result
+      }
+    }
+
+    const pane: PaneSnapshot = {
+      id: paneId(),
+      sessionId: '',
+      wsUrl: '',
+      toolId: 'editor',
+      toolName: 'Editor',
+      isRunning: true,
+      exitCode: null,
+      title: null,
+      paneType: 'editor',
+      filePath: payload.filePath,
+      editorFiles: [{ filePath: payload.filePath }],
+      editorActiveFile: payload.filePath,
+    }
+    const id = tabId()
+    const openedTab: TabSnapshot = {
+      id,
+      toolId: 'editor',
+      toolName: 'Editor',
+      name: computeDisplayName('Editor', payload.worktreePath, 'editor', tabs),
+      worktreePath: payload.worktreePath,
+      rootSplit: { type: 'leaf', pane },
+      focusedPaneId: pane.id,
+    }
+
+    tabs.push(openedTab)
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: id,
+      openedTab,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, id)
+    return result
+  }
+
+  detachEditorFile(sender: WebContents, payload: DetachEditorFilePayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const detachedFile = (
+      pane.editorFiles ?? (pane.filePath ? [{ filePath: pane.filePath }] : [])
+    ).find((file) => file.filePath === payload.filePath) ?? { filePath: payload.filePath }
+    const updatedPane = paneWithoutEditorFile(pane, payload.filePath)
+    if (!updatedPane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+    }
+
+    const detachedPane: PaneSnapshot = {
+      id: paneId(),
+      sessionId: '',
+      wsUrl: '',
+      toolId: 'editor',
+      toolName: 'Editor',
+      isRunning: true,
+      exitCode: null,
+      title: null,
+      paneType: 'editor',
+      filePath: payload.filePath,
+      editorFiles: [detachedFile],
+      editorActiveFile: payload.filePath,
+    }
+    const openedTab: TabSnapshot = {
+      id: tabId(),
+      toolId: 'editor',
+      toolName: 'Editor',
+      name: computeDisplayName('Editor', payload.worktreePath, 'editor', tabs),
+      worktreePath: payload.worktreePath,
+      rootSplit: { type: 'leaf', pane: detachedPane },
+      focusedPaneId: detachedPane.id,
+    }
+    tabs.push(openedTab)
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: openedTab.id,
+      openedTab,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, openedTab.id)
+    return result
+  }
+
+  closeEditorFile(sender: WebContents, payload: CloseEditorFilePayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const updatedPane = paneWithoutEditorFile(pane, payload.filePath)
+    if (updatedPane) {
+      tabs[tabIndex] = {
+        ...tab,
+        rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+      }
+      const result = {
+        worktreePath: payload.worktreePath,
+        tabs,
+        activeTabId: activeId ?? tab.id,
+        closedPaneId: payload.paneId,
+      }
+      this.setTabState(sender, payload.worktreePath, tabs, result.activeTabId)
+      return result
+    }
+
+    const removeResult = removePaneSnapshot(tab.rootSplit, payload.paneId)
+    if (!removeResult) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    let nextActiveId = activeId
+    let closedTabId: string | undefined
+    if (!removeResult.tree) {
+      tabs.splice(tabIndex, 1)
+      closedTabId = tab.id
+      if (nextActiveId === tab.id) {
+        nextActiveId = tabs.length > 0 ? tabs[Math.min(tabIndex, tabs.length - 1)].id : null
+      }
+    } else {
+      tabs[tabIndex] = {
+        ...tab,
+        rootSplit: removeResult.tree,
+        focusedPaneId:
+          tab.focusedPaneId === payload.paneId
+            ? firstPaneSnapshot(removeResult.tree).id
+            : tab.focusedPaneId,
+      }
+      nextActiveId = nextActiveId ?? tab.id
+    }
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: nextActiveId,
+      closedTabId,
+      closedPaneId: payload.paneId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, nextActiveId)
+    return result
+  }
+
+  moveEditorFile(sender: WebContents, payload: MoveEditorFilePayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const updatedPane = paneWithMovedEditorFile(pane, payload.filePath, payload.toIndex)
+    if (!updatedPane || updatedPane === pane)
+      return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId ?? tab.id,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, result.activeTabId)
+    return result
+  }
+
+  moveEditorFileBetweenPanes(
+    sender: WebContents,
+    payload: MoveEditorFileBetweenPanesPayload,
+  ): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+
+    if (payload.sourcePaneId === payload.targetPaneId) {
+      return this.moveEditorFile(sender, {
+        worktreePath: payload.worktreePath,
+        paneId: payload.targetPaneId,
+        filePath: payload.filePath,
+        toIndex: payload.toIndex,
+      })
+    }
+
+    const sourceTabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.sourcePaneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
+    const targetTabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some((pane) => pane.id === payload.targetPaneId),
+    )
+    if (sourceTabIndex < 0 || targetTabIndex < 0) {
+      return emptyResult(payload.worktreePath, tabs, activeId)
+    }
+
+    const sourceTab = tabs[sourceTabIndex]
+    const targetTab = tabs[targetTabIndex]
+    const sourcePane = allPaneSnapshots(sourceTab.rootSplit).find(
+      (candidate) => candidate.id === payload.sourcePaneId,
+    )
+    const targetPane = allPaneSnapshots(targetTab.rootSplit).find(
+      (candidate) => candidate.id === payload.targetPaneId,
+    )
+    if (!sourcePane || !targetPane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const sourceFiles =
+      sourcePane.editorFiles ?? (sourcePane.filePath ? [{ filePath: sourcePane.filePath }] : [])
+    const movingFile = sourceFiles.find((file) => file.filePath === payload.filePath)
+    if (!movingFile) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    let nextActiveId = activeId
+    const targetTabId = targetTab.id
+    const updatedSourcePane = paneWithoutEditorFile(sourcePane, payload.filePath)
+    if (!updatedSourcePane) {
+      const removeResult = removePaneSnapshot(sourceTab.rootSplit, payload.sourcePaneId)
+      if (!removeResult) return emptyResult(payload.worktreePath, tabs, activeId)
+
+      if (!removeResult.tree) {
+        tabs.splice(sourceTabIndex, 1)
+        if (nextActiveId === sourceTab.id) nextActiveId = targetTabId
+      } else {
+        tabs[sourceTabIndex] = {
+          ...sourceTab,
+          rootSplit: removeResult.tree,
+          focusedPaneId:
+            sourceTab.focusedPaneId === payload.sourcePaneId
+              ? firstPaneSnapshot(removeResult.tree).id
+              : sourceTab.focusedPaneId,
+        }
+      }
+    } else {
+      tabs[sourceTabIndex] = {
+        ...sourceTab,
+        rootSplit: updatePaneSnapshot(
+          sourceTab.rootSplit,
+          payload.sourcePaneId,
+          () => updatedSourcePane,
+        ),
+      }
+    }
+
+    const currentTargetTabIndex = tabs.findIndex((tab) => tab.id === targetTabId)
+    if (currentTargetTabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const currentTargetTab = tabs[currentTargetTabIndex]
+    const currentTargetPane = allPaneSnapshots(currentTargetTab.rootSplit).find(
+      (candidate) => candidate.id === payload.targetPaneId,
+    )
+    if (!currentTargetPane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[currentTargetTabIndex] = {
+      ...currentTargetTab,
+      rootSplit: updatePaneSnapshot(currentTargetTab.rootSplit, payload.targetPaneId, (pane) =>
+        paneWithInsertedEditorFile(pane, movingFile, payload.toIndex),
+      ),
+      focusedPaneId: payload.targetPaneId,
+    }
+    nextActiveId = targetTabId
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: nextActiveId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, nextActiveId)
+    return result
+  }
+
+  setActiveEditorFile(sender: WebContents, payload: SetActiveEditorFilePayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const updatedPane = paneWithActiveEditorFile(pane, payload.filePath)
+    if (!updatedPane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  updateEditorFileState(
+    sender: WebContents,
+    payload: UpdateEditorFileStatePayload,
+  ): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const patch = editorFileStatePatch(payload.patch)
+    const updatedPane = paneWithUpdatedEditorFileState(pane, payload.filePath, patch)
+    if (!updatedPane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  async loadEditorFile(
+    sender: WebContents,
+    payload: LoadEditorFilePayload,
+  ): Promise<EditorFileLoadResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
     if (tabIndex < 0) {
-      return emptyResult(payload.worktreePath, tabs, payload.activeTabId ?? null)
+      return { ok: false, tag: 'ReadFailed', message: 'Editor file is not open' }
     }
 
     const tab = tabs[tabIndex]
     const pane = allPaneSnapshots(tab.rootSplit).find(
       (candidate) => candidate.id === payload.paneId,
     )
-    if (!pane) return emptyResult(payload.worktreePath, tabs, payload.activeTabId ?? null)
+    if (!pane) return { ok: false, tag: 'ReadFailed', message: 'Editor pane is not open' }
+
+    const loadResult = await this.deps.loadEditorFile(
+      sender,
+      payload.filePath,
+      payload.options?.maxBytes,
+    )
+    if (!loadResult.ok) return loadResult
+
+    const patch: Partial<EditorFileSnapshot> = loadResult.binary
+      ? {
+          dirty: false,
+          originalContent: undefined,
+          currentContent: undefined,
+          fileMtimeMs: loadResult.mtimeMs,
+          fileLineEnding: undefined,
+          externalChangeDetected: false,
+        }
+      : {
+          dirty: false,
+          originalContent: loadResult.content,
+          currentContent: loadResult.content,
+          fileMtimeMs: loadResult.mtimeMs,
+          fileLineEnding: loadResult.fileLineEnding,
+          externalChangeDetected: false,
+        }
+
+    const updatedPane = paneWithUpdatedEditorFileState(pane, payload.filePath, patch)
+    if (!updatedPane) {
+      return { ok: false, tag: 'ReadFailed', message: 'Editor file is not open' }
+    }
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return { ...loadResult, result }
+  }
+
+  async saveEditorFile(
+    sender: WebContents,
+    payload: SaveEditorFilePayload,
+  ): Promise<EditorFileSaveResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some(
+        (pane) => pane.id === payload.paneId && paneHasEditorFile(pane, payload.filePath),
+      ),
+    )
+    if (tabIndex < 0) {
+      return { ok: false, tag: 'WriteFailed', message: 'Editor file is not open' }
+    }
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane) return { ok: false, tag: 'WriteFailed', message: 'Editor pane is not open' }
+
+    const content = payload.options.content
+    const normalized =
+      payload.options.fileLineEnding === 'CRLF' ? content.replace(/\r?\n/g, '\r\n') : content
+    const writeResult = await this.deps.writeEditorFile(
+      sender,
+      payload.filePath,
+      normalized,
+      payload.options.expectedMtimeMs,
+    )
+    if (!writeResult.ok) return writeResult
+
+    const updatedPane = paneWithUpdatedEditorFileState(pane, payload.filePath, {
+      dirty: false,
+      originalContent: content,
+      currentContent: content,
+      fileMtimeMs: writeResult.mtimeMs,
+      externalChangeDetected: false,
+    })
+    if (!updatedPane) {
+      return { ok: false, tag: 'WriteFailed', message: 'Editor file is not open' }
+    }
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return { ok: true, mtimeMs: writeResult.mtimeMs, size: writeResult.size, result }
+  }
+
+  async prepareCloseEditorFile(
+    sender: WebContents,
+    payload: PrepareCloseEditorFilePayload,
+  ): Promise<TabClosePreflightResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const file = this.editorFileSnapshot(tabs, payload.paneId, payload.filePath)
+    if (!file?.dirty) return { ok: true }
+
+    const choice = await this.deps.confirmUnsavedChanges(sender, [payload.filePath])
+    if (choice === 'cancel') return { ok: false, reason: 'cancelled' }
+    if (choice === 'discard') return { ok: true }
+
+    const saveResult = await this.saveEditorFile(sender, {
+      worktreePath: payload.worktreePath,
+      paneId: payload.paneId,
+      filePath: payload.filePath,
+      options: {
+        content: file.currentContent ?? '',
+        fileLineEnding: file.fileLineEnding,
+        expectedMtimeMs: file.fileMtimeMs,
+      },
+    })
+    if (!saveResult.ok) return { ok: false, reason: 'save-failed', failedCount: 1 }
+
+    return { ok: true }
+  }
+
+  updatePaneTitle(sender: WebContents, payload: UpdatePaneTitlePayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some((pane) => pane.sessionId === payload.sessionId),
+    )
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.sessionId === payload.sessionId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, pane.id, (previous) => ({
+        ...previous,
+        title: payload.title,
+      })),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  updatePaneUrl(sender: WebContents, payload: UpdatePaneUrlPayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some((pane) => pane.sessionId === payload.sessionId),
+    )
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.sessionId === payload.sessionId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, pane.id, (previous) => ({
+        ...previous,
+        url: payload.url,
+      })),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  updateTmuxSessionName(
+    sender: WebContents,
+    payload: UpdateTmuxSessionNamePayload,
+  ): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some((pane) => pane.tmuxSessionName === payload.oldName),
+    )
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.tmuxSessionName === payload.oldName,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, pane.id, (previous) => ({
+        ...previous,
+        tmuxSessionName: payload.newName,
+      })),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  async handlePtyExit(
+    sender: WebContents,
+    payload: HandlePtyExitPayload,
+  ): Promise<TabCommandResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) =>
+      allPaneSnapshots(tab.rootSplit).some((pane) => pane.sessionId === payload.sessionId),
+    )
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.sessionId === payload.sessionId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tmuxName = payload.tmuxSessionName || pane.tmuxSessionName
+    const detached = tmuxName
+      ? await this.deps.toolSessions.hasTmuxSession(tmuxName).catch(() => false)
+      : false
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, pane.id, (previous) => ({
+        ...previous,
+        isRunning: false,
+        exitCode: payload.exitCode,
+        detached,
+        tmuxSessionName: tmuxName,
+      })),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  async killTmuxPane(sender: WebContents, payload: KillTmuxPanePayload): Promise<TabCommandResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane?.tmuxSessionName) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    await this.deps.toolSessions.killTmuxSession(pane.tmuxSessionName).catch(() => {})
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, (previous) => ({
+        ...previous,
+        isRunning: false,
+        detached: false,
+        tmuxSessionName: undefined,
+      })),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  async reattachTmuxPane(
+    sender: WebContents,
+    payload: ReattachTmuxPanePayload,
+  ): Promise<TabCommandResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane?.tmuxSessionName) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const exists = await this.deps.toolSessions
+      .hasTmuxSession(pane.tmuxSessionName)
+      .catch(() => false)
+    const updatedPane = exists
+      ? {
+          ...pane,
+          ...(await this.deps.toolSessions.attachTmux(sender, {
+            tmuxSessionName: pane.tmuxSessionName,
+          })),
+          isRunning: true,
+          exitCode: null,
+          detached: false,
+        }
+      : await this.restartPaneSnapshot(sender, payload.worktreePath, pane, {
+          workspaceName: payload.options?.workspaceName,
+          branch: payload.options?.branch,
+        })
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => updatedPane),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+      restartedPane: updatedPane,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  toggleFocusedInspector(
+    sender: WebContents,
+    payload: ToggleFocusedInspectorPayload,
+  ): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === tab.focusedPaneId,
+    )
+    if (!pane || !AI_TOOL_IDS.has(pane.toolId)) {
+      return emptyResult(payload.worktreePath, tabs, activeId)
+    }
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: updatePaneSnapshot(tab.rootSplit, pane.id, (previous) => ({
+        ...previous,
+        inspectorOpen: previous.inspectorOpen !== true,
+      })),
+    }
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  async restartPane(sender: WebContents, payload: RestartPanePayload): Promise<TabCommandResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    if (tabIndex < 0) {
+      return emptyResult(payload.worktreePath, tabs, this.getCommandActiveTabId(sender.id, payload))
+    }
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane) {
+      return emptyResult(payload.worktreePath, tabs, this.getCommandActiveTabId(sender.id, payload))
+    }
 
     const restartedPane = await this.restartPaneSnapshot(sender, payload.worktreePath, pane, {
       workspaceName: payload.options?.workspaceName,
@@ -508,62 +2264,967 @@ export class TabCommandService {
       rootSplit: updatePaneSnapshot(tab.rootSplit, payload.paneId, () => restartedPane),
     }
 
-    return {
+    const activeId = this.getCommandActiveTabId(sender.id, payload) ?? tab.id
+    const result = {
       worktreePath: payload.worktreePath,
       tabs,
-      activeTabId: payload.activeTabId ?? tab.id,
+      activeTabId: activeId,
       restartedPane,
     }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
   }
 
   async closeTab(sender: WebContents, payload: CloseTabPayload): Promise<TabCommandResult> {
+    this.trackSender(sender)
     this.assertSenderOwnsWorktree(sender, payload.worktreePath)
-    const tabs = [...validateTabSnapshots(payload.tabs)]
+    const tabs = this.getCommandTabs(sender.id, payload)
     const idx = tabs.findIndex((tab) => tab.id === payload.tabId)
-    if (idx < 0) return emptyResult(payload.worktreePath, tabs, payload.activeTabId ?? null)
+    if (idx < 0) {
+      return emptyResult(payload.worktreePath, tabs, this.getCommandActiveTabId(sender.id, payload))
+    }
 
     const [tab] = tabs.splice(idx, 1)
+    this.pushClosedTab(sender.id, payload.worktreePath, tab)
     await this.cleanupPanes(sender, allPaneSnapshots(tab.rootSplit))
 
-    let nextActiveId = payload.activeTabId ?? null
+    let nextActiveId = this.getCommandActiveTabId(sender.id, payload)
     if (nextActiveId === payload.tabId) {
       nextActiveId = tabs.length > 0 ? tabs[Math.min(idx, tabs.length - 1)].id : null
     }
 
-    return {
+    const result = {
       worktreePath: payload.worktreePath,
       tabs,
       activeTabId: nextActiveId,
       closedTabId: payload.tabId,
     }
+    this.setTabState(sender, payload.worktreePath, tabs, nextActiveId)
+    return result
+  }
+
+  async prepareCloseTab(
+    sender: WebContents,
+    payload: PrepareCloseTabPayload,
+  ): Promise<TabClosePreflightResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const tab = tabs.find((candidate) => candidate.id === payload.tabId)
+    if (!tab || tab.suspended) return { ok: true }
+
+    const dirtyFiles = this.dirtyEditorFiles(tab)
+    if (dirtyFiles.length === 0) return { ok: true }
+
+    const choice = await this.deps.confirmUnsavedChanges(
+      sender,
+      dirtyFiles.map((file) => file.filePath),
+    )
+    if (choice === 'cancel') return { ok: false, reason: 'cancelled' }
+    if (choice === 'discard') return { ok: true }
+
+    let failedCount = 0
+    for (const file of dirtyFiles) {
+      try {
+        const result = await this.saveEditorFile(sender, {
+          worktreePath: payload.worktreePath,
+          paneId: file.paneId,
+          filePath: file.filePath,
+          options: {
+            content: file.currentContent ?? '',
+            fileLineEnding: file.fileLineEnding,
+            expectedMtimeMs: file.fileMtimeMs,
+          },
+        })
+        if (!result.ok) failedCount += 1
+      } catch {
+        failedCount += 1
+      }
+    }
+    if (failedCount > 0) return { ok: false, reason: 'save-failed', failedCount }
+
+    return { ok: true }
+  }
+
+  async getCloseWarning(
+    sender: WebContents,
+    payload: GetCloseWarningPayload,
+  ): Promise<CloseWarningResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const target = this.validateCloseWarningTarget(payload.target)
+    const panes = this.closeWarningPanes(tabs, target)
+    return { description: await this.getActiveProcessDescription(panes) }
+  }
+
+  async closePane(sender: WebContents, payload: ClosePanePayload): Promise<TabCommandResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const removeResult = removePaneSnapshot(tab.rootSplit, payload.paneId)
+    if (!removeResult) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    await this.cleanupPanes(sender, [removeResult.removed])
+
+    let nextActiveId = activeId
+    let closedTabId: string | undefined
+    if (!removeResult.tree) {
+      this.pushClosedTab(sender.id, payload.worktreePath, tab)
+      tabs.splice(tabIndex, 1)
+      closedTabId = payload.tabId
+      if (nextActiveId === payload.tabId) {
+        nextActiveId = tabs.length > 0 ? tabs[Math.min(tabIndex, tabs.length - 1)].id : null
+      }
+    } else {
+      const focusedPane = firstPaneSnapshot(removeResult.tree)
+      tabs[tabIndex] = reconcileTabSnapshotIdentity(
+        {
+          ...tab,
+          rootSplit: removeResult.tree,
+          focusedPaneId: focusedPane.id,
+        },
+        tabs,
+      )
+      nextActiveId = nextActiveId ?? tab.id
+    }
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: nextActiveId,
+      closedTabId,
+      closedPaneId: payload.paneId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, nextActiveId)
+    return result
+  }
+
+  async closeAllForWorktree(
+    sender: WebContents,
+    payload: CloseAllForWorktreePayload,
+  ): Promise<TabCommandResult> {
+    this.trackSender(sender)
+    const workspaceId = this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+
+    await this.cleanupPanes(
+      sender,
+      tabs.flatMap((tab) => allPaneSnapshots(tab.rootSplit)),
+    )
+
+    try {
+      this.deps.layoutStore.delete(workspaceId, payload.worktreePath)
+    } catch (error) {
+      if (!this.deps.layoutStore.isClosed()) {
+        console.error('Failed to delete layout:', error)
+        throw error
+      }
+    }
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs: [],
+      activeTabId: null,
+    }
+    this.setTabState(sender, payload.worktreePath, result.tabs, result.activeTabId)
+    return result
+  }
+
+  async reopenClosedTab(
+    sender: WebContents,
+    payload: ReopenClosedTabPayload,
+  ): Promise<TabCommandResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const entry = this.popClosedTab(sender.id, payload.worktreePath)
+    if (!entry) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    if (entry.toolId === 'diff') {
+      return this.openDiffTab(sender, payload)
+    }
+
+    const pane = await this.createPane(sender, entry.toolId, payload.worktreePath, {
+      workspaceName: payload.options?.workspaceName,
+      branch: payload.options?.branch,
+      profileId: entry.profileId,
+    })
+    const openedTab: TabSnapshot = {
+      id: tabId(),
+      toolId: pane.toolId,
+      toolName: pane.toolName,
+      name: computeDisplayName(
+        pane.toolName,
+        payload.worktreePath,
+        pane.toolId,
+        tabs,
+        pane.profileName,
+      ),
+      worktreePath: payload.worktreePath,
+      rootSplit: { type: 'leaf', pane },
+      focusedPaneId: pane.id,
+    }
+    tabs.push(openedTab)
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: openedTab.id,
+      openedTab,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, openedTab.id)
+    return result
+  }
+
+  setActiveTab(sender: WebContents, payload: SetActiveTabPayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const currentActiveId = this.getCommandActiveTabId(sender.id, payload)
+    const nextActiveId = tabs.some((tab) => tab.id === payload.tabId)
+      ? payload.tabId
+      : currentActiveId
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: nextActiveId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, nextActiveId)
+    return result
+  }
+
+  moveTab(sender: WebContents, payload: MoveTabPayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    if (
+      payload.fromIndex === payload.toIndex ||
+      payload.fromIndex < 0 ||
+      payload.fromIndex >= tabs.length ||
+      payload.toIndex < 0 ||
+      payload.toIndex >= tabs.length
+    ) {
+      return emptyResult(payload.worktreePath, tabs, activeId)
+    }
+
+    const [tab] = tabs.splice(payload.fromIndex, 1)
+    tabs.splice(payload.toIndex, 0, tab)
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  moveTabToSplit(sender: WebContents, payload: MoveTabToSplitPayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const sourceIndex = tabs.findIndex((tab) => tab.id === payload.sourceTabId)
+    const targetIndex = tabs.findIndex((tab) => tab.id === payload.targetTabId)
+    if (sourceIndex < 0 || targetIndex < 0 || payload.sourceTabId === payload.targetTabId) {
+      return emptyResult(payload.worktreePath, tabs, activeId)
+    }
+
+    const sourceTab = tabs[sourceIndex]
+    const targetTab = tabs[targetIndex]
+    const nextRoot = graftSplitSnapshot(
+      targetTab.rootSplit,
+      payload.targetPaneId,
+      payload.direction,
+      sourceTab.rootSplit,
+      payload.position,
+    )
+    if (!nextRoot) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[targetIndex] = {
+      ...targetTab,
+      rootSplit: nextRoot,
+      focusedPaneId: firstPaneSnapshot(sourceTab.rootSplit).id,
+    }
+    tabs.splice(sourceIndex, 1)
+
+    const nextActiveId = activeId === payload.sourceTabId ? payload.targetTabId : activeId
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: nextActiveId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, nextActiveId)
+    return result
+  }
+
+  movePaneToTarget(sender: WebContents, payload: MovePaneToTargetPayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const sourceIndex = tabs.findIndex((tab) => tab.id === payload.sourceTabId)
+    const targetIndex = tabs.findIndex((tab) => tab.id === payload.targetTabId)
+    if (sourceIndex < 0 || targetIndex < 0) {
+      return emptyResult(payload.worktreePath, tabs, activeId)
+    }
+
+    const sourceTab = tabs[sourceIndex]
+    const targetTab = tabs[targetIndex]
+    const removeResult = removePaneSnapshot(sourceTab.rootSplit, payload.sourcePaneId)
+    if (!removeResult) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const leaf: SplitSnapshot = { type: 'leaf', pane: removeResult.removed }
+
+    if (payload.sourceTabId === payload.targetTabId) {
+      if (!removeResult.tree) return emptyResult(payload.worktreePath, tabs, activeId)
+
+      const nextRoot = graftSplitSnapshot(
+        removeResult.tree,
+        payload.targetPaneId,
+        payload.direction,
+        leaf,
+        payload.position,
+      )
+      if (!nextRoot) return emptyResult(payload.worktreePath, tabs, activeId)
+
+      tabs[sourceIndex] = reconcileTabSnapshotIdentity(
+        {
+          ...sourceTab,
+          rootSplit: nextRoot,
+          focusedPaneId: payload.sourcePaneId,
+        },
+        tabs,
+      )
+
+      const result = {
+        worktreePath: payload.worktreePath,
+        tabs,
+        activeTabId: activeId ?? sourceTab.id,
+      }
+      this.setTabState(sender, payload.worktreePath, tabs, result.activeTabId)
+      return result
+    }
+
+    const nextTargetRoot = graftSplitSnapshot(
+      targetTab.rootSplit,
+      payload.targetPaneId,
+      payload.direction,
+      leaf,
+      payload.position,
+    )
+    if (!nextTargetRoot) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const nextTabs = [...tabs]
+    if (removeResult.tree) {
+      nextTabs[sourceIndex] = reconcileTabSnapshotIdentity(
+        {
+          ...sourceTab,
+          rootSplit: removeResult.tree,
+          focusedPaneId: firstPaneSnapshot(removeResult.tree).id,
+        },
+        nextTabs,
+      )
+    } else {
+      nextTabs.splice(sourceIndex, 1)
+    }
+
+    const nextTargetIndex = nextTabs.findIndex((tab) => tab.id === payload.targetTabId)
+    if (nextTargetIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    nextTabs[nextTargetIndex] = reconcileTabSnapshotIdentity(
+      {
+        ...targetTab,
+        rootSplit: nextTargetRoot,
+        focusedPaneId: payload.sourcePaneId,
+      },
+      nextTabs,
+    )
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs: nextTabs,
+      activeTabId: payload.targetTabId,
+    }
+    this.setTabState(sender, payload.worktreePath, nextTabs, result.activeTabId)
+    return result
+  }
+
+  detachPaneToTab(sender: WebContents, payload: DetachPaneToTabPayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const sourceIndex = tabs.findIndex((tab) => tab.id === payload.sourceTabId)
+    if (sourceIndex < 0) {
+      return emptyResult(payload.worktreePath, tabs, this.getCommandActiveTabId(sender.id, payload))
+    }
+
+    const sourceTab = tabs[sourceIndex]
+    if (sourceTab.rootSplit.type === 'leaf') {
+      return emptyResult(payload.worktreePath, tabs, this.getCommandActiveTabId(sender.id, payload))
+    }
+
+    const removeResult = removePaneSnapshot(sourceTab.rootSplit, payload.sourcePaneId)
+    if (!removeResult?.tree) {
+      return emptyResult(payload.worktreePath, tabs, this.getCommandActiveTabId(sender.id, payload))
+    }
+
+    tabs[sourceIndex] = reconcileTabSnapshotIdentity(
+      {
+        ...sourceTab,
+        rootSplit: removeResult.tree,
+        focusedPaneId: firstPaneSnapshot(removeResult.tree).id,
+      },
+      tabs,
+    )
+
+    const removed = removeResult.removed
+    const openedTab: TabSnapshot = {
+      id: tabId(),
+      toolId: removed.toolId,
+      toolName: removed.toolName,
+      name: computeDisplayName(
+        removed.toolName,
+        payload.worktreePath,
+        removed.toolId,
+        tabs,
+        removed.profileName,
+      ),
+      worktreePath: payload.worktreePath,
+      rootSplit: { type: 'leaf', pane: removed },
+      focusedPaneId: removed.id,
+    }
+    tabs.push(openedTab)
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: openedTab.id,
+      openedTab,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, openedTab.id)
+    return result
   }
 
   async spawnPane(sender: WebContents, payload: SpawnPanePayload): Promise<PaneSnapshot> {
+    this.trackSender(sender)
     this.assertSenderOwnsWorktree(sender, payload.worktreePath)
     return this.createPane(sender, payload.toolId, payload.worktreePath, payload.options)
   }
 
-  saveLayout(sender: WebContents, payload: SaveLayoutPayload): void {
+  async splitPane(sender: WebContents, payload: SplitPanePayload): Promise<TabCommandResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    if (NO_SPLIT_TOOLS.has(tab.toolId)) {
+      return emptyResult(payload.worktreePath, tabs, activeId)
+    }
+    const target = allPaneSnapshots(tab.rootSplit).find((pane) => pane.id === payload.paneId)
+    if (!target || splitDepth(tab.rootSplit) >= MAX_SPLIT_DEPTH) {
+      return emptyResult(payload.worktreePath, tabs, activeId)
+    }
+
+    const pane = await this.createPane(sender, 'shell', payload.worktreePath)
+    const nextRoot = splitPaneSnapshot(tab.rootSplit, payload.paneId, payload.direction, pane)
+    if (!nextRoot) {
+      await this.deps.toolSessions.killPty(pane.sessionId)
+      return emptyResult(payload.worktreePath, tabs, activeId)
+    }
+
+    tabs[tabIndex] = {
+      ...tab,
+      rootSplit: nextRoot,
+      focusedPaneId: pane.id,
+    }
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId ?? tab.id,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, result.activeTabId)
+    return result
+  }
+
+  focusPane(sender: WebContents, payload: FocusPanePayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const pane = allPaneSnapshots(tab.rootSplit).find(
+      (candidate) => candidate.id === payload.paneId,
+    )
+    if (!pane) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = { ...tab, focusedPaneId: payload.paneId }
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId ?? tab.id,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, result.activeTabId)
+    return result
+  }
+
+  navigatePaneFocus(sender: WebContents, payload: NavigatePaneFocusPayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    const targetPaneId = navigatePaneSnapshot(tab.rootSplit, tab.focusedPaneId, payload.direction)
+    if (!targetPaneId) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = { ...tab, focusedPaneId: targetPaneId }
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId ?? tab.id,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, result.activeTabId)
+    return result
+  }
+
+  updateSplitRatio(sender: WebContents, payload: UpdateSplitRatioPayload): TabCommandResult {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    if (tabIndex < 0 || !Number.isFinite(payload.ratio)) {
+      return emptyResult(payload.worktreePath, tabs, activeId)
+    }
+
+    const tab = tabs[tabIndex]
+    const updated = updateSplitRatioSnapshot(tab.rootSplit, payload.splitId, payload.ratio)
+    if (!updated.changed) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    tabs[tabIndex] = { ...tab, rootSplit: updated.split }
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId ?? tab.id,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, result.activeTabId)
+    return result
+  }
+
+  async restoreLayout(
+    sender: WebContents,
+    payload: RestoreLayoutPayload,
+  ): Promise<TabCommandResult & { restored: boolean }> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+
+    let layout: SerializedLayout
+    try {
+      const parsed: unknown = JSON.parse(payload.layoutJson)
+      validateSerializedLayout(parsed)
+      layout = parsed
+    } catch {
+      return {
+        ...emptyResult(
+          payload.worktreePath,
+          this.getCommandTabs(sender.id, payload),
+          this.getCommandActiveTabId(sender.id, payload),
+        ),
+        restored: false,
+      }
+    }
+
+    if (layout.tabs.length === 0) {
+      return {
+        ...emptyResult(
+          payload.worktreePath,
+          this.getCommandTabs(sender.id, payload),
+          this.getCommandActiveTabId(sender.id, payload),
+        ),
+        restored: false,
+      }
+    }
+
+    const activeIndex = Math.min(Math.max(0, layout.activeTabIndex), layout.tabs.length - 1)
+    const restoredTabs: TabSnapshot[] = []
+
+    for (const [index, serializedTab] of layout.tabs.entries()) {
+      if (index !== activeIndex) {
+        restoredTabs.push(
+          this.createSuspendedTabSnapshot(payload.worktreePath, serializedTab, restoredTabs),
+        )
+        continue
+      }
+
+      try {
+        const rootSplit = await this.restoreSerializedSplitSnapshot(
+          sender,
+          payload.worktreePath,
+          serializedTab.rootSplit,
+          {
+            workspaceName: payload.options?.workspaceName,
+            branch: payload.options?.branch,
+          },
+        )
+        const focusedPane = firstPaneSnapshot(rootSplit)
+        restoredTabs.push({
+          id: tabId(),
+          toolId: serializedTab.toolId,
+          toolName: serializedTab.toolName,
+          name: computeDisplayName(
+            serializedTab.toolName,
+            payload.worktreePath,
+            serializedTab.toolId,
+            restoredTabs,
+          ),
+          worktreePath: payload.worktreePath,
+          rootSplit,
+          focusedPaneId: focusedPane.id,
+        })
+      } catch {
+        restoredTabs.push(
+          this.createSuspendedTabSnapshot(payload.worktreePath, serializedTab, restoredTabs),
+        )
+      }
+    }
+
+    const activeTab = restoredTabs.find((tab) => !tab.suspended) ?? restoredTabs[0]
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs: restoredTabs,
+      activeTabId: activeTab.id,
+      restored: true,
+    }
+    this.setTabState(sender, payload.worktreePath, restoredTabs, activeTab.id)
+    return result
+  }
+
+  async resumeSuspendedTab(
+    sender: WebContents,
+    payload: ResumeSuspendedTabPayload,
+  ): Promise<TabCommandResult> {
+    this.trackSender(sender)
+    this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.getCommandTabs(sender.id, payload)
+    const activeId = this.getCommandActiveTabId(sender.id, payload)
+    const tabIndex = tabs.findIndex((tab) => tab.id === payload.tabId)
+    if (tabIndex < 0) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const tab = tabs[tabIndex]
+    if (!tab.suspended) return emptyResult(payload.worktreePath, tabs, activeId)
+
+    const rootSplit = await this.restoreSerializedSplitSnapshot(
+      sender,
+      payload.worktreePath,
+      tab.suspended,
+      {
+        workspaceName: payload.options?.workspaceName,
+        branch: payload.options?.branch,
+      },
+    )
+    const focusedPane = firstPaneSnapshot(rootSplit)
+    const resumedTab = { ...tab }
+    delete resumedTab.suspended
+    tabs[tabIndex] = {
+      ...resumedTab,
+      rootSplit,
+      focusedPaneId: focusedPane.id,
+    }
+
+    const result = {
+      worktreePath: payload.worktreePath,
+      tabs,
+      activeTabId: activeId,
+    }
+    this.setTabState(sender, payload.worktreePath, tabs, activeId)
+    return result
+  }
+
+  async killAll(sender: WebContents): Promise<TabStateSnapshot> {
+    this.trackSender(sender)
+    const tabsByWorktree = this.getAllCommandTabsByWorktree(sender.id)
+
+    await this.cleanupPanes(
+      sender,
+      [...tabsByWorktree.values()].flatMap((tabs) =>
+        tabs.flatMap((tab) => allPaneSnapshots(tab.rootSplit)),
+      ),
+    )
+
+    this.tabsByWorktreeByWindow.delete(sender.id)
+    this.activeTabIdByWorktreeByWindow.delete(sender.id)
+    this.emitAppStateChanged(sender)
+    return this.getSnapshot(sender.id)
+  }
+
+  focusSession(sender: WebContents, payload: FocusSessionPayload): TabCommandResult | null {
+    this.trackSender(sender)
+    const tabsByWorktree = this.getAllCommandTabsByWorktree(sender.id)
+
+    for (const [worktreePath, tabs] of tabsByWorktree) {
+      const tabIndex = tabs.findIndex((tab) =>
+        allPaneSnapshots(tab.rootSplit).some((pane) => pane.sessionId === payload.sessionId),
+      )
+      if (tabIndex < 0) continue
+
+      const tab = tabs[tabIndex]
+      const pane = allPaneSnapshots(tab.rootSplit).find(
+        (candidate) => candidate.sessionId === payload.sessionId,
+      )
+      if (!pane) continue
+
+      tabs[tabIndex] = {
+        ...tab,
+        focusedPaneId: pane.id,
+      }
+      const result = {
+        worktreePath,
+        tabs,
+        activeTabId: tab.id,
+      }
+      this.setTabState(sender, worktreePath, tabs, tab.id)
+      return result
+    }
+
+    return null
+  }
+
+  getSnapshot(webContentsId: number): TabStateSnapshot {
+    const tabsByWorktree: Record<string, TabSnapshot[]> = {}
+    const activeTabIdByWorktree: Record<string, string | null> = {}
+
+    const tabs = this.tabsByWorktreeByWindow.get(webContentsId)
+    for (const [worktreePath, snapshots] of tabs?.entries() ?? []) {
+      tabsByWorktree[worktreePath] = snapshots
+    }
+
+    const activeTabs = this.activeTabIdByWorktreeByWindow.get(webContentsId)
+    for (const [worktreePath, tabId] of activeTabs?.entries() ?? []) {
+      activeTabIdByWorktree[worktreePath] = tabId
+    }
+
+    return { tabsByWorktree, activeTabIdByWorktree }
+  }
+
+  saveCurrentLayout(sender: WebContents, payload: SaveCurrentLayoutPayload): void {
     const workspaceId = this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+    const tabs = this.tabsByWorktreeByWindow.get(sender.id)?.get(payload.worktreePath) ?? []
+    const activeId =
+      this.activeTabIdByWorktreeByWindow.get(sender.id)?.get(payload.worktreePath) ?? null
+    const layout = this.createSerializedLayout(tabs, activeId)
 
     try {
-      this.deps.layoutStore.save(workspaceId, payload.worktreePath, payload.layoutJson)
+      if (!layout) {
+        this.deps.layoutStore.delete(workspaceId, payload.worktreePath)
+        return
+      }
+      this.deps.layoutStore.save(workspaceId, payload.worktreePath, JSON.stringify(layout))
     } catch (error) {
       if (this.deps.layoutStore.isClosed()) return
       console.error('Failed to save layout:', error)
     }
   }
 
-  deleteLayout(sender: WebContents, payload: DeleteLayoutPayload): void {
-    const workspaceId = this.assertSenderOwnsWorktree(sender, payload.worktreePath)
+  private getCommandTabs(webContentsId: number, payload: TabCommandPayloadBase): TabSnapshot[] {
+    return [...(this.tabsByWorktreeByWindow.get(webContentsId)?.get(payload.worktreePath) ?? [])]
+  }
 
-    try {
-      this.deps.layoutStore.delete(workspaceId, payload.worktreePath)
-    } catch (error) {
-      if (this.deps.layoutStore.isClosed()) return
-      console.error('Failed to delete layout:', error)
-      throw error
+  private getCommandActiveTabId(
+    webContentsId: number,
+    payload: TabCommandPayloadBase,
+  ): string | null {
+    const stored = this.activeTabIdByWorktreeByWindow.get(webContentsId)?.get(payload.worktreePath)
+    return stored ?? null
+  }
+
+  private getAllCommandTabsByWorktree(webContentsId: number): Map<string, TabSnapshot[]> {
+    const tabsByWorktree = new Map<string, TabSnapshot[]>()
+
+    for (const [worktreePath, tabs] of this.tabsByWorktreeByWindow.get(webContentsId)?.entries() ??
+      []) {
+      tabsByWorktree.set(worktreePath, tabs)
     }
+
+    return tabsByWorktree
+  }
+
+  private pushClosedTab(webContentsId: number, worktreePath: string, tab: TabSnapshot): void {
+    let closedTabsByWorktree = this.closedTabsByWorktreeByWindow.get(webContentsId)
+    if (!closedTabsByWorktree) {
+      closedTabsByWorktree = new Map()
+      this.closedTabsByWorktreeByWindow.set(webContentsId, closedTabsByWorktree)
+    }
+
+    let stack = closedTabsByWorktree.get(worktreePath)
+    if (!stack) {
+      stack = []
+      closedTabsByWorktree.set(worktreePath, stack)
+    }
+
+    stack.push({
+      toolId: tab.toolId,
+      toolName: tab.toolName,
+      profileId: this.tabProfileId(tab),
+    })
+    if (stack.length > MAX_CLOSED_TABS) stack.shift()
+  }
+
+  private popClosedTab(webContentsId: number, worktreePath: string): ClosedTabEntry | undefined {
+    return this.closedTabsByWorktreeByWindow.get(webContentsId)?.get(worktreePath)?.pop()
+  }
+
+  private tabProfileId(tab: TabSnapshot): string | undefined {
+    if (tab.rootSplit.type === 'leaf') return tab.rootSplit.pane.profileId
+    const focusedPane = allPaneSnapshots(tab.rootSplit).find(
+      (pane) => pane.id === tab.focusedPaneId,
+    )
+    return focusedPane?.profileId
+  }
+
+  private dirtyEditorFiles(tab: TabSnapshot): DirtyEditorFile[] {
+    const dirtyFiles: DirtyEditorFile[] = []
+    for (const pane of allPaneSnapshots(tab.rootSplit)) {
+      if (pane.paneType !== 'editor') continue
+      for (const file of pane.editorFiles ?? []) {
+        if (file.dirty === true) {
+          dirtyFiles.push({
+            paneId: pane.id,
+            filePath: file.filePath,
+            currentContent: file.currentContent,
+            fileLineEnding: file.fileLineEnding,
+            fileMtimeMs: file.fileMtimeMs,
+          })
+        }
+      }
+    }
+    return dirtyFiles
+  }
+
+  private editorFileSnapshot(
+    tabs: TabSnapshot[],
+    paneId: string,
+    filePath: string,
+  ): EditorFileSnapshot | null {
+    for (const tab of tabs) {
+      const pane = allPaneSnapshots(tab.rootSplit).find((candidate) => candidate.id === paneId)
+      const file = pane?.editorFiles?.find((candidate) => candidate.filePath === filePath)
+      if (file) return file
+    }
+    return null
+  }
+
+  private validateCloseWarningTarget(target: unknown): CloseWarningTarget {
+    if (!isRecord(target) || typeof target.tabId !== 'string') {
+      throw new Error('Invalid close warning target')
+    }
+    if (target.kind === 'tab') {
+      return { kind: 'tab', tabId: target.tabId }
+    }
+    if (target.kind === 'pane' && typeof target.paneId === 'string') {
+      return { kind: 'pane', tabId: target.tabId, paneId: target.paneId }
+    }
+    throw new Error('Invalid close warning target')
+  }
+
+  private closeWarningPanes(tabs: TabSnapshot[], target: CloseWarningTarget): PaneSnapshot[] {
+    const tab = tabs.find((candidate) => candidate.id === target.tabId)
+    if (!tab || tab.suspended) return []
+    if (target.kind === 'tab') return allPaneSnapshots(tab.rootSplit)
+
+    const pane = allPaneSnapshots(tab.rootSplit).find((candidate) => candidate.id === target.paneId)
+    return pane ? [pane] : []
+  }
+
+  private async getActiveProcessDescription(panes: PaneSnapshot[]): Promise<string | null> {
+    let busyAgentSessions = 0
+    let activeShell = 0
+
+    await Promise.all(
+      panes.map(async (pane) => {
+        if (!pane.isRunning) return
+        if (this.deps.toolSessions.isAgentTool(pane.toolId)) {
+          if (this.deps.toolSessions.isAgentBusy(pane.sessionId)) busyAgentSessions++
+          return
+        }
+        try {
+          if (await this.deps.toolSessions.hasChildProcess(pane.sessionId)) activeShell++
+        } catch {
+          // PTY may already be gone.
+        }
+      }),
+    )
+
+    if (busyAgentSessions === 0 && activeShell === 0) return null
+
+    const parts: string[] = []
+    if (busyAgentSessions > 0) {
+      parts.push(`${busyAgentSessions} active agent session${busyAgentSessions > 1 ? 's' : ''}`)
+    }
+    if (activeShell > 0) {
+      parts.push(`${activeShell} running process${activeShell > 1 ? 'es' : ''}`)
+    }
+    return parts.join(' and ')
+  }
+
+  private setTabState(
+    sender: WebContents,
+    worktreePath: string,
+    tabs: TabSnapshot[],
+    activeTabId: string | null,
+  ): void {
+    let tabsByWorktree = this.tabsByWorktreeByWindow.get(sender.id)
+    if (!tabsByWorktree) {
+      tabsByWorktree = new Map()
+      this.tabsByWorktreeByWindow.set(sender.id, tabsByWorktree)
+    }
+    tabsByWorktree.set(worktreePath, tabs)
+
+    let activeTabs = this.activeTabIdByWorktreeByWindow.get(sender.id)
+    if (!activeTabs) {
+      activeTabs = new Map()
+      this.activeTabIdByWorktreeByWindow.set(sender.id, activeTabs)
+    }
+    activeTabs.set(worktreePath, activeTabId)
+
+    this.emitAppStateChanged(sender)
+  }
+
+  private trackSender(sender: WebContents): void {
+    if (this.trackedWebContents.has(sender.id)) return
+    this.trackedWebContents.add(sender.id)
+    sender.once('destroyed', () => {
+      this.tabsByWorktreeByWindow.delete(sender.id)
+      this.activeTabIdByWorktreeByWindow.delete(sender.id)
+      this.closedTabsByWorktreeByWindow.delete(sender.id)
+      this.trackedWebContents.delete(sender.id)
+    })
+  }
+
+  private emitAppStateChanged(sender: WebContents): void {
+    if (sender.isDestroyed()) return
+    this.deps.emitAppStateChanged(sender)
   }
 
   private assertSenderOwnsWorktree(sender: WebContents, worktreePath: string): string {
@@ -572,6 +3233,219 @@ export class TabCommandService {
       throw new Error(`Worktree is not attached to this window: ${worktreePath}`)
     }
     return workspaceId
+  }
+
+  private createSerializedLayout(
+    tabs: TabSnapshot[],
+    activeTabId: string | null,
+  ): SerializedLayout | null {
+    const serializedTabs: SerializedLayout['tabs'] = []
+    const activeIndex = tabs.findIndex((tab) => tab.id === activeTabId)
+    let adjustedActiveIndex = 0
+
+    for (const [index, tab] of tabs.entries()) {
+      const rootSplit = tab.suspended
+        ? cloneSerializedSplitNode(tab.suspended)
+        : this.serializeSplitForLayout(tab.rootSplit)
+      if (!rootSplit) continue
+      if (index === activeIndex) adjustedActiveIndex = serializedTabs.length
+      serializedTabs.push({ toolId: tab.toolId, toolName: tab.toolName, rootSplit })
+    }
+
+    if (serializedTabs.length === 0) return null
+    return {
+      tabs: serializedTabs,
+      activeTabIndex: adjustedActiveIndex,
+    }
+  }
+
+  private serializeSplitForLayout(node: SplitSnapshot): SerializedSplitNode | null {
+    if (node.type === 'leaf') return this.serializePaneForLayout(node.pane)
+
+    const first = this.serializeSplitForLayout(node.first)
+    const second = this.serializeSplitForLayout(node.second)
+    if (!first && !second) return null
+    if (!first) return second
+    if (!second) return first
+    return {
+      type: node.direction === 'horizontal' ? 'hsplit' : 'vsplit',
+      first,
+      second,
+      ratio: node.ratio,
+    }
+  }
+
+  private serializePaneForLayout(pane: PaneSnapshot): SerializedSplitNode | null {
+    if (pane.paneType === 'notes' || pane.paneType === 'drawing') return null
+    if (
+      pane.paneType !== 'editor' &&
+      pane.paneType !== 'browser' &&
+      !pane.isRunning &&
+      !pane.tmuxSessionName
+    ) {
+      return null
+    }
+
+    const leaf: SerializedSplitNode = {
+      type: 'leaf',
+      toolId: pane.toolId,
+      toolName: pane.toolName,
+    }
+    const agentSessionId = this.deps.toolSessions.getAgentSessionId(pane.sessionId)
+    if (agentSessionId) {
+      leaf.agentSessionId = agentSessionId
+      if (pane.toolId === 'claude') leaf.claudeSessionId = agentSessionId
+    }
+    if (pane.paneType === 'browser') {
+      leaf.browserUrl = pane.url ?? ''
+    }
+    if (pane.paneType === 'editor') {
+      leaf.filePath = pane.filePath
+      const files = pane.editorFiles ?? []
+      if (files.length > 0) {
+        leaf.editorFiles = files.map((file) => file.filePath)
+        leaf.editorActiveFile = pane.editorActiveFile ?? files[0].filePath
+      } else if (pane.filePath) {
+        leaf.editorFiles = [pane.filePath]
+        leaf.editorActiveFile = pane.filePath
+      }
+    }
+    if (pane.tmuxSessionName) leaf.tmuxSessionName = pane.tmuxSessionName
+    if (pane.profileId) leaf.profileId = pane.profileId
+    return leaf
+  }
+
+  private createSuspendedTabSnapshot(
+    worktreePath: string,
+    serializedTab: SerializedLayout['tabs'][number],
+    existingTabs: TabSnapshot[],
+  ): TabSnapshot {
+    const placeholderPaneId = paneId()
+    return {
+      id: tabId(),
+      toolId: serializedTab.toolId,
+      toolName: serializedTab.toolName,
+      name: computeDisplayName(
+        serializedTab.toolName,
+        worktreePath,
+        serializedTab.toolId,
+        existingTabs,
+      ),
+      worktreePath,
+      rootSplit: {
+        type: 'leaf',
+        pane: {
+          id: placeholderPaneId,
+          sessionId: '',
+          wsUrl: '',
+          toolId: serializedTab.toolId,
+          toolName: serializedTab.toolName,
+          isRunning: false,
+          exitCode: null,
+          title: null,
+        },
+      },
+      focusedPaneId: placeholderPaneId,
+      suspended: serializedTab.rootSplit,
+    }
+  }
+
+  private async restoreSerializedSplitSnapshot(
+    sender: WebContents,
+    worktreePath: string,
+    node: SerializedSplitNode,
+    options: { workspaceName?: string; branch?: string },
+  ): Promise<SplitSnapshot> {
+    if (node.type === 'leaf') {
+      return {
+        type: 'leaf',
+        pane: await this.restoreSerializedPaneSnapshot(sender, worktreePath, node, options),
+      }
+    }
+
+    const [first, second] = await Promise.all([
+      this.restoreSerializedSplitSnapshot(sender, worktreePath, node.first, options),
+      this.restoreSerializedSplitSnapshot(sender, worktreePath, node.second, options),
+    ])
+    return {
+      type: 'split',
+      id: splitId(),
+      direction: node.type === 'hsplit' ? 'horizontal' : 'vertical',
+      ratio: node.ratio,
+      first,
+      second,
+    }
+  }
+
+  private async restoreSerializedPaneSnapshot(
+    sender: WebContents,
+    worktreePath: string,
+    node: Extract<SerializedSplitNode, { type: 'leaf' }>,
+    options: { workspaceName?: string; branch?: string },
+  ): Promise<PaneSnapshot> {
+    if (node.toolId === 'editor' && (node.filePath || (node.editorFiles?.length ?? 0) > 0)) {
+      const files = node.editorFiles ?? (node.filePath ? [node.filePath] : [])
+      const activeFile = node.editorActiveFile ?? files[0] ?? node.filePath ?? ''
+      return {
+        id: paneId(),
+        sessionId: '',
+        wsUrl: '',
+        toolId: 'editor',
+        toolName: node.toolName,
+        isRunning: true,
+        exitCode: null,
+        title: null,
+        paneType: 'editor',
+        filePath: activeFile,
+        editorFiles: files.map((filePath) => ({ filePath })),
+        editorActiveFile: activeFile,
+      }
+    }
+
+    if (node.toolId === 'browser') {
+      return {
+        id: paneId(),
+        sessionId: randomUUID(),
+        wsUrl: '',
+        toolId: 'browser',
+        toolName: node.toolName,
+        isRunning: true,
+        exitCode: null,
+        title: null,
+        paneType: 'browser',
+        url: node.browserUrl,
+      }
+    }
+
+    if (node.tmuxSessionName) {
+      const exists = await this.deps.toolSessions
+        .hasTmuxSession(node.tmuxSessionName)
+        .catch(() => false)
+      if (exists) {
+        const result = await this.deps.toolSessions.attachTmux(sender, {
+          tmuxSessionName: node.tmuxSessionName,
+        })
+        return {
+          id: paneId(),
+          sessionId: result.sessionId,
+          wsUrl: result.wsUrl,
+          toolId: node.toolId,
+          toolName: node.toolName,
+          isRunning: true,
+          exitCode: null,
+          title: null,
+          tmuxSessionName: node.tmuxSessionName,
+          profileId: node.profileId,
+        }
+      }
+    }
+
+    return this.createPane(sender, node.toolId, worktreePath, {
+      workspaceName: options.workspaceName,
+      branch: options.branch,
+      resumeSessionId: node.agentSessionId ?? node.claudeSessionId,
+      profileId: node.profileId,
+    })
   }
 
   private async createPane(
@@ -626,6 +3500,20 @@ export class TabCommandService {
         exitCode: null,
         title: null,
         paneType: 'editor',
+      }
+    }
+
+    if (toolId === 'diff') {
+      return {
+        id: paneId(),
+        sessionId: '',
+        wsUrl: '',
+        toolId,
+        toolName: 'Diff',
+        isRunning: false,
+        exitCode: null,
+        title: null,
+        paneType: 'diff',
       }
     }
 

--- a/src/main/commands/types.ts
+++ b/src/main/commands/types.ts
@@ -39,15 +39,33 @@ export interface WorkspaceStateSnapshot {
   aheadBehind: { ahead: number; behind: number } | null
 }
 
-export interface WorkspaceCommandResult {
+export interface WorkspaceSnapshot {
   projects: ProjectSnapshot[]
   workspaceState: WorkspaceStateSnapshot
+}
+
+export interface AppStateSnapshot {
+  workspace: WorkspaceSnapshot
+  tabs: TabStateSnapshot
+}
+
+export interface WorkspaceCommandResult extends WorkspaceSnapshot {
   restoredLayouts?: Array<{ worktreePath: string; layoutJson: string }>
   focusedExistingWindow?: boolean
   warnings: CommandWarning[]
 }
 
 export type PaneKind = 'terminal' | 'browser' | 'notes' | 'drawing' | 'editor' | 'diff'
+
+export interface EditorFileSnapshot {
+  filePath: string
+  dirty?: boolean
+  originalContent?: string
+  currentContent?: string
+  fileMtimeMs?: number
+  fileLineEnding?: 'LF' | 'CRLF'
+  externalChangeDetected?: boolean
+}
 
 export interface PaneSnapshot {
   id: string
@@ -61,9 +79,10 @@ export interface PaneSnapshot {
   paneType?: PaneKind
   tmuxSessionName?: string
   detached?: boolean
+  inspectorOpen?: boolean
   url?: string
   filePath?: string
-  editorFiles?: Array<{ filePath: string }>
+  editorFiles?: EditorFileSnapshot[]
   editorActiveFile?: string
   profileId?: string
   profileName?: string
@@ -73,11 +92,43 @@ export type SplitSnapshot =
   | { type: 'leaf'; pane: PaneSnapshot }
   | {
       type: 'split'
+      id: string
       direction: 'horizontal' | 'vertical'
       ratio: number
       first: SplitSnapshot
       second: SplitSnapshot
     }
+
+export type SerializedSplitNode =
+  | {
+      type: 'leaf'
+      toolId: string
+      toolName: string
+      agentSessionId?: string
+      claudeSessionId?: string
+      browserUrl?: string
+      browserDevToolsMode?: 'bottom' | 'right'
+      filePath?: string
+      editorFiles?: string[]
+      editorActiveFile?: string
+      tmuxSessionName?: string
+      profileId?: string
+    }
+  | {
+      type: 'hsplit' | 'vsplit'
+      first: SerializedSplitNode
+      second: SerializedSplitNode
+      ratio: number
+    }
+
+export interface SerializedLayout {
+  tabs: Array<{
+    toolId: string
+    toolName: string
+    rootSplit: SerializedSplitNode
+  }>
+  activeTabIndex: number
+}
 
 export interface TabSnapshot {
   id: string
@@ -87,6 +138,7 @@ export interface TabSnapshot {
   worktreePath: string
   rootSplit: SplitSnapshot
   focusedPaneId: string
+  suspended?: SerializedSplitNode
 }
 
 export interface TabCommandResult {
@@ -96,6 +148,55 @@ export interface TabCommandResult {
   openedTab?: TabSnapshot
   restartedPane?: PaneSnapshot
   closedTabId?: string
+  closedPaneId?: string
+}
+
+export type CloseWarningTarget =
+  | { kind: 'tab'; tabId: string }
+  | { kind: 'pane'; tabId: string; paneId: string }
+
+export interface CloseWarningResult {
+  description: string | null
+}
+
+export type TabClosePreflightResult =
+  | { ok: true }
+  | { ok: false; reason: 'cancelled' }
+  | { ok: false; reason: 'save-failed'; failedCount: number }
+
+export type EditorFileSaveResult =
+  | { ok: true; mtimeMs: number; size: number; result: TabCommandResult }
+  | { ok: false; tag: 'StaleWrite'; actualMtimeMs: number }
+  | { ok: false; tag: 'WriteFailed' | 'StatFailed'; message: string }
+
+export type EditorFileReadResult =
+  | {
+      ok: true
+      binary: false
+      content: string
+      truncated: boolean
+      size: number
+      canWrite: boolean
+      mtimeMs: number
+      fileLineEnding: 'LF' | 'CRLF'
+    }
+  | {
+      ok: true
+      binary: true
+      size: number
+      canWrite: boolean
+      mtimeMs: number
+    }
+  | { ok: false; tag: 'ReadFailed' | 'StatFailed'; message: string }
+
+export type EditorFileLoadResult =
+  | (Extract<EditorFileReadResult, { ok: true; binary: false }> & { result: TabCommandResult })
+  | (Extract<EditorFileReadResult, { ok: true; binary: true }> & { result: TabCommandResult })
+  | Extract<EditorFileReadResult, { ok: false }>
+
+export interface TabStateSnapshot {
+  tabsByWorktree: Record<string, TabSnapshot[]>
+  activeTabIdByWorktree: Record<string, string | null>
 }
 
 export interface AgentCommandResult {

--- a/src/main/commands/types.ts
+++ b/src/main/commands/types.ts
@@ -159,10 +159,19 @@ export interface CloseWarningResult {
   description: string | null
 }
 
+export interface CloseWarningEntry {
+  tabName: string
+  description: string
+}
+
 export type TabClosePreflightResult =
   | { ok: true }
   | { ok: false; reason: 'cancelled' }
   | { ok: false; reason: 'save-failed'; failedCount: number }
+
+export type TabCloseAllPreflightResult =
+  | TabClosePreflightResult
+  | { ok: false; reason: 'active-processes'; warnings: CloseWarningEntry[] }
 
 export type EditorFileSaveResult =
   | { ok: true; mtimeMs: number; size: number; result: TabCommandResult }

--- a/src/main/commands/workspaceCommands.ts
+++ b/src/main/commands/workspaceCommands.ts
@@ -13,6 +13,7 @@ import type {
   CommandWarning,
   ProjectSnapshot,
   WorkspaceCommandResult,
+  WorkspaceSnapshot,
   WorkspaceStateSnapshot,
 } from './types'
 
@@ -34,6 +35,7 @@ interface WorkspaceCommandServiceDeps {
   persistWindowConfigs: () => void
   validatePathAccess: (webContentsId: number, targetPath: string) => Promise<string>
   clearWorkspaceFileCache: (path: string) => void
+  emitAppStateChanged: (sender: WebContents) => void
 }
 
 interface AttachProjectOptions {
@@ -42,9 +44,12 @@ interface AttachProjectOptions {
   restoredLayouts: Array<{ worktreePath: string; layoutJson: string }>
 }
 
+type WorktreeStatusSnapshot = Pick<WorkspaceStateSnapshot, 'branch' | 'isDirty' | 'aheadBehind'>
+
 export class WorkspaceCommandService {
   private projectsByWindow = new Map<number, ProjectSnapshot[]>()
   private selectedWorktreeByWindow = new Map<number, string>()
+  private statusByWorktreeByWindow = new Map<number, Map<string, WorktreeStatusSnapshot>>()
   private grantedAttachPathsByWindow = new Map<number, Set<string>>()
   private trackedWebContents = new Set<number>()
 
@@ -89,11 +94,13 @@ export class WorkspaceCommandService {
     if (targetPath) {
       this.selectedWorktreeByWindow.set(sender.id, targetPath)
       this.deps.windowManager.setActiveWorktree(sender.id, targetPath)
+      await this.refreshSelectedWorktreeStatus(sender.id, targetPath)
       this.deps.persistWindowConfigs()
     }
 
     const result = this.result(sender.id, warnings, restoredLayouts)
     if (focusedExistingWindow) result.focusedExistingWindow = true
+    this.emitAppStateChanged(sender)
     return result
   }
 
@@ -108,6 +115,7 @@ export class WorkspaceCommandService {
     })
     const result = this.result(sender.id, warnings, restoredLayouts)
     if (focusedExistingWindow) result.focusedExistingWindow = true
+    this.emitAppStateChanged(sender)
     return result
   }
 
@@ -120,6 +128,7 @@ export class WorkspaceCommandService {
     const key = this.projectKey(project)
     this.deps.windowManager.removeWorkspacePath(sender.id, key)
     if (project.repoRoot) this.deps.windowManager.disposeGitWatcher(sender.id, project.repoRoot)
+    this.clearProjectStatus(sender.id, project)
 
     const ws = this.deps.workspaceStore.getByPath(key)
     if (ws) this.deps.layoutStore.deleteAll(ws.id)
@@ -144,7 +153,9 @@ export class WorkspaceCommandService {
     }
 
     this.deps.persistWindowConfigs()
-    return this.result(sender.id, [], [])
+    const result = this.result(sender.id, [], [])
+    this.emitAppStateChanged(sender)
+    return result
   }
 
   async selectWorktree(sender: WebContents, worktreePath: string): Promise<WorkspaceCommandResult> {
@@ -157,8 +168,18 @@ export class WorkspaceCommandService {
     }
     this.selectedWorktreeByWindow.set(sender.id, worktreePath)
     this.deps.windowManager.setActiveWorktree(sender.id, worktreePath)
+    await this.refreshSelectedWorktreeStatus(sender.id, worktreePath)
     this.deps.persistWindowConfigs()
-    return this.result(sender.id, [], [])
+    const result = this.result(sender.id, [], [])
+    this.emitAppStateChanged(sender)
+    return result
+  }
+
+  getSnapshot(webContentsId: number): WorkspaceSnapshot {
+    return {
+      projects: this.getProjects(webContentsId),
+      workspaceState: this.workspaceState(webContentsId),
+    }
   }
 
   getWorkspaceIdForWorktree(webContentsId: number, worktreePath: string): string | null {
@@ -189,6 +210,7 @@ export class WorkspaceCommandService {
         worktree.path === detectedProjectRoot ? { ...worktree, path: projectRoot } : worktree,
       ),
     }
+    this.updateGitStatusCache(sender.id, info)
     const projects = this.getProjects(sender.id)
     const projectIndex = projects.findIndex(
       (project) =>
@@ -225,7 +247,9 @@ export class WorkspaceCommandService {
     }
 
     this.deps.persistWindowConfigs()
-    return this.result(sender.id, warnings, [])
+    const result = this.result(sender.id, warnings, [])
+    this.emitAppStateChanged(sender)
+    return result
   }
 
   private async attachProjectSnapshot(
@@ -274,6 +298,7 @@ export class WorkspaceCommandService {
     }
 
     this.projectsByWindow.set(sender.id, [...projects, project])
+    this.updateGitStatusCache(sender.id, info)
 
     this.deps.windowManager.addWorkspacePath(sender.id, projectPath)
     this.deps.persistWindowConfigs()
@@ -320,6 +345,8 @@ export class WorkspaceCommandService {
           })
         }
         this.updateProjectGitInfo(sender.id, repoRoot, info)
+        this.updateGitStatusCache(sender.id, info)
+        this.emitAppStateChanged(sender)
         if (!sender.isDestroyed()) {
           sender.send('git:changed', { ...info, repoRoot, changes })
         }
@@ -363,9 +390,9 @@ export class WorkspaceCommandService {
     warnings: CommandWarning[],
     restoredLayouts: Array<{ worktreePath: string; layoutJson: string }>,
   ): WorkspaceCommandResult {
+    const snapshot = this.getSnapshot(webContentsId)
     return {
-      projects: this.getProjects(webContentsId),
-      workspaceState: this.workspaceState(webContentsId),
+      ...snapshot,
       ...(restoredLayouts.length > 0 ? { restoredLayouts } : {}),
       warnings,
     }
@@ -390,12 +417,15 @@ export class WorkspaceCommandService {
     const selectedWorktree = project.worktrees.find(
       (worktree) => worktree.path === selectedWorktreePath,
     )
+    const status = selectedWorktreePath
+      ? this.getWorktreeStatus(webContentsId, selectedWorktreePath)
+      : null
     return {
       project,
       selectedWorktreePath,
-      branch: selectedWorktree?.branch ?? null,
-      isDirty: false,
-      aheadBehind: null,
+      branch: status?.branch ?? selectedWorktree?.branch ?? null,
+      isDirty: status?.isDirty ?? false,
+      aheadBehind: status?.aheadBehind ?? null,
     }
   }
 
@@ -409,6 +439,7 @@ export class WorkspaceCommandService {
     sender.once('destroyed', () => {
       this.projectsByWindow.delete(sender.id)
       this.selectedWorktreeByWindow.delete(sender.id)
+      this.statusByWorktreeByWindow.delete(sender.id)
       this.grantedAttachPathsByWindow.delete(sender.id)
       this.trackedWebContents.delete(sender.id)
     })
@@ -456,6 +487,25 @@ export class WorkspaceCommandService {
     const info = await GitRepository.detect(worktreePath).unwrapOr(defaultGitInfo)
     if (!info.repoRoot) return
     this.updateProjectGitInfo(webContentsId, info.repoRoot, info)
+    this.updateGitStatusCache(webContentsId, info)
+  }
+
+  private async refreshSelectedWorktreeStatus(
+    webContentsId: number,
+    worktreePath: string,
+  ): Promise<void> {
+    const project = this.getProjectForWorktree(webContentsId, worktreePath)
+    if (!project?.isGitRepo) return
+
+    const info = await GitRepository.detect(worktreePath).unwrapOr(defaultGitInfo)
+    if (!info.isGitRepo) return
+
+    const worktree = info.worktrees.find((candidate) => candidate.path === worktreePath)
+    this.setWorktreeStatus(webContentsId, worktreePath, {
+      branch: worktree?.branch ?? info.branch,
+      isDirty: info.isDirty,
+      aheadBehind: info.aheadBehind,
+    })
   }
 
   private updateProjectGitInfo(webContentsId: number, repoRoot: string, info: GitInfo): void {
@@ -481,6 +531,57 @@ export class WorkspaceCommandService {
     this.projectsByWindow.set(webContentsId, projects)
   }
 
+  private updateGitStatusCache(webContentsId: number, info: GitInfo): void {
+    const mainWorktreePath = info.worktrees.find((worktree) => worktree.isMain)?.path
+    const repoStatus: WorktreeStatusSnapshot = {
+      branch: info.branch,
+      isDirty: info.isDirty,
+      aheadBehind: info.aheadBehind,
+    }
+
+    if (info.repoRoot) this.setWorktreeStatus(webContentsId, info.repoRoot, repoStatus)
+    if (mainWorktreePath) this.setWorktreeStatus(webContentsId, mainWorktreePath, repoStatus)
+
+    for (const worktree of info.worktrees) {
+      if (worktree.path === mainWorktreePath) continue
+      const existing = this.getWorktreeStatus(webContentsId, worktree.path)
+      this.setWorktreeStatus(webContentsId, worktree.path, {
+        branch: worktree.branch ?? existing?.branch ?? null,
+        isDirty: existing?.isDirty ?? false,
+        aheadBehind: existing?.aheadBehind ?? null,
+      })
+    }
+  }
+
+  private setWorktreeStatus(
+    webContentsId: number,
+    worktreePath: string,
+    status: WorktreeStatusSnapshot,
+  ): void {
+    let statuses = this.statusByWorktreeByWindow.get(webContentsId)
+    if (!statuses) {
+      statuses = new Map()
+      this.statusByWorktreeByWindow.set(webContentsId, statuses)
+    }
+    statuses.set(worktreePath, status)
+  }
+
+  private getWorktreeStatus(
+    webContentsId: number,
+    worktreePath: string,
+  ): WorktreeStatusSnapshot | null {
+    return this.statusByWorktreeByWindow.get(webContentsId)?.get(worktreePath) ?? null
+  }
+
+  private clearProjectStatus(webContentsId: number, project: ProjectSnapshot): void {
+    const statuses = this.statusByWorktreeByWindow.get(webContentsId)
+    if (!statuses) return
+    for (const ownedPath of this.getOwnedPaths(project)) {
+      statuses.delete(ownedPath)
+    }
+    if (statuses.size === 0) this.statusByWorktreeByWindow.delete(webContentsId)
+  }
+
   private getDefaultWorktreePath(project: ProjectSnapshot | undefined): string | undefined {
     if (!project) return undefined
     if (!project.isGitRepo) return project.workspace.path
@@ -497,6 +598,11 @@ export class WorkspaceCommandService {
 
   private projectKey(project: ProjectSnapshot): string {
     return project.repoRoot ?? project.workspace.path
+  }
+
+  private emitAppStateChanged(sender: WebContents): void {
+    if (sender.isDestroyed()) return
+    this.deps.emitAppStateChanged(sender)
   }
 
   private stalePathsWarning(removedPaths: string[]): CommandWarning {

--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -353,14 +353,17 @@ export class GitRepository {
   }
 
   static isBranchMerged(repoRoot: string, branch: string): ResultAsync<boolean, GitError> {
+    return this.getMergedBranches(repoRoot).map((merged) => merged.includes(branch))
+  }
+
+  static getMergedBranches(repoRoot: string): ResultAsync<string[], GitError> {
     const git = simpleGit(repoRoot)
-    return gitCall('branch --merged', git.raw(['branch', '--merged'])).map((raw) => {
-      const merged = raw
+    return gitCall('branch --merged', git.raw(['branch', '--merged'])).map((raw) =>
+      raw
         .split('\n')
         .map((line) => line.replace(/^\*?\s+/, '').trim())
-        .filter(Boolean)
-      return merged.includes(branch)
-    })
+        .filter(Boolean),
+    )
   }
 
   static worktreeAdd(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -126,6 +126,15 @@ const tmuxManager = new TmuxManager(app.getPath('userData'))
 const remoteSessionService = new RemoteSessionService(preferencesStore)
 const perfHudService = new PerfHudService()
 windowManager.setTmuxManager(tmuxManager)
+let lastClosedWindowConfigs: WindowConfig[] | null = null
+windowManager.setOnWindowCloseSnapshot(({ configs, isLastWindow }) => {
+  if (!isLastWindow || !windowManager.shouldQuitOnLastWindowClose()) return
+  lastClosedWindowConfigs = configs
+  persistOpenWindowConfigs(configs)
+})
+windowManager.setOnWindowConfigChanged((configs) => {
+  persistOpenWindowConfigs(configs)
+})
 windowManager.setOnWindowDispose((paths) => {
   for (const path of paths) {
     const ws = workspaceStore.getByPath(path)
@@ -136,8 +145,29 @@ let manualCheckInProgress = false
 let updateInstalling = false
 let updateCheckInFlight = false
 let updateCheckIntervalTimer: ReturnType<typeof setInterval> | null = null
+let forceExitTimer: ReturnType<typeof setTimeout> | null = null
 
 type UpdateCheckFrequency = 'never' | 'hourly' | 'daily' | 'weekly'
+
+async function readLicenseText(): Promise<string> {
+  const candidates = app.isPackaged
+    ? [join(app.getAppPath(), 'LICENSE.md'), resolve(process.resourcesPath, 'LICENSE.md')]
+    : [
+        join(app.getAppPath(), 'LICENSE.md'),
+        resolve(app.getAppPath(), '..', '..', 'LICENSE.md'),
+        resolve('LICENSE.md'),
+      ]
+
+  for (const candidate of candidates) {
+    try {
+      return await readFile(candidate, 'utf-8')
+    } catch {
+      // Try the next dev/packaged location.
+    }
+  }
+
+  return ''
+}
 
 const HOUR_MS = 60 * 60 * 1000
 const DAY_MS = 24 * HOUR_MS
@@ -198,6 +228,64 @@ let notchOverlay: NotchOverlayManager | null = null
 let crashReporter: CrashReporter | null = null
 let ipcCommandBridge: IpcCommandBridge | null = null
 
+function canCreateApplicationWindow(): boolean {
+  return !windowManager.isQuitting && !database.isClosed()
+}
+
+function scheduleForceExit(reason: string, timeoutMs = 5000): void {
+  if (forceExitTimer) return
+  forceExitTimer = setTimeout(() => {
+    console.error(`[quit] ${reason}; forcing exit`)
+    app.exit(0)
+  }, timeoutMs)
+  forceExitTimer.unref?.()
+}
+
+function disposeRuntimeForQuit(options: { disposeWindows: boolean; forceExit?: boolean }): void {
+  windowManager.isQuitting = true
+
+  if (updateCheckIntervalTimer) {
+    clearInterval(updateCheckIntervalTimer)
+    updateCheckIntervalTimer = null
+  }
+
+  crashReporter?.clearSentinel()
+  notchOverlay?.dispose()
+  agentSessionManager?.dispose()
+  remoteSessionService.dispose()
+  perfHudService.shutdown()
+
+  if (options.disposeWindows) {
+    windowManager.disposeAll()
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.destroy()
+    }
+  }
+
+  wsBridge.disposeAll()
+  ptyManager.dispose()
+  database.close()
+  if (options.forceExit !== false) {
+    scheduleForceExit('shutdown did not complete within 5s')
+  }
+}
+
+function persistOpenWindowConfigs(configs?: WindowConfig[]): void {
+  const currentConfigs = configs ?? windowManager.getAllWindowConfigs()
+  const nextConfigs =
+    currentConfigs.length > 0 ? currentConfigs : (lastClosedWindowConfigs ?? currentConfigs)
+
+  if (!configs && currentConfigs.length > 0) {
+    lastClosedWindowConfigs = null
+  }
+
+  if (nextConfigs.length > 0) {
+    preferencesStore.set('openWindowConfigs', JSON.stringify(nextConfigs))
+  } else {
+    preferencesStore.delete('openWindowConfigs')
+  }
+}
+
 // Register canopy:// URL scheme
 if (process.defaultApp) {
   if (process.argv.length >= 2) {
@@ -214,6 +302,8 @@ if (!gotTheLock) {
 }
 
 async function handleCanopyUrl(url: string): Promise<void> {
+  if (!canCreateApplicationWindow()) return
+
   try {
     const parsed = new URL(url)
     const path = parsed.searchParams.get('path')
@@ -333,10 +423,12 @@ function buildAppMenu(): void {
         {
           label: 'New Window',
           accelerator: 'CmdOrCtrl+Shift+N',
-          click: () =>
+          click: () => {
+            if (!canCreateApplicationWindow()) return
             windowManager.createWindow({
               bounds: cascadeBounds(windowManager.getLastFocusedBounds()),
-            }),
+            })
+          },
         },
         { type: 'separator' },
         ...(!isMac
@@ -777,7 +869,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('app:getAboutInfo', async () => ({
     version: app.getVersion(),
     homepage: 'https://canopy.itsol.tech',
-    license: await readFile(join(app.getAppPath(), 'LICENSE.md'), 'utf-8'),
+    license: await readLicenseText(),
   }))
 
   ipcMain.handle(
@@ -888,6 +980,7 @@ app.whenReady().then(async () => {
         const win = windowManager.createWindow({
           bounds,
           windowState: config.windowState,
+          startupRestore: true,
         })
         // Only surface the stale-cleanup toast in one window to avoid duplicates
         const removedPaths =
@@ -960,6 +1053,8 @@ app.whenReady().then(async () => {
 
   // Handle URL scheme on Windows/Linux (second instance) — also create new window if no URL
   app.on('second-instance', (_event, argv) => {
+    if (!canCreateApplicationWindow()) return
+
     const url = argv.find((a) => a.startsWith('canopy://'))
     if (url) {
       handleCanopyUrl(url)
@@ -969,27 +1064,26 @@ app.whenReady().then(async () => {
   })
 
   app.on('activate', function () {
+    if (!canCreateApplicationWindow()) return
+
     if (BrowserWindow.getAllWindows().length === 0)
       windowManager.createWindow({ bounds: cascadeBounds(windowManager.getLastFocusedBounds()) })
   })
 })
 
 app.on('before-quit', (event) => {
+  if (database.isClosed()) return
+
   // During update install, skip cleanup that could interfere with Squirrel.
   // Window configs already saved; windows already destroyed.
   if (updateInstalling) {
-    if (updateCheckIntervalTimer) {
-      clearInterval(updateCheckIntervalTimer)
-      updateCheckIntervalTimer = null
-    }
-    crashReporter?.clearSentinel()
-    notchOverlay?.dispose()
-    agentSessionManager?.dispose()
-    remoteSessionService.dispose()
-    perfHudService.shutdown()
-    database.close()
+    disposeRuntimeForQuit({ disposeWindows: false, forceExit: false })
     return
   }
+
+  // Persist the exact window/project grouping before any async quit path can
+  // re-enter or tear down windows.
+  persistOpenWindowConfigs()
 
   // hasAnyActiveSession() is async (spawns `pgrep`/`wmic` per shell), but
   // event.preventDefault() must be called synchronously. preventDefault
@@ -1009,7 +1103,11 @@ app.on('before-quit', (event) => {
           return
         }
         const focusedWin = BrowserWindow.getFocusedWindow() ?? windowManager.getAllWindows()[0]
-        if (!focusedWin || focusedWin.isDestroyed()) return
+        if (!focusedWin || focusedWin.isDestroyed()) {
+          windowManager.isQuitting = true
+          app.quit()
+          return
+        }
         const { response } = await dialog.showMessageBox(focusedWin, {
           type: 'warning',
           buttons: ['Quit', 'Cancel'],
@@ -1026,16 +1124,6 @@ app.on('before-quit', (event) => {
       })
       return
     }
-  }
-
-  // Always save window configs before any async quit path.
-  // The tmux-ask branch below returns early and re-enters via app.quit(),
-  // so this is the only reliable place to persist.
-  const configs = windowManager.getAllWindowConfigs()
-  if (configs.length > 0) {
-    preferencesStore.set('openWindowConfigs', JSON.stringify(configs))
-  } else {
-    preferencesStore.delete('openWindowConfigs')
   }
 
   // Handle tmux close policy synchronously before any async work
@@ -1078,23 +1166,10 @@ app.on('before-quit', (event) => {
   // From this point onward we are intentionally shutting down the app.
   // Window teardown should detach tmux-backed PTYs unless the policy above
   // explicitly killed the tmux server.
-  windowManager.isQuitting = true
-
-  if (updateCheckIntervalTimer) {
-    clearInterval(updateCheckIntervalTimer)
-    updateCheckIntervalTimer = null
-  }
-  crashReporter?.clearSentinel()
-  notchOverlay?.dispose()
-  agentSessionManager?.dispose()
-  remoteSessionService.dispose()
-  perfHudService.shutdown()
-  windowManager.disposeAll()
-  database.close()
+  disposeRuntimeForQuit({ disposeWindows: true })
 })
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
+  if (windowManager.isQuitting || database.isClosed()) return
+  if (windowManager.shouldQuitOnLastWindowClose()) app.quit()
 })

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -6,6 +6,7 @@ import {
   BrowserWindow,
   systemPreferences,
   type IpcMainInvokeEvent,
+  type WebContents,
 } from 'electron'
 import os from 'os'
 import fs from 'fs'
@@ -72,6 +73,11 @@ import {
   BRANCH_TYPE_OPTIONS,
 } from '../taskTracker/branchTemplate'
 import { createPullRequest, buildPRConfig } from '../taskTracker/prCreation'
+import {
+  formatTaskContext,
+  type TaskAttachmentPath,
+  type TaskContextInput,
+} from '../taskTracker/taskContext'
 import { getBranchTemplate, getPRTemplate } from '../taskTracker/configDefaults'
 import type { GitHubService } from '../github/GitHubService'
 import { gitHubErrorMessage } from '../github/errors'
@@ -99,6 +105,7 @@ import { WorkspaceCommandService } from '../commands/workspaceCommands'
 import { TabCommandService, ToolSessionService } from '../commands/tabCommands'
 import { AgentCommandService } from '../commands/agentCommands'
 import { RunConfigCommandService } from '../commands/runConfigCommands'
+import type { AppStateSnapshot, EditorFileReadResult } from '../commands/types'
 
 // Session-level flag: once the user has successfully authenticated to reveal
 // a saved credential in the current app session, subsequent autofills reuse
@@ -115,6 +122,129 @@ let credentialSessionAuthenticated = false
 // this cache; 'reveal' always fetches fresh. Cleared on any save/delete/import
 // so stale plaintext is never returned, and on app quit.
 const credentialSessionCache = new Map<string, Credential>()
+
+interface TaskTrackerBranchFromTaskPayload {
+  connectionId: string
+  task: TrackerTask
+  boardId?: string
+  branchType?: string
+  repoRoot?: string
+}
+
+interface TaskTrackerCreateBranchFromTaskPayload extends TaskTrackerBranchFromTaskPayload {
+  repoRoot: string
+  baseBranch: string
+  stashBeforeCreate?: boolean
+}
+
+interface TaskTrackerCreateWorktreeFromTaskPayload extends TaskTrackerBranchFromTaskPayload {
+  repoRoot: string
+  worktreePath: string
+  baseBranch: string
+}
+
+interface TaskTrackerBuildTaskContextPayload {
+  connectionId: string
+  task: TaskContextInput
+  repoRoot?: string
+  trackerId?: string
+}
+
+interface WorktreeRemoveWithBranchPayload {
+  repoRoot: string
+  worktreePath: string
+  branch?: string
+  deleteBranch?: boolean
+  forceOnFailure?: boolean
+}
+
+interface WorktreePrepareRemovePayload {
+  repoRoot: string
+  worktreePath: string
+  branch: string
+}
+
+interface WorktreePrepareRemoveResult {
+  hasUncommittedChanges: boolean
+  unmergedCommitCount: number
+  branchMerged: boolean
+  forceRequired: boolean
+  canDeleteBranch: boolean
+  warnings: string[]
+}
+
+interface WorktreeGetMergedBranchesPayload {
+  repoRoot: string
+  branches: string[]
+}
+
+interface WorktreeGetMergedBranchesResult {
+  mergedBranches: string[]
+}
+
+interface GitBranchPrepareDeletePayload {
+  repoRoot: string
+  branch: string
+}
+
+interface GitBranchPrepareDeleteResult {
+  branchMerged: boolean
+  forceRequired: boolean
+  warnings: string[]
+}
+
+interface GitBranchDeleteWithPreflightPayload {
+  repoRoot: string
+  branch: string
+  forceIfUnmerged?: boolean
+}
+
+interface GitBranchDeleteWithPreflightResult {
+  branchDeleted: boolean
+  forcedBranchDelete: boolean
+  branchMerged: boolean
+}
+
+type GitPreparePushResult =
+  | {
+      hasUpstream: false
+      confirmationMessage: string
+    }
+  | {
+      hasUpstream: true
+      branch: string
+      remote: string
+      commitCount: number
+      confirmationMessage: string
+    }
+
+type WorktreeCreatePayload =
+  | {
+      repoRoot: string
+      worktreePath: string
+      mode: 'new'
+      branch: string
+      baseBranch: string
+    }
+  | {
+      repoRoot: string
+      worktreePath: string
+      mode: 'existing'
+      branch: string
+      createLocalTracking?: boolean
+    }
+
+interface WorktreeCreateResult {
+  branch: string
+  worktreePath: string
+}
+
+interface WorktreeRemoveWithBranchResult {
+  worktreeRemoved: boolean
+  branchDeleted: boolean
+  forcedWorktreeRemove: boolean
+  forcedBranchDelete: boolean
+}
 
 // Dedupe concurrent first-use OS auth prompts for the autofill path. When two
 // autofill requests race past `credentialSessionAuthenticated === false` at
@@ -218,6 +348,146 @@ export function registerIpcHandlers(
     }
   }
 
+  function getAppStateSnapshot(webContentsId: number): AppStateSnapshot {
+    return {
+      workspace: workspaceCommandService.getSnapshot(webContentsId),
+      tabs: tabCommandService.getSnapshot(webContentsId),
+    }
+  }
+
+  function emitAppStateChanged(sender: WebContents): void {
+    if (sender.isDestroyed()) return
+    sender.send('app:stateChanged', getAppStateSnapshot(sender.id))
+  }
+
+  async function confirmUnsavedChangesDialog(
+    sender: WebContents,
+    filePaths: string[],
+  ): Promise<'save' | 'discard' | 'cancel'> {
+    const win = BrowserWindow.fromWebContents(sender) ?? BrowserWindow.getFocusedWindow()
+    if (!win) return 'cancel'
+    const fileList =
+      filePaths.length === 1 ? path.basename(filePaths[0]) : `${filePaths.length} files`
+    const { response } = await dialog.showMessageBox(win, {
+      type: 'warning',
+      buttons: ['Save', "Don't Save", 'Cancel'],
+      defaultId: 0,
+      cancelId: 2,
+      title: 'Unsaved changes',
+      message: `You have unsaved changes in ${fileList}`,
+      detail: 'Do you want to save them before closing?',
+    })
+    return match(response)
+      .with(0, () => 'save' as const)
+      .with(1, () => 'discard' as const)
+      .otherwise(() => 'cancel' as const)
+  }
+
+  async function writeTextFileWithExpectedMtime(
+    webContentsId: number,
+    filePath: string,
+    content: string,
+    expectedMtimeMs?: number,
+  ): Promise<FsWriteFileResponse> {
+    const resolved = await validatePathAccess(webContentsId, filePath)
+    // Structured response instead of a thrown Error — keeps the typed
+    // `_tag` discriminant intact across IPC so the renderer branches on
+    // `result.tag` instead of string-matching a flattened message.
+    if (expectedMtimeMs !== undefined) {
+      const statResult = await fromExternalCall(fs.promises.stat(resolved), errorMessage)
+      if (statResult.isErr()) return { ok: false, tag: 'StatFailed', message: statResult.error }
+      const actualMtimeMs = statResult.value.mtimeMs
+      if (Math.abs(actualMtimeMs - expectedMtimeMs) > 1) {
+        return { ok: false, tag: 'StaleWrite', actualMtimeMs }
+      }
+    }
+    const writeResult = await fromExternalCall(
+      fs.promises.writeFile(resolved, content, 'utf-8'),
+      errorMessage,
+    )
+    if (writeResult.isErr()) {
+      return { ok: false, tag: 'WriteFailed', message: writeResult.error }
+    }
+    const finalStat = await fromExternalCall(fs.promises.stat(resolved), errorMessage)
+    if (finalStat.isErr()) return { ok: false, tag: 'StatFailed', message: finalStat.error }
+    return { ok: true, mtimeMs: finalStat.value.mtimeMs, size: finalStat.value.size }
+  }
+
+  async function loadEditorFileFromDisk(
+    webContentsId: number,
+    filePath: string,
+    maxBytes?: number,
+  ): Promise<EditorFileReadResult> {
+    let resolved: string
+    try {
+      resolved = await validatePathAccess(webContentsId, filePath)
+    } catch (e) {
+      return { ok: false, tag: 'ReadFailed', message: errorMessage(e) }
+    }
+
+    const readLimit = Math.min(maxBytes ?? 1_048_576, 10_485_760)
+    let stat: fs.Stats
+    try {
+      stat = fs.statSync(resolved)
+    } catch (e) {
+      return { ok: false, tag: 'StatFailed', message: errorMessage(e) }
+    }
+
+    let canWrite = true
+    try {
+      fs.accessSync(resolved, fs.constants.W_OK)
+    } catch {
+      canWrite = false
+    }
+
+    const readSize = Math.min(stat.size, readLimit)
+    let fd: number
+    try {
+      fd = fs.openSync(resolved, 'r')
+    } catch (e) {
+      return { ok: false, tag: 'ReadFailed', message: errorMessage(e) }
+    }
+
+    try {
+      const buf = Buffer.alloc(readSize)
+      let offset = 0
+      while (offset < readSize) {
+        const bytesRead = fs.readSync(fd, buf, offset, readSize - offset, offset)
+        if (bytesRead === 0) break
+        offset += bytesRead
+      }
+
+      const detectEnd = Math.min(offset, 8192)
+      for (let i = 0; i < detectEnd; i++) {
+        if (buf[i] === 0) {
+          return {
+            ok: true,
+            binary: true,
+            size: stat.size,
+            canWrite,
+            mtimeMs: stat.mtimeMs,
+          }
+        }
+      }
+
+      const content = buf.subarray(0, offset).toString('utf-8')
+      return {
+        ok: true,
+        binary: false,
+        content,
+        truncated: stat.size > readLimit,
+        size: stat.size,
+        canWrite,
+        mtimeMs: stat.mtimeMs,
+        fileLineEnding: content.includes('\r\n') ? 'CRLF' : 'LF',
+      }
+    } catch (e) {
+      return { ok: false, tag: 'ReadFailed', message: errorMessage(e) }
+    } finally {
+      fs.closeSync(fd)
+    }
+  }
+
   const workspaceCommandService = new WorkspaceCommandService({
     workspaceStore,
     layoutStore,
@@ -228,6 +498,7 @@ export function registerIpcHandlers(
     clearWorkspaceFileCache: (workspacePath) => {
       workspaceFileCache.delete(workspacePath)
     },
+    emitAppStateChanged,
   })
   const toolSessionService = new ToolSessionService({
     ptyManager,
@@ -246,8 +517,14 @@ export function registerIpcHandlers(
     layoutStore,
     browserManager,
     windowManager,
+    confirmUnsavedChanges: (sender, filePaths) => confirmUnsavedChangesDialog(sender, filePaths),
+    writeEditorFile: (sender, filePath, content, expectedMtimeMs) =>
+      writeTextFileWithExpectedMtime(sender.id, filePath, content, expectedMtimeMs),
+    loadEditorFile: (sender, filePath, maxBytes) =>
+      loadEditorFileFromDisk(sender.id, filePath, maxBytes),
     resolveWorkspaceIdForWorktree: (webContentsId, worktreePath) =>
       workspaceCommandService.getWorkspaceIdForWorktree(webContentsId, worktreePath),
+    emitAppStateChanged,
   })
   const agentCommandService = new AgentCommandService({
     ptyManager,
@@ -280,8 +557,72 @@ export function registerIpcHandlers(
   ipcMain.handle('workspace:command:initGitRepo', (event, payload: { path: string }) =>
     workspaceCommandService.initGitRepo(event.sender, payload.path),
   )
+  ipcMain.handle('app:getState', (event) => getAppStateSnapshot(event.sender.id))
+  ipcMain.handle('app:getStartupRestoreState', (event) => ({
+    restoring: windowManager.hasStartupRestore(event.sender.id),
+  }))
+  ipcMain.handle('app:completeStartupRestore', (event) => {
+    windowManager.completeStartupRestore(event.sender.id)
+  })
   ipcMain.handle('tab:command:openTool', (event, payload) =>
     tabCommandService.openTool(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:openDiff', (event, payload) =>
+    tabCommandService.openDiffTab(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:openSessionTab', (event, payload) =>
+    tabCommandService.openSessionTab(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:openEditorFile', (event, payload) =>
+    tabCommandService.openEditorFile(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:detachEditorFile', (event, payload) =>
+    tabCommandService.detachEditorFile(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:closeEditorFile', (event, payload) =>
+    tabCommandService.closeEditorFile(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:prepareCloseEditorFile', (event, payload) =>
+    tabCommandService.prepareCloseEditorFile(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:moveEditorFile', (event, payload) =>
+    tabCommandService.moveEditorFile(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:moveEditorFileBetweenPanes', (event, payload) =>
+    tabCommandService.moveEditorFileBetweenPanes(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:setActiveEditorFile', (event, payload) =>
+    tabCommandService.setActiveEditorFile(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:updateEditorFileState', (event, payload) =>
+    tabCommandService.updateEditorFileState(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:loadEditorFile', (event, payload) =>
+    tabCommandService.loadEditorFile(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:saveEditorFile', (event, payload) =>
+    tabCommandService.saveEditorFile(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:updatePaneTitle', (event, payload) =>
+    tabCommandService.updatePaneTitle(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:updatePaneUrl', (event, payload) =>
+    tabCommandService.updatePaneUrl(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:updateTmuxSessionName', (event, payload) =>
+    tabCommandService.updateTmuxSessionName(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:handlePtyExit', (event, payload) =>
+    tabCommandService.handlePtyExit(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:killTmuxPane', (event, payload) =>
+    tabCommandService.killTmuxPane(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:reattachTmuxPane', (event, payload) =>
+    tabCommandService.reattachTmuxPane(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:toggleFocusedInspector', (event, payload) =>
+    tabCommandService.toggleFocusedInspector(event.sender, payload),
   )
   ipcMain.handle('tab:command:restartPane', (event, payload) =>
     tabCommandService.restartPane(event.sender, payload),
@@ -289,14 +630,63 @@ export function registerIpcHandlers(
   ipcMain.handle('tab:command:closeTab', (event, payload) =>
     tabCommandService.closeTab(event.sender, payload),
   )
+  ipcMain.handle('tab:command:prepareCloseTab', (event, payload) =>
+    tabCommandService.prepareCloseTab(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:getCloseWarning', (event, payload) =>
+    tabCommandService.getCloseWarning(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:reopenClosedTab', (event, payload) =>
+    tabCommandService.reopenClosedTab(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:closePane', (event, payload) =>
+    tabCommandService.closePane(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:closeAllForWorktree', (event, payload) =>
+    tabCommandService.closeAllForWorktree(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:setActiveTab', (event, payload) =>
+    tabCommandService.setActiveTab(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:moveTab', (event, payload) =>
+    tabCommandService.moveTab(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:moveTabToSplit', (event, payload) =>
+    tabCommandService.moveTabToSplit(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:movePaneToTarget', (event, payload) =>
+    tabCommandService.movePaneToTarget(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:detachPaneToTab', (event, payload) =>
+    tabCommandService.detachPaneToTab(event.sender, payload),
+  )
   ipcMain.handle('tab:command:spawnPane', (event, payload) =>
     tabCommandService.spawnPane(event.sender, payload),
   )
-  ipcMain.handle('tab:command:saveLayout', (event, payload) =>
-    tabCommandService.saveLayout(event.sender, payload),
+  ipcMain.handle('tab:command:splitPane', (event, payload) =>
+    tabCommandService.splitPane(event.sender, payload),
   )
-  ipcMain.handle('tab:command:deleteLayout', (event, payload) =>
-    tabCommandService.deleteLayout(event.sender, payload),
+  ipcMain.handle('tab:command:focusPane', (event, payload) =>
+    tabCommandService.focusPane(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:navigatePaneFocus', (event, payload) =>
+    tabCommandService.navigatePaneFocus(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:updateSplitRatio', (event, payload) =>
+    tabCommandService.updateSplitRatio(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:restoreLayout', (event, payload) =>
+    tabCommandService.restoreLayout(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:resumeSuspendedTab', (event, payload) =>
+    tabCommandService.resumeSuspendedTab(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:killAll', (event) => tabCommandService.killAll(event.sender))
+  ipcMain.handle('tab:command:focusSession', (event, payload) =>
+    tabCommandService.focusSession(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:saveCurrentLayout', (event, payload) =>
+    tabCommandService.saveCurrentLayout(event.sender, payload),
   )
   ipcMain.handle('agent:command:sendTaskContext', (event, payload) =>
     agentCommandService.sendTaskContext(event.sender, payload),
@@ -320,7 +710,11 @@ export function registerIpcHandlers(
     'pty:resize',
     (event, payload: { sessionId: string; cols: number; rows: number }) => {
       if (!windowManager.ownsPtySession(event.sender.id, payload.sessionId)) {
-        throw new Error('PTY session is not owned by this window')
+        // Terminal resize can arrive late from hidden/unmounted renderer instances
+        // or another window that still has stale layout state. Resize is
+        // idempotent and carries no input data, so ignore it while keeping
+        // mutating PTY operations like write/kill strictly owned.
+        return
       }
       // Validate dimensions: positive integers within sane terminal bounds.
       // node-pty will otherwise throw on NaN / negative / huge values and
@@ -707,6 +1101,7 @@ export function registerIpcHandlers(
   // --- App: Multi-window ---
 
   ipcMain.handle('app:newWindow', () => {
+    if (windowManager.isQuitting) return
     windowManager.createWindow({
       bounds: cascadeBounds(windowManager.getLastFocusedBounds()),
     })
@@ -953,8 +1348,43 @@ export function registerIpcHandlers(
     return unwrapOrThrow(result, gitErrorMessage)
   })
 
+  ipcMain.handle(
+    'git:commitWorktree',
+    async (
+      event,
+      payload: {
+        repoRoot: string
+        message: string
+        stageAll?: boolean
+      },
+    ) => {
+      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const result = await GitRepository.commit(resolvedRepo, payload.message, payload.stageAll)
+      return unwrapOrThrow(result, gitErrorMessage)
+    },
+  )
+
+  ipcMain.handle('git:pushWorktree', async (event, payload: { repoRoot: string }) => {
+    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const result = await GitRepository.push(resolvedRepo)
+    return unwrapOrThrow(result, gitErrorMessage)
+  })
+
   ipcMain.handle('git:pull', async (_event, payload: { repoRoot: string; rebase: boolean }) => {
     const result = await GitRepository.pull(payload.repoRoot, payload.rebase)
+    return unwrapOrThrow(result, gitErrorMessage)
+  })
+
+  ipcMain.handle('git:pullWithPreferences', async (event, payload: { repoRoot: string }) => {
+    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const rebase = (preferencesStore.get('gitPullRebase') ?? 'true') !== 'false'
+    const result = unwrapOrThrow(await GitRepository.pull(resolvedRepo, rebase), gitErrorMessage)
+    return { ...result, rebase }
+  })
+
+  ipcMain.handle('git:fetchWorktree', async (event, payload: { repoRoot: string }) => {
+    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const result = await GitRepository.fetch(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })
 
@@ -973,8 +1403,20 @@ export function registerIpcHandlers(
     return unwrapOrThrow(result, gitErrorMessage)
   })
 
+  ipcMain.handle('git:stashWorktree', async (event, payload: { repoRoot: string }) => {
+    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const result = await GitRepository.stash(resolvedRepo)
+    return unwrapOrThrow(result, gitErrorMessage)
+  })
+
   ipcMain.handle('git:stashPop', async (_event, payload: { repoRoot: string }) => {
     const result = await GitRepository.stashPop(payload.repoRoot)
+    return unwrapOrThrow(result, gitErrorMessage)
+  })
+
+  ipcMain.handle('git:stashPopWorktree', async (event, payload: { repoRoot: string }) => {
+    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const result = await GitRepository.stashPop(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })
 
@@ -995,6 +1437,15 @@ export function registerIpcHandlers(
     },
   )
 
+  ipcMain.handle(
+    'git:branchCreateFromHead',
+    async (event, payload: { repoRoot: string; branch: string }) => {
+      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const result = await GitRepository.createBranch(resolvedRepo, payload.branch, 'HEAD')
+      return unwrapOrThrow(result, gitErrorMessage)
+    },
+  )
+
   ipcMain.handle('git:checkout', async (_event, payload: { repoRoot: string; branch: string }) => {
     const result = await GitRepository.checkout(payload.repoRoot, payload.branch)
     return unwrapOrThrow(result, gitErrorMessage)
@@ -1005,6 +1456,55 @@ export function registerIpcHandlers(
     async (_event, payload: { repoRoot: string; name: string; force: boolean }) => {
       const result = await GitRepository.deleteBranch(payload.repoRoot, payload.name, payload.force)
       return unwrapOrThrow(result, gitErrorMessage)
+    },
+  )
+
+  ipcMain.handle(
+    'git:branchPrepareDelete',
+    async (
+      event,
+      payload: GitBranchPrepareDeletePayload,
+    ): Promise<GitBranchPrepareDeleteResult> => {
+      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const branchMerged = unwrapOrThrow(
+        await GitRepository.isBranchMerged(resolvedRepo, payload.branch),
+        gitErrorMessage,
+      )
+      const warnings = branchMerged ? [] : ['Branch has not been fully merged.']
+
+      return {
+        branchMerged,
+        forceRequired: !branchMerged,
+        warnings,
+      }
+    },
+  )
+
+  ipcMain.handle(
+    'git:branchDeleteWithPreflight',
+    async (
+      event,
+      payload: GitBranchDeleteWithPreflightPayload,
+    ): Promise<GitBranchDeleteWithPreflightResult> => {
+      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const branchMerged = unwrapOrThrow(
+        await GitRepository.isBranchMerged(resolvedRepo, payload.branch),
+        gitErrorMessage,
+      )
+      const forceDelete = !branchMerged && Boolean(payload.forceIfUnmerged)
+
+      if (!branchMerged && !forceDelete) {
+        throw new Error('Branch has not been fully merged.')
+      }
+
+      const result = await GitRepository.deleteBranch(resolvedRepo, payload.branch, forceDelete)
+      unwrapOrThrow(result, gitErrorMessage)
+
+      return {
+        branchDeleted: true,
+        forcedBranchDelete: forceDelete,
+        branchMerged,
+      }
     },
   )
 
@@ -1023,6 +1523,26 @@ export function registerIpcHandlers(
   ipcMain.handle('git:pushInfo', async (_event, payload: { repoRoot: string }) => {
     return GitRepository.getPushInfo(payload.repoRoot).unwrapOr(null)
   })
+
+  ipcMain.handle(
+    'git:preparePush',
+    async (event, payload: { repoRoot: string }): Promise<GitPreparePushResult> => {
+      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const info = await GitRepository.getPushInfo(resolvedRepo).unwrapOr(null)
+      if (!info) {
+        return {
+          hasUpstream: false,
+          confirmationMessage: 'No upstream branch — push and set tracking to origin?',
+        }
+      }
+
+      return {
+        hasUpstream: true,
+        ...info,
+        confirmationMessage: `Push ${info.commitCount} commit(s) to ${info.remote}/${info.branch}?`,
+      }
+    },
+  )
 
   ipcMain.handle(
     'git:branchMerged',
@@ -1079,12 +1599,176 @@ export function registerIpcHandlers(
   )
 
   ipcMain.handle(
+    'worktree:create',
+    async (event, payload: WorktreeCreatePayload): Promise<WorktreeCreateResult> => {
+      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const expandedPath = payload.worktreePath.startsWith('~/')
+        ? os.homedir() + payload.worktreePath.slice(1)
+        : payload.worktreePath
+      const worktreePath = await validateWorktreeCreationPath(event.sender.id, expandedPath)
+
+      if (payload.mode === 'new') {
+        const result = await GitRepository.worktreeAdd(
+          resolvedRepo,
+          worktreePath,
+          payload.branch,
+          payload.baseBranch,
+        )
+        unwrapOrThrow(result, gitErrorMessage)
+      } else {
+        const result = await GitRepository.worktreeAddCheckout(
+          resolvedRepo,
+          worktreePath,
+          payload.branch,
+          payload.createLocalTracking ?? false,
+        )
+        unwrapOrThrow(result, gitErrorMessage)
+      }
+
+      return { branch: payload.branch, worktreePath }
+    },
+  )
+
+  ipcMain.handle(
     'git:worktreeRemove',
     async (event, payload: { repoRoot: string; path: string; force: boolean }) => {
       const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
       const resolvedTarget = await validateWorktreeExistingPath(event.sender.id, payload.path)
       const result = await GitRepository.worktreeRemove(resolvedRepo, resolvedTarget, payload.force)
       return unwrapOrThrow(result, gitErrorMessage)
+    },
+  )
+
+  ipcMain.handle(
+    'worktree:prepareRemove',
+    async (event, payload: WorktreePrepareRemovePayload): Promise<WorktreePrepareRemoveResult> => {
+      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedTarget = await validateWorktreeExistingPath(
+        event.sender.id,
+        payload.worktreePath,
+      )
+      const isDetached = payload.branch === '(detached)'
+
+      const statusResult = await GitRepository.getStatusPorcelain(resolvedRepo, resolvedTarget)
+      const status = unwrapOrThrow(statusResult, gitErrorMessage)
+      const hasUncommittedChanges = status.trim().length > 0
+
+      const unmergedCommits = isDetached
+        ? []
+        : unwrapOrThrow(
+            await GitRepository.getUnmergedCommits(resolvedRepo, payload.branch),
+            gitErrorMessage,
+          )
+      const branchMerged = isDetached
+        ? false
+        : unwrapOrThrow(
+            await GitRepository.isBranchMerged(resolvedRepo, payload.branch),
+            gitErrorMessage,
+          )
+
+      const warnings: string[] = []
+      if (hasUncommittedChanges) warnings.push('Has uncommitted changes.')
+      if (unmergedCommits.length > 0) {
+        warnings.push(`${unmergedCommits.length} unmerged commit(s) not on any remote.`)
+      }
+
+      return {
+        hasUncommittedChanges,
+        unmergedCommitCount: unmergedCommits.length,
+        branchMerged,
+        forceRequired: warnings.length > 0,
+        canDeleteBranch: !isDetached && branchMerged,
+        warnings,
+      }
+    },
+  )
+
+  ipcMain.handle(
+    'worktree:getMergedBranches',
+    async (
+      event,
+      payload: WorktreeGetMergedBranchesPayload,
+    ): Promise<WorktreeGetMergedBranchesResult> => {
+      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const requestedBranches = Array.from(
+        new Set(payload.branches.filter((branch) => branch && branch !== '(detached)')),
+      )
+      if (requestedBranches.length === 0) return { mergedBranches: [] }
+
+      const mergedBranches = unwrapOrThrow(
+        await GitRepository.getMergedBranches(resolvedRepo),
+        gitErrorMessage,
+      )
+      const mergedSet = new Set(mergedBranches)
+
+      return {
+        mergedBranches: requestedBranches.filter((branch) => mergedSet.has(branch)),
+      }
+    },
+  )
+
+  ipcMain.handle('worktree:listBranches', async (event, payload: { repoRoot: string }) => {
+    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    return unwrapOrThrow(await GitRepository.listBranches(resolvedRepo), gitErrorMessage)
+  })
+
+  ipcMain.handle('worktree:refreshBranches', async (event, payload: { repoRoot: string }) => {
+    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    unwrapOrThrow(await GitRepository.fetchAll(resolvedRepo), gitErrorMessage)
+    return unwrapOrThrow(await GitRepository.listBranches(resolvedRepo), gitErrorMessage)
+  })
+
+  ipcMain.handle(
+    'worktree:removeWithBranch',
+    async (
+      event,
+      payload: WorktreeRemoveWithBranchPayload,
+    ): Promise<WorktreeRemoveWithBranchResult> => {
+      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedTarget = await validateWorktreeExistingPath(
+        event.sender.id,
+        payload.worktreePath,
+      )
+      const forceOnFailure = payload.forceOnFailure ?? false
+      const shouldDeleteBranch =
+        payload.deleteBranch ?? Boolean(payload.branch && payload.branch !== '(detached)')
+
+      let forcedWorktreeRemove = false
+      try {
+        const result = await GitRepository.worktreeRemove(resolvedRepo, resolvedTarget, false)
+        unwrapOrThrow(result, gitErrorMessage)
+      } catch (e) {
+        if (!forceOnFailure) throw e
+        const forcedResult = await GitRepository.worktreeRemove(resolvedRepo, resolvedTarget, true)
+        unwrapOrThrow(forcedResult, gitErrorMessage)
+        forcedWorktreeRemove = true
+      }
+
+      let branchDeleted = false
+      let forcedBranchDelete = false
+      if (shouldDeleteBranch) {
+        if (!payload.branch || payload.branch === '(detached)') {
+          throw new Error('Branch name is required when deleteBranch is true')
+        }
+        try {
+          const result = await GitRepository.deleteBranch(resolvedRepo, payload.branch, false)
+          unwrapOrThrow(result, gitErrorMessage)
+          branchDeleted = true
+        } catch (e) {
+          if (!forceOnFailure) throw e
+          const forcedResult = await GitRepository.deleteBranch(resolvedRepo, payload.branch, true)
+          unwrapOrThrow(forcedResult, gitErrorMessage)
+          branchDeleted = true
+          forcedBranchDelete = true
+        }
+      }
+
+      return {
+        worktreeRemoved: true,
+        branchDeleted,
+        forcedWorktreeRemove,
+        forcedBranchDelete,
+      }
     },
   )
 
@@ -1112,6 +1796,32 @@ export function registerIpcHandlers(
     if (filePath.startsWith('/')) throw new Error('Invalid file path: must be relative')
     if (filePath.includes('..')) throw new Error('Invalid file path: must not contain ..')
   }
+
+  ipcMain.handle('changes:getDiff', async (event, payload: { worktreePath: string }) => {
+    const resolvedWorktree = await validatePathAccess(event.sender.id, payload.worktreePath)
+    const result = await GitRepository.getDiffParsed(resolvedWorktree)
+    return result.unwrapOr({ files: [] })
+  })
+
+  ipcMain.handle(
+    'changes:stageFile',
+    async (event, payload: { worktreePath: string; filePath: string }) => {
+      const resolvedWorktree = await validatePathAccess(event.sender.id, payload.worktreePath)
+      validateFilePath(payload.filePath)
+      const result = await GitRepository.stageFile(resolvedWorktree, payload.filePath)
+      return unwrapOrThrow(result, gitErrorMessage)
+    },
+  )
+
+  ipcMain.handle(
+    'changes:revertFile',
+    async (event, payload: { worktreePath: string; filePath: string }) => {
+      const resolvedWorktree = await validatePathAccess(event.sender.id, payload.worktreePath)
+      validateFilePath(payload.filePath)
+      const result = await GitRepository.revertFile(resolvedWorktree, payload.filePath)
+      return unwrapOrThrow(result, gitErrorMessage)
+    },
+  )
 
   ipcMain.handle(
     'git:diffFile',
@@ -1475,8 +2185,11 @@ export function registerIpcHandlers(
     return resolved
   }
 
-  ipcMain.handle('fs:readDir', async (event, payload: { dirPath: string }) => {
-    const resolved = await validatePathAccess(event.sender.id, payload.dirPath)
+  async function readFileTreeDir(
+    webContentsId: number,
+    dirPath: string,
+  ): Promise<Array<{ name: string; isDirectory: boolean; size: number }>> {
+    const resolved = await validatePathAccess(webContentsId, dirPath)
     const entries = await fs.promises.readdir(resolved, { withFileTypes: true })
     const ignorePatterns = getIgnorePatterns()
     const filtered = entries.filter((e) => !isIgnoredEntry(e.name, ignorePatterns))
@@ -1501,6 +2214,69 @@ export function registerIpcHandlers(
         if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
         return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
       })
+  }
+
+  ipcMain.handle('fileTree:readDir', async (event, payload: { dirPath: string }) => {
+    return readFileTreeDir(event.sender.id, payload.dirPath)
+  })
+
+  function parseFileTreeGitStatus(porcelain: string): {
+    statuses: Record<string, string>
+    affectedPaths: string[]
+    changedDirs: string[]
+  } {
+    const statuses: Record<string, string> = {}
+    const affectedPaths = new Set<string>()
+    const changedDirs = new Set<string>()
+
+    const collectPath = (rawPath: string): void => {
+      const normalized = rawPath.trim()
+      if (!normalized) return
+      affectedPaths.add(normalized)
+
+      const segments = normalized.split('/')
+      let dir = ''
+      for (let i = 0; i < segments.length - 1; i++) {
+        dir = dir === '' ? segments[i] : `${dir}/${segments[i]}`
+        changedDirs.add(dir)
+      }
+    }
+
+    for (const line of porcelain.split('\n')) {
+      if (line.length < 4) continue
+      const xy = line.substring(0, 2)
+      const filePath = line.substring(3)
+      const status = xy[0] !== ' ' && xy[0] !== '?' ? xy[0] : xy[1]
+      statuses[filePath] = status === '?' ? '?' : status
+      for (const part of filePath.split(' -> ')) collectPath(part)
+    }
+
+    return {
+      statuses,
+      affectedPaths: [...affectedPaths].sort(),
+      changedDirs: [...changedDirs].sort(),
+    }
+  }
+
+  ipcMain.handle(
+    'fileTree:getGitStatus',
+    async (
+      event,
+      payload: { repoRoot: string; worktreePath: string },
+    ): Promise<{
+      statuses: Record<string, string>
+      affectedPaths: string[]
+      changedDirs: string[]
+    }> => {
+      const repoRoot = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const worktreePath = await validatePathAccess(event.sender.id, payload.worktreePath)
+      const porcelain = await GitRepository.getStatusPorcelain(repoRoot, worktreePath).unwrapOr('')
+      return parseFileTreeGitStatus(porcelain)
+    },
+  )
+
+  ipcMain.handle('fs:readDir', async (event, payload: { dirPath: string }) => {
+    return readFileTreeDir(event.sender.id, payload.dirPath)
   })
 
   ipcMain.handle('fs:readFile', async (event, payload: { filePath: string; maxBytes?: number }) => {
@@ -1642,28 +2418,12 @@ export function registerIpcHandlers(
       event,
       payload: { filePath: string; content: string; expectedMtimeMs?: number },
     ): Promise<FsWriteFileResponse> => {
-      const resolved = await validatePathAccess(event.sender.id, payload.filePath)
-      // Structured response instead of a thrown Error — keeps the typed
-      // `_tag` discriminant intact across IPC so the renderer branches on
-      // `result.tag` instead of string-matching a flattened message.
-      if (payload.expectedMtimeMs !== undefined) {
-        const statResult = await fromExternalCall(fs.promises.stat(resolved), errorMessage)
-        if (statResult.isErr()) return { ok: false, tag: 'StatFailed', message: statResult.error }
-        const actualMtimeMs = statResult.value.mtimeMs
-        if (Math.abs(actualMtimeMs - payload.expectedMtimeMs) > 1) {
-          return { ok: false, tag: 'StaleWrite', actualMtimeMs }
-        }
-      }
-      const writeResult = await fromExternalCall(
-        fs.promises.writeFile(resolved, payload.content, 'utf-8'),
-        errorMessage,
+      return writeTextFileWithExpectedMtime(
+        event.sender.id,
+        payload.filePath,
+        payload.content,
+        payload.expectedMtimeMs,
       )
-      if (writeResult.isErr()) {
-        return { ok: false, tag: 'WriteFailed', message: writeResult.error }
-      }
-      const finalStat = await fromExternalCall(fs.promises.stat(resolved), errorMessage)
-      if (finalStat.isErr()) return { ok: false, tag: 'StatFailed', message: finalStat.error }
-      return { ok: true, mtimeMs: finalStat.value.mtimeMs, size: finalStat.value.size }
     },
   )
 
@@ -1776,8 +2536,8 @@ export function registerIpcHandlers(
     return resolved
   }
 
-  ipcMain.handle('fs:createFile', async (event, payload: { filePath: string }): Promise<void> => {
-    const resolved = await validateCreationPath(event.sender.id, payload.filePath)
+  async function createFileTreeFile(webContentsId: number, filePath: string): Promise<void> {
+    const resolved = await validateCreationPath(webContentsId, filePath)
     // Ensure the parent dir exists (handles nested paths typed in the prompt
     // like "subdir/newfile.ts" — creates "subdir" if missing).
     await fs.promises.mkdir(path.dirname(resolved), { recursive: true })
@@ -1785,35 +2545,39 @@ export function registerIpcHandlers(
     // anything the user typed by accident.
     const handle = await fs.promises.open(resolved, 'wx')
     await handle.close()
+  }
+
+  async function createFileTreeDirectory(webContentsId: number, dirPath: string): Promise<void> {
+    const resolved = await validateCreationPath(webContentsId, dirPath)
+    await fs.promises.mkdir(resolved, { recursive: true })
+  }
+
+  ipcMain.handle(
+    'fileTree:createFile',
+    async (event, payload: { filePath: string }): Promise<void> => {
+      await createFileTreeFile(event.sender.id, payload.filePath)
+    },
+  )
+
+  ipcMain.handle(
+    'fileTree:createDirectory',
+    async (event, payload: { dirPath: string }): Promise<void> => {
+      await createFileTreeDirectory(event.sender.id, payload.dirPath)
+    },
+  )
+
+  ipcMain.handle('fs:createFile', async (event, payload: { filePath: string }): Promise<void> => {
+    await createFileTreeFile(event.sender.id, payload.filePath)
   })
 
   ipcMain.handle('fs:mkdir', async (event, payload: { dirPath: string }): Promise<void> => {
-    const resolved = await validateCreationPath(event.sender.id, payload.dirPath)
-    await fs.promises.mkdir(resolved, { recursive: true })
+    await createFileTreeDirectory(event.sender.id, payload.dirPath)
   })
 
   ipcMain.handle(
     'dialog:confirmUnsavedChanges',
     async (event, payload: { filePaths: string[] }): Promise<'save' | 'discard' | 'cancel'> => {
-      const win = BrowserWindow.fromWebContents(event.sender) ?? BrowserWindow.getFocusedWindow()
-      if (!win) return 'cancel'
-      const fileList =
-        payload.filePaths.length === 1
-          ? payload.filePaths[0].split('/').pop()
-          : `${payload.filePaths.length} files`
-      const { response } = await dialog.showMessageBox(win, {
-        type: 'warning',
-        buttons: ['Save', "Don't Save", 'Cancel'],
-        defaultId: 0,
-        cancelId: 2,
-        title: 'Unsaved changes',
-        message: `You have unsaved changes in ${fileList}`,
-        detail: 'Do you want to save them before closing?',
-      })
-      return match(response)
-        .with(0, () => 'save' as const)
-        .with(1, () => 'discard' as const)
-        .otherwise(() => 'cancel' as const)
+      return confirmUnsavedChangesDialog(event.sender, payload.filePaths)
     },
   )
 
@@ -1930,6 +2694,26 @@ export function registerIpcHandlers(
       repo = result.unwrapOr(null)
     }
     return mergeConfigs(global, repo)
+  }
+
+  async function resolveTaskTrackerBranchName(
+    payload: TaskTrackerBranchFromTaskPayload,
+  ): Promise<string> {
+    const resolved = await resolveEffectiveConfig(payload.repoRoot)
+    const branchTpl = resolved
+      ? getBranchTemplate(resolved.config, payload.boardId)
+      : { template: '{taskKey}', customVars: {} }
+
+    const sprint = resolved
+      ? await taskTrackerManager
+          .getCurrentSprintFromConfig(resolved.config, payload.boardId, payload.repoRoot)
+          .unwrapOr(null)
+      : await taskTrackerManager
+          .getCurrentSprint(payload.connectionId, payload.boardId)
+          .unwrapOr(null)
+
+    const variables = buildVariables(payload.task, sprint, branchTpl.customVars, payload.branchType)
+    return renderBranchName(branchTpl.template, variables)
   }
 
   ipcMain.handle('tracker:resolvedConfig', async (_event, payload: { repoRoot?: string }) => {
@@ -2190,13 +2974,13 @@ export function registerIpcHandlers(
     'trackerConfig:fetchBoards',
     async (_event, payload: { repoRoot?: string; trackerId?: string }) => {
       const resolved = await resolveEffectiveConfig(payload.repoRoot)
-      if (!resolved) throw new Error('No tracker configured')
+      if (!resolved) return []
       const result = await taskTrackerManager.fetchBoardsFromConfig(
         resolved.config,
         payload.trackerId,
         payload.repoRoot,
       )
-      return unwrapOrThrow(result, taskTrackerErrorMessage)
+      return result.unwrapOr([])
     },
   )
 
@@ -2380,6 +3164,118 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle(
+    'taskTracker:buildTaskContext',
+    async (_event, payload: TaskTrackerBuildTaskContextPayload) => {
+      const resolved = await resolveEffectiveConfig(payload.repoRoot)
+      const hasConfigTracker = Boolean(resolved?.config.trackers.length)
+
+      let fullTask: TrackerTask | null = null
+      if (hasConfigTracker && resolved) {
+        const result = await taskTrackerManager.findTaskByKeyFromConfig(
+          resolved.config,
+          payload.task.key,
+          payload.trackerId,
+          payload.repoRoot,
+        )
+        if (result.isOk()) fullTask = result.value
+      }
+      if (!fullTask) {
+        fullTask = await taskTrackerManager.findTaskByKey(payload.task.key).catch(() => null)
+      }
+
+      let comments: Array<{ author: string; body: string; created: string }> = []
+      if (hasConfigTracker && resolved) {
+        const result = await taskTrackerManager.fetchTaskCommentsFromConfig(
+          resolved.config,
+          payload.task.key,
+          payload.trackerId,
+          payload.repoRoot,
+        )
+        if (result.isOk()) comments = result.value
+      }
+      if (comments.length === 0) {
+        const result = await taskTrackerManager.fetchTaskComments(
+          payload.connectionId,
+          payload.task.key,
+          payload.repoRoot,
+        )
+        comments = result.unwrapOr([])
+      }
+
+      let rawAttachments: Array<{ name: string; url: string }> = []
+      if (hasConfigTracker && resolved) {
+        const result = await taskTrackerManager.fetchTaskAttachmentsFromConfig(
+          resolved.config,
+          payload.task.key,
+          payload.trackerId,
+          payload.repoRoot,
+        )
+        if (result.isOk()) rawAttachments = result.value
+      }
+      if (rawAttachments.length === 0) {
+        const result = await taskTrackerManager.fetchTaskAttachments(
+          payload.connectionId,
+          payload.task.key,
+        )
+        rawAttachments = result.unwrapOr([])
+      }
+
+      const attachments: TaskAttachmentPath[] = []
+      const failedAttachments: string[] = []
+      const downloadResults = await Promise.allSettled(
+        rawAttachments.map(async (attachment) => {
+          if (hasConfigTracker && resolved) {
+            const configResult = await taskTrackerManager.downloadAttachmentFromConfig(
+              resolved.config,
+              attachment.url,
+              attachment.name,
+              payload.trackerId,
+              payload.repoRoot,
+            )
+            if (configResult.isOk()) {
+              return { name: attachment.name, localPath: configResult.value }
+            }
+          }
+
+          const legacyResult = await taskTrackerManager.downloadAttachment(
+            payload.connectionId,
+            attachment.url,
+            attachment.name,
+          )
+          if (legacyResult.isErr()) {
+            throw new Error(taskTrackerErrorMessage(legacyResult.error))
+          }
+          return { name: attachment.name, localPath: legacyResult.value }
+        }),
+      )
+
+      for (let i = 0; i < downloadResults.length; i++) {
+        const result = downloadResults[i]
+        if (result.status === 'fulfilled') {
+          attachments.push(result.value)
+        } else {
+          failedAttachments.push(rawAttachments[i].name)
+        }
+      }
+
+      if (attachments.length > 0) {
+        const paths = attachments.map((attachment) => attachment.localPath)
+        setTimeout(() => {
+          for (const filePath of paths) {
+            taskTrackerManager.cleanupAttachmentDir(filePath)
+          }
+        }, 60_000)
+      }
+
+      const taskForContext: TaskContextInput = fullTask
+        ? { ...payload.task, description: fullTask.description || payload.task.description }
+        : payload.task
+
+      return formatTaskContext(taskForContext, comments, attachments, failedAttachments)
+    },
+  )
+
+  ipcMain.handle(
     'taskTracker:resolveBranchName',
     async (
       _event,
@@ -2391,27 +3287,59 @@ export function registerIpcHandlers(
         repoRoot?: string
       },
     ) => {
-      const resolved = await resolveEffectiveConfig(payload.repoRoot)
-      const branchTpl = resolved
-        ? getBranchTemplate(resolved.config, payload.boardId)
-        : { template: '{taskKey}', customVars: {} }
+      return resolveTaskTrackerBranchName(payload)
+    },
+  )
 
-      // Get sprint: prefer config-based, fall back to legacy
-      const sprint = resolved
-        ? await taskTrackerManager
-            .getCurrentSprintFromConfig(resolved.config, payload.boardId, payload.repoRoot)
-            .unwrapOr(null)
-        : await taskTrackerManager
-            .getCurrentSprint(payload.connectionId, payload.boardId)
-            .unwrapOr(null)
+  ipcMain.handle(
+    'taskTracker:prepareBranchFromTask',
+    async (event, payload: TaskTrackerBranchFromTaskPayload & { repoRoot: string }) => {
+      const repoRoot = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const branchName = await resolveTaskTrackerBranchName({ ...payload, repoRoot })
+      return { branchName }
+    },
+  )
 
-      const variables = buildVariables(
-        payload.task,
-        sprint,
-        branchTpl.customVars,
-        payload.branchType,
+  ipcMain.handle(
+    'taskTracker:createBranchFromTask',
+    async (event, payload: TaskTrackerCreateBranchFromTaskPayload) => {
+      const repoRoot = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const branchName = await resolveTaskTrackerBranchName({ ...payload, repoRoot })
+
+      if (payload.stashBeforeCreate) {
+        const stashResult = await GitRepository.stash(repoRoot)
+        unwrapOrThrow(stashResult, gitErrorMessage)
+      }
+
+      const createResult = await GitRepository.createBranch(
+        repoRoot,
+        branchName,
+        payload.baseBranch,
       )
-      return renderBranchName(branchTpl.template, variables)
+      unwrapOrThrow(createResult, gitErrorMessage)
+
+      return { branchName }
+    },
+  )
+
+  ipcMain.handle(
+    'taskTracker:createWorktreeFromTask',
+    async (event, payload: TaskTrackerCreateWorktreeFromTaskPayload) => {
+      const repoRoot = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const expandedPath = payload.worktreePath.startsWith('~/')
+        ? os.homedir() + payload.worktreePath.slice(1)
+        : payload.worktreePath
+      const worktreePath = await validateWorktreeCreationPath(event.sender.id, expandedPath)
+      const branchName = await resolveTaskTrackerBranchName({ ...payload, repoRoot })
+      const result = await GitRepository.worktreeAdd(
+        repoRoot,
+        worktreePath,
+        branchName,
+        payload.baseBranch,
+      )
+      unwrapOrThrow(result, gitErrorMessage)
+
+      return { branchName, worktreePath }
     },
   )
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -428,22 +428,22 @@ export function registerIpcHandlers(
     const readLimit = Math.min(maxBytes ?? 1_048_576, 10_485_760)
     let stat: fs.Stats
     try {
-      stat = fs.statSync(resolved)
+      stat = await fs.promises.stat(resolved)
     } catch (e) {
       return { ok: false, tag: 'StatFailed', message: errorMessage(e) }
     }
 
     let canWrite = true
     try {
-      fs.accessSync(resolved, fs.constants.W_OK)
+      await fs.promises.access(resolved, fs.constants.W_OK)
     } catch {
       canWrite = false
     }
 
     const readSize = Math.min(stat.size, readLimit)
-    let fd: number
+    let fileHandle: Awaited<ReturnType<typeof fs.promises.open>>
     try {
-      fd = fs.openSync(resolved, 'r')
+      fileHandle = await fs.promises.open(resolved, 'r')
     } catch (e) {
       return { ok: false, tag: 'ReadFailed', message: errorMessage(e) }
     }
@@ -452,7 +452,7 @@ export function registerIpcHandlers(
       const buf = Buffer.alloc(readSize)
       let offset = 0
       while (offset < readSize) {
-        const bytesRead = fs.readSync(fd, buf, offset, readSize - offset, offset)
+        const { bytesRead } = await fileHandle.read(buf, offset, readSize - offset, offset)
         if (bytesRead === 0) break
         offset += bytesRead
       }
@@ -484,7 +484,7 @@ export function registerIpcHandlers(
     } catch (e) {
       return { ok: false, tag: 'ReadFailed', message: errorMessage(e) }
     } finally {
-      fs.closeSync(fd)
+      await fileHandle.close().catch(() => undefined)
     }
   }
 
@@ -632,6 +632,9 @@ export function registerIpcHandlers(
   )
   ipcMain.handle('tab:command:prepareCloseTab', (event, payload) =>
     tabCommandService.prepareCloseTab(event.sender, payload),
+  )
+  ipcMain.handle('tab:command:prepareCloseAllForWorktree', (event, payload) =>
+    tabCommandService.prepareCloseAllForWorktree(event.sender, payload),
   )
   ipcMain.handle('tab:command:getCloseWarning', (event, payload) =>
     tabCommandService.getCloseWarning(event.sender, payload),
@@ -3165,8 +3168,18 @@ export function registerIpcHandlers(
 
   ipcMain.handle(
     'taskTracker:buildTaskContext',
-    async (_event, payload: TaskTrackerBuildTaskContextPayload) => {
-      const resolved = await resolveEffectiveConfig(payload.repoRoot)
+    async (event, payload: TaskTrackerBuildTaskContextPayload) => {
+      if (
+        !payload?.task ||
+        typeof payload.task.key !== 'string' ||
+        !TASK_KEY_RE.test(payload.task.key)
+      ) {
+        throw new Error('Invalid task key')
+      }
+      const repoRoot = payload.repoRoot
+        ? await validatePathAccess(event.sender.id, payload.repoRoot)
+        : undefined
+      const resolved = await resolveEffectiveConfig(repoRoot)
       const hasConfigTracker = Boolean(resolved?.config.trackers.length)
 
       let fullTask: TrackerTask | null = null
@@ -3175,7 +3188,7 @@ export function registerIpcHandlers(
           resolved.config,
           payload.task.key,
           payload.trackerId,
-          payload.repoRoot,
+          repoRoot,
         )
         if (result.isOk()) fullTask = result.value
       }
@@ -3189,7 +3202,7 @@ export function registerIpcHandlers(
           resolved.config,
           payload.task.key,
           payload.trackerId,
-          payload.repoRoot,
+          repoRoot,
         )
         if (result.isOk()) comments = result.value
       }
@@ -3197,7 +3210,7 @@ export function registerIpcHandlers(
         const result = await taskTrackerManager.fetchTaskComments(
           payload.connectionId,
           payload.task.key,
-          payload.repoRoot,
+          repoRoot,
         )
         comments = result.unwrapOr([])
       }
@@ -3208,7 +3221,7 @@ export function registerIpcHandlers(
           resolved.config,
           payload.task.key,
           payload.trackerId,
-          payload.repoRoot,
+          repoRoot,
         )
         if (result.isOk()) rawAttachments = result.value
       }
@@ -3230,7 +3243,7 @@ export function registerIpcHandlers(
               attachment.url,
               attachment.name,
               payload.trackerId,
-              payload.repoRoot,
+              repoRoot,
             )
             if (configResult.isOk()) {
               return { name: attachment.name, localPath: configResult.value }

--- a/src/main/pty/PtyManager.ts
+++ b/src/main/pty/PtyManager.ts
@@ -1,7 +1,7 @@
 import * as pty from 'node-pty'
 import type { IPty } from 'node-pty'
 import { randomUUID } from 'crypto'
-import { execFile } from 'child_process'
+import { execFile, execFileSync } from 'child_process'
 import os from 'os'
 import { getLoginEnv } from '../shell/loginEnv'
 
@@ -9,6 +9,10 @@ interface PtySession {
   id: string
   pty: IPty
   tmuxSessionName?: string
+}
+
+interface KillOptions {
+  killProcessTree?: boolean
 }
 
 export interface SpawnOptions {
@@ -133,9 +137,12 @@ export class PtyManager {
     }
   }
 
-  kill(id: string): void {
+  kill(id: string, options?: KillOptions): void {
     const session = this.sessions.get(id)
     if (session) {
+      if (options?.killProcessTree) {
+        this.terminateProcessTree(session.pty.pid)
+      }
       try {
         session.pty.kill()
       } catch {
@@ -171,12 +178,69 @@ export class PtyManager {
 
   dispose(): void {
     for (const [id, session] of this.sessions) {
+      this.terminateProcessTree(session.pty.pid)
       try {
         session.pty.kill()
       } catch {
         // PTY already exited — ignore
       }
       this.sessions.delete(id)
+    }
+  }
+
+  private terminateProcessTree(pid: number): void {
+    if (!Number.isFinite(pid) || pid <= 0) return
+
+    if (process.platform === 'win32') {
+      try {
+        execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+          stdio: 'ignore',
+          timeout: 2000,
+        })
+      } catch {
+        // Process may already be gone.
+      }
+      return
+    }
+
+    const pids = [...this.collectDescendantPids(pid), pid]
+    for (const targetPid of pids) {
+      this.signalPid(targetPid, 'SIGTERM')
+    }
+
+    const forceKill = setTimeout(() => {
+      for (const targetPid of pids) {
+        this.signalPid(targetPid, 'SIGKILL')
+      }
+    }, 750)
+    forceKill.unref?.()
+  }
+
+  private collectDescendantPids(pid: number): number[] {
+    const children = this.collectChildPids(pid)
+    return children.flatMap((childPid) => [...this.collectDescendantPids(childPid), childPid])
+  }
+
+  private collectChildPids(pid: number): number[] {
+    try {
+      return execFileSync('pgrep', ['-P', String(pid)], {
+        encoding: 'utf-8',
+        timeout: 1000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+        .split(/\s+/)
+        .map((value) => Number(value))
+        .filter((value) => Number.isInteger(value) && value > 0)
+    } catch {
+      return []
+    }
+  }
+
+  private signalPid(pid: number, signal: NodeJS.Signals): void {
+    try {
+      process.kill(pid, signal)
+    } catch {
+      // Process may already be gone or owned by another user.
     }
   }
 }

--- a/src/main/pty/WsBridge.ts
+++ b/src/main/pty/WsBridge.ts
@@ -74,6 +74,11 @@ export class WsBridge {
     return `ws://127.0.0.1:${port}/${encodeURIComponent(sessionId)}`
   }
 
+  getUrl(sessionId: string): string | null {
+    if (!this.bridges.has(sessionId) || this.port <= 0) return null
+    return `ws://127.0.0.1:${this.port}/${encodeURIComponent(sessionId)}`
+  }
+
   /** Terminate all WS clients across all bridges (triggers renderer reconnection) */
   disconnectAllClients(): void {
     for (const bridge of this.bridges.values()) {

--- a/src/main/taskTracker/taskContext.ts
+++ b/src/main/taskTracker/taskContext.ts
@@ -1,4 +1,4 @@
-interface TaskContextInput {
+export interface TaskContextInput {
   key: string
   summary: string
   description: string
@@ -8,19 +8,17 @@ interface TaskContextInput {
   url?: string
 }
 
-interface TaskComment {
+export interface TaskComment {
   author: string
   body: string
   created: string
 }
 
-interface TaskAttachmentPath {
+export interface TaskAttachmentPath {
   name: string
   localPath: string
 }
 
-// Description and comment bodies are sent without a character cap — the agent manages
-// its own context window and will summarise or ignore content as needed.
 const MAX_COMMENTS = 15
 
 function normalizeTaskText(text: string): string {
@@ -87,8 +85,8 @@ export function formatTaskContext(
   ) {
     lines.push('', '## Attachments')
     if (attachments) {
-      for (const a of attachments) {
-        lines.push(`@${a.localPath}`)
+      for (const attachment of attachments) {
+        lines.push(`@${attachment.localPath}`)
       }
     }
     if (failedAttachments && failedAttachments.length > 0) {
@@ -97,60 +95,4 @@ export function formatTaskContext(
   }
 
   return lines.join('\n')
-}
-
-export async function fetchAndFormatTaskContext(
-  connectionId: string,
-  task: TaskContextInput,
-  repoRoot?: string,
-): Promise<string> {
-  const [fullTask, comments, rawAttachments] = await Promise.all([
-    // Re-fetch full task to get description (list fetch omits it for performance)
-    window.api
-      .trackerConfigFindTaskByKey(repoRoot, task.key, connectionId)
-      .catch(() => window.api.taskTrackerFindTaskByKey(task.key).catch(() => null)),
-    window.api
-      .trackerConfigFetchTaskComments(repoRoot, task.key, connectionId)
-      .catch(() => window.api.taskTrackerFetchTaskComments(connectionId, task.key).catch(() => [])),
-    window.api
-      .trackerConfigFetchTaskAttachments(repoRoot, task.key, connectionId)
-      .catch(() =>
-        window.api.taskTrackerFetchTaskAttachments(connectionId, task.key).catch(() => []),
-      ),
-  ])
-
-  const resolvedTask: TaskContextInput = fullTask
-    ? { ...task, description: fullTask.description || task.description }
-    : task
-
-  const attachments: TaskAttachmentPath[] = []
-  const failedAttachments: string[] = []
-  const downloadResults = await Promise.allSettled(
-    rawAttachments.map(async (a) => {
-      const localPath = await window.api
-        .trackerConfigDownloadAttachment(repoRoot, a.url, a.name, connectionId)
-        .catch(() => window.api.taskTrackerDownloadAttachment(connectionId, a.url, a.name))
-      return { name: a.name, localPath }
-    }),
-  )
-  for (let i = 0; i < downloadResults.length; i++) {
-    const result = downloadResults[i]
-    if (result.status === 'fulfilled') {
-      attachments.push(result.value)
-    } else {
-      failedAttachments.push(rawAttachments[i].name)
-    }
-  }
-
-  const context = formatTaskContext(resolvedTask, comments, attachments, failedAttachments)
-
-  // Schedule cleanup of downloaded attachment files
-  if (attachments.length > 0) {
-    const paths = attachments.map((a) => a.localPath)
-    setTimeout(() => {
-      window.api.taskTrackerCleanupAttachments(paths).catch(() => {})
-    }, 60_000)
-  }
-
-  return context
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -8,6 +8,7 @@ import type {
   EditorFileSnapshot,
   RunConfigCommandResult,
   RunConfigProcessSnapshot,
+  TabCloseAllPreflightResult,
   TabClosePreflightResult,
   TabCommandResult,
   TabStateSnapshot,
@@ -542,6 +543,10 @@ interface CanopyAPI {
   ) => Promise<TabCommandResult>
   tabCloseTab: (worktreePath: string, tabId: string) => Promise<TabCommandResult>
   tabPrepareCloseTab: (worktreePath: string, tabId: string) => Promise<TabClosePreflightResult>
+  tabPrepareCloseAllForWorktree: (
+    worktreePath: string,
+    options?: { confirmedActiveProcesses?: boolean },
+  ) => Promise<TabCloseAllPreflightResult>
   tabGetCloseWarning: (
     worktreePath: string,
     target: CloseWarningTarget,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,9 +1,16 @@
 import type {
   AgentCommandResult,
+  AppStateSnapshot,
+  CloseWarningResult,
+  CloseWarningTarget,
+  EditorFileLoadResult,
+  EditorFileSaveResult,
+  EditorFileSnapshot,
   RunConfigCommandResult,
   RunConfigProcessSnapshot,
-  TabSnapshot,
+  TabClosePreflightResult,
   TabCommandResult,
+  TabStateSnapshot,
   WorkspaceCommandResult,
 } from '../main/commands/types'
 
@@ -100,10 +107,106 @@ interface GitPushInfo {
   commitCount: number
 }
 
+type GitPreparePushResult =
+  | {
+      hasUpstream: false
+      confirmationMessage: string
+    }
+  | {
+      hasUpstream: true
+      branch: string
+      remote: string
+      commitCount: number
+      confirmationMessage: string
+    }
+
 interface GitBranchList {
   local: string[]
   remote: string[]
   current: string | null
+}
+
+interface WorktreeRemoveWithBranchInput {
+  repoRoot: string
+  worktreePath: string
+  branch?: string
+  deleteBranch?: boolean
+  forceOnFailure?: boolean
+}
+
+interface WorktreePrepareRemoveInput {
+  repoRoot: string
+  worktreePath: string
+  branch: string
+}
+
+interface WorktreePrepareRemoveResult {
+  hasUncommittedChanges: boolean
+  unmergedCommitCount: number
+  branchMerged: boolean
+  forceRequired: boolean
+  canDeleteBranch: boolean
+  warnings: string[]
+}
+
+interface WorktreeGetMergedBranchesInput {
+  repoRoot: string
+  branches: string[]
+}
+
+interface WorktreeGetMergedBranchesResult {
+  mergedBranches: string[]
+}
+
+interface GitBranchPrepareDeleteInput {
+  repoRoot: string
+  branch: string
+}
+
+interface GitBranchPrepareDeleteResult {
+  branchMerged: boolean
+  forceRequired: boolean
+  warnings: string[]
+}
+
+interface GitBranchDeleteWithPreflightInput {
+  repoRoot: string
+  branch: string
+  forceIfUnmerged?: boolean
+}
+
+interface GitBranchDeleteWithPreflightResult {
+  branchDeleted: boolean
+  forcedBranchDelete: boolean
+  branchMerged: boolean
+}
+
+type WorktreeCreateInput =
+  | {
+      repoRoot: string
+      worktreePath: string
+      mode: 'new'
+      branch: string
+      baseBranch: string
+    }
+  | {
+      repoRoot: string
+      worktreePath: string
+      mode: 'existing'
+      branch: string
+      createLocalTracking?: boolean
+    }
+
+interface WorktreeCreateResult {
+  branch: string
+  worktreePath: string
+}
+
+interface WorktreeRemoveWithBranchResult {
+  worktreeRemoved: boolean
+  branchDeleted: boolean
+  forcedWorktreeRemove: boolean
+  forcedBranchDelete: boolean
 }
 
 interface AgentHookEventData {
@@ -189,16 +292,10 @@ interface DirEntry {
   size: number
 }
 
-type FileReadResult =
-  | { content: string; truncated: boolean; size: number; binary: false }
-  | { binary: true; size: number }
-
-type FileWriteResult = import('../main/ipc/fsErrors').FsWriteFileResponse
-
-interface FileStatResult {
-  mtimeMs: number
-  size: number
-  canWrite: boolean
+interface FileTreeGitStatus {
+  statuses: Record<string, string>
+  changedDirs: string[]
+  affectedPaths: string[]
 }
 
 interface CanopyAPI {
@@ -256,7 +353,6 @@ interface CanopyAPI {
   resizePty: (sessionId: string, cols: number, rows: number) => Promise<void>
   killPty: (sessionId: string, killTmux?: boolean) => Promise<void>
   writePty: (sessionId: string, data: string) => Promise<void>
-  hasChildProcess: (sessionId: string) => Promise<boolean>
   getPtyDimensions: (sessionId: string) => Promise<{ cols: number; rows: number } | null>
 
   // Tmux
@@ -286,6 +382,14 @@ interface CanopyAPI {
   workspaceDetachProject: (path: string) => Promise<WorkspaceCommandResult>
   workspaceSelectWorktree: (path: string) => Promise<WorkspaceCommandResult>
   workspaceInitGitRepo: (path: string) => Promise<WorkspaceCommandResult>
+  getAppState: () => Promise<AppStateSnapshot>
+  getStartupRestoreState: () => Promise<{ restoring: boolean }>
+  completeStartupRestore: () => Promise<void>
+  onAppStateChanged: (callback: (snapshot: AppStateSnapshot) => void) => () => void
+  fileTreeReadDir: (dirPath: string) => Promise<DirEntry[]>
+  fileTreeCreateFile: (filePath: string) => Promise<void>
+  fileTreeCreateDirectory: (dirPath: string) => Promise<void>
+  fileTreeGetGitStatus: (repoRoot: string, worktreePath: string) => Promise<FileTreeGitStatus>
 
   // Preferences
   getPref: (key: string) => Promise<string | null>
@@ -327,10 +431,106 @@ interface CanopyAPI {
       profileId?: string
       workspaceName?: string
       branch?: string
-      tabs?: TabSnapshot[]
-      activeTabId?: string | null
     },
   ) => Promise<TabCommandResult>
+  tabOpenDiff: (worktreePath: string) => Promise<TabCommandResult>
+  tabOpenSessionTab: (
+    worktreePath: string,
+    name: string,
+    sessionId: string,
+  ) => Promise<TabCommandResult>
+  tabOpenEditorFile: (worktreePath: string, filePath: string) => Promise<TabCommandResult>
+  tabDetachEditorFile: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+  ) => Promise<TabCommandResult>
+  tabCloseEditorFile: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+  ) => Promise<TabCommandResult>
+  tabPrepareCloseEditorFile: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+  ) => Promise<TabClosePreflightResult>
+  tabMoveEditorFile: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    toIndex: number,
+  ) => Promise<TabCommandResult>
+  tabMoveEditorFileBetweenPanes: (
+    worktreePath: string,
+    sourcePaneId: string,
+    targetPaneId: string,
+    filePath: string,
+    toIndex: number,
+  ) => Promise<TabCommandResult>
+  tabSetActiveEditorFile: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+  ) => Promise<TabCommandResult>
+  tabUpdateEditorFileState: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    patch: Partial<EditorFileSnapshot>,
+  ) => Promise<TabCommandResult>
+  tabLoadEditorFile: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    options?: { maxBytes?: number },
+  ) => Promise<EditorFileLoadResult>
+  tabSaveEditorFile: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    options: {
+      content: string
+      fileLineEnding?: 'LF' | 'CRLF'
+      expectedMtimeMs?: number
+    },
+  ) => Promise<EditorFileSaveResult>
+  tabUpdatePaneTitle: (
+    worktreePath: string,
+    sessionId: string,
+    title: string,
+  ) => Promise<TabCommandResult>
+  tabUpdatePaneUrl: (
+    worktreePath: string,
+    sessionId: string,
+    url: string,
+  ) => Promise<TabCommandResult>
+  tabUpdateTmuxSessionName: (
+    worktreePath: string,
+    oldName: string,
+    newName: string,
+  ) => Promise<TabCommandResult>
+  tabHandlePtyExit: (
+    worktreePath: string,
+    sessionId: string,
+    exitCode: number,
+    tmuxSessionName?: string,
+  ) => Promise<TabCommandResult>
+  tabKillTmuxPane: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+  ) => Promise<TabCommandResult>
+  tabReattachTmuxPane: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+    },
+  ) => Promise<TabCommandResult>
+  tabToggleFocusedInspector: (worktreePath: string, tabId: string) => Promise<TabCommandResult>
   tabRestartPane: (
     worktreePath: string,
     tabId: string,
@@ -338,14 +538,50 @@ interface CanopyAPI {
     options?: {
       workspaceName?: string
       branch?: string
-      tabs?: TabSnapshot[]
-      activeTabId?: string | null
     },
   ) => Promise<TabCommandResult>
-  tabCloseTab: (
+  tabCloseTab: (worktreePath: string, tabId: string) => Promise<TabCommandResult>
+  tabPrepareCloseTab: (worktreePath: string, tabId: string) => Promise<TabClosePreflightResult>
+  tabGetCloseWarning: (
     worktreePath: string,
-    tabId: string,
-    options?: { tabs?: TabSnapshot[]; activeTabId?: string | null },
+    target: CloseWarningTarget,
+  ) => Promise<CloseWarningResult>
+  tabReopenClosedTab: (
+    worktreePath: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+    },
+  ) => Promise<TabCommandResult>
+  tabClosePane: (worktreePath: string, tabId: string, paneId: string) => Promise<TabCommandResult>
+  tabCloseAllForWorktree: (worktreePath: string) => Promise<TabCommandResult>
+  tabSetActiveTab: (worktreePath: string, tabId: string) => Promise<TabCommandResult>
+  tabMoveTab: (
+    worktreePath: string,
+    fromIndex: number,
+    toIndex: number,
+  ) => Promise<TabCommandResult>
+  tabMoveTabToSplit: (
+    worktreePath: string,
+    sourceTabId: string,
+    targetTabId: string,
+    targetPaneId: string,
+    direction: 'horizontal' | 'vertical',
+    position: 'first' | 'second',
+  ) => Promise<TabCommandResult>
+  tabMovePaneToTarget: (
+    worktreePath: string,
+    sourceTabId: string,
+    sourcePaneId: string,
+    targetTabId: string,
+    targetPaneId: string,
+    direction: 'horizontal' | 'vertical',
+    position: 'first' | 'second',
+  ) => Promise<TabCommandResult>
+  tabDetachPaneToTab: (
+    worktreePath: string,
+    sourceTabId: string,
+    sourcePaneId: string,
   ) => Promise<TabCommandResult>
   tabSpawnPane: (
     toolId: string,
@@ -358,8 +594,43 @@ interface CanopyAPI {
       resumeSessionId?: string
     },
   ) => Promise<PaneSnapshot>
-  tabSaveLayout: (worktreePath: string, layoutJson: string) => Promise<void>
-  tabDeleteLayout: (worktreePath: string) => Promise<void>
+  tabSplitPane: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+    direction: 'horizontal' | 'vertical',
+  ) => Promise<TabCommandResult>
+  tabFocusPane: (worktreePath: string, tabId: string, paneId: string) => Promise<TabCommandResult>
+  tabNavigatePaneFocus: (
+    worktreePath: string,
+    tabId: string,
+    direction: 'left' | 'right' | 'up' | 'down',
+  ) => Promise<TabCommandResult>
+  tabUpdateSplitRatio: (
+    worktreePath: string,
+    tabId: string,
+    splitId: string,
+    ratio: number,
+  ) => Promise<TabCommandResult>
+  tabRestoreLayout: (
+    worktreePath: string,
+    layoutJson: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+    },
+  ) => Promise<TabCommandResult & { restored: boolean }>
+  tabResumeSuspendedTab: (
+    worktreePath: string,
+    tabId: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+    },
+  ) => Promise<TabCommandResult>
+  tabKillAll: () => Promise<TabStateSnapshot>
+  tabFocusSession: (sessionId: string) => Promise<TabCommandResult | null>
+  tabSaveCurrentLayout: (worktreePath: string) => Promise<void>
 
   agentSendTaskContext: (payload: {
     text: string
@@ -426,16 +697,31 @@ interface CanopyAPI {
   gitCommit: (repoRoot: string, message: string, stageAll?: boolean) => Promise<GitCommitResult>
   gitPush: (repoRoot: string) => Promise<{ branch: string; remote: string }>
   gitPull: (repoRoot: string, rebase: boolean) => Promise<{ summary: string }>
+  gitPullWithPreferences: (payload: { repoRoot: string }) => Promise<{
+    summary: string
+    rebase: boolean
+  }>
+  gitCommitWorktree: (payload: {
+    repoRoot: string
+    message: string
+    stageAll?: boolean
+  }) => Promise<GitCommitResult>
+  gitPushWorktree: (payload: { repoRoot: string }) => Promise<{ branch: string; remote: string }>
+  gitFetchWorktree: (payload: { repoRoot: string }) => Promise<void>
   gitFetch: (repoRoot: string) => Promise<void>
   gitFetchAll: (repoRoot: string) => Promise<void>
+  gitStashWorktree: (payload: { repoRoot: string }) => Promise<void>
   gitStash: (repoRoot: string) => Promise<void>
+  gitStashPopWorktree: (payload: { repoRoot: string }) => Promise<void>
   gitStashPop: (repoRoot: string) => Promise<void>
   gitBranches: (repoRoot: string) => Promise<GitBranchList>
   gitBranchCreate: (repoRoot: string, name: string, baseBranch: string) => Promise<void>
+  gitBranchCreateFromHead: (payload: { repoRoot: string; branch: string }) => Promise<void>
   gitCheckout: (repoRoot: string, branch: string) => Promise<void>
   gitBranchDelete: (repoRoot: string, name: string, force: boolean) => Promise<void>
   gitBranchDeleteRemote: (repoRoot: string, remote: string, name: string) => Promise<void>
   gitPushInfo: (repoRoot: string) => Promise<GitPushInfo | null>
+  gitPreparePush: (payload: { repoRoot: string }) => Promise<GitPreparePushResult>
   gitBranchMerged: (repoRoot: string, branch: string) => Promise<boolean>
   gitWorktreeAdd: (
     repoRoot: string,
@@ -450,8 +736,29 @@ interface CanopyAPI {
     createLocalTracking: boolean,
   ) => Promise<void>
   gitWorktreeRemove: (repoRoot: string, path: string, force: boolean) => Promise<void>
+  worktreeCreate: (payload: WorktreeCreateInput) => Promise<WorktreeCreateResult>
+  worktreePrepareRemove: (
+    payload: WorktreePrepareRemoveInput,
+  ) => Promise<WorktreePrepareRemoveResult>
+  worktreeGetMergedBranches: (
+    payload: WorktreeGetMergedBranchesInput,
+  ) => Promise<WorktreeGetMergedBranchesResult>
+  worktreeListBranches: (payload: { repoRoot: string }) => Promise<GitBranchList>
+  worktreeRefreshBranches: (payload: { repoRoot: string }) => Promise<GitBranchList>
+  gitBranchPrepareDelete: (
+    payload: GitBranchPrepareDeleteInput,
+  ) => Promise<GitBranchPrepareDeleteResult>
+  gitBranchDeleteWithPreflight: (
+    payload: GitBranchDeleteWithPreflightInput,
+  ) => Promise<GitBranchDeleteWithPreflightResult>
+  worktreeRemoveWithBranch: (
+    payload: WorktreeRemoveWithBranchInput,
+  ) => Promise<WorktreeRemoveWithBranchResult>
   gitUnmergedCommits: (repoRoot: string, branch: string) => Promise<string[]>
   gitStatusPorcelain: (repoRoot: string, worktreePath?: string) => Promise<string>
+  changesGetDiff: (payload: { worktreePath: string }) => Promise<ParsedDiff>
+  changesStageFile: (payload: { worktreePath: string; filePath: string }) => Promise<void>
+  changesRevertFile: (payload: { worktreePath: string; filePath: string }) => Promise<void>
   gitDiff: (repoRoot: string) => Promise<ParsedDiff>
   gitDiffFile: (repoRoot: string, filePath: string) => Promise<ParsedDiff>
   gitStageFile: (repoRoot: string, filePath: string) => Promise<void>
@@ -587,19 +894,8 @@ interface CanopyAPI {
   onMenuShowPreferences: (callback: () => void) => () => void
 
   // Filesystem
-  readDir: (dirPath: string) => Promise<DirEntry[]>
-  readFile: (filePath: string, maxBytes?: number) => Promise<FileReadResult>
-  writeFile: (
-    filePath: string,
-    content: string,
-    expectedMtimeMs?: number,
-  ) => Promise<FileWriteResult>
-  createFile: (filePath: string) => Promise<void>
-  mkdir: (dirPath: string) => Promise<void>
-  statFile: (filePath: string) => Promise<FileStatResult>
   quickOpenListFiles: (worktreePath: string, force?: boolean) => Promise<string[]>
   quickOpenInvalidateCache: (worktreePath: string) => Promise<void>
-  confirmUnsavedChanges: (filePaths: string[]) => Promise<'save' | 'discard' | 'cancel'>
 
   // Repo Config
   repoConfigLoad: (repoRoot: string) => Promise<RepoConfig | null>
@@ -734,6 +1030,7 @@ interface CanopyAPI {
     filename: string,
   ) => Promise<string>
   taskTrackerCleanupAttachments: (filePaths: string[]) => Promise<void>
+  taskTrackerBuildTaskContext: (payload: TaskTrackerBuildTaskContextInput) => Promise<string>
   taskTrackerResolveBranchName: (
     connectionId: string,
     task: TrackerTask,
@@ -741,6 +1038,15 @@ interface CanopyAPI {
     branchType?: string,
     repoRoot?: string,
   ) => Promise<string>
+  taskTrackerPrepareBranchFromTask: (
+    payload: TaskTrackerBranchFromTaskInput,
+  ) => Promise<TaskTrackerBranchFromTaskResult>
+  taskTrackerCreateBranchFromTask: (
+    payload: TaskTrackerCreateBranchFromTaskInput,
+  ) => Promise<TaskTrackerBranchFromTaskResult>
+  taskTrackerCreateWorktreeFromTask: (
+    payload: TaskTrackerCreateWorktreeFromTaskInput,
+  ) => Promise<TaskTrackerCreateWorktreeFromTaskResult>
   taskTrackerResolveBranchType: (
     taskType: string,
     connectionId?: string,
@@ -989,6 +1295,39 @@ interface TrackerTask {
   sprintNumber?: number
   assignee?: string
   url?: string
+}
+
+interface TaskTrackerBranchFromTaskInput {
+  connectionId: string
+  task: TrackerTask
+  boardId?: string
+  branchType?: string
+  repoRoot: string
+}
+
+interface TaskTrackerCreateBranchFromTaskInput extends TaskTrackerBranchFromTaskInput {
+  baseBranch: string
+  stashBeforeCreate?: boolean
+}
+
+interface TaskTrackerCreateWorktreeFromTaskInput extends TaskTrackerBranchFromTaskInput {
+  worktreePath: string
+  baseBranch: string
+}
+
+interface TaskTrackerBranchFromTaskResult {
+  branchName: string
+}
+
+interface TaskTrackerCreateWorktreeFromTaskResult extends TaskTrackerBranchFromTaskResult {
+  worktreePath: string
+}
+
+interface TaskTrackerBuildTaskContextInput {
+  connectionId: string
+  task: TrackerTask
+  repoRoot?: string
+  trackerId?: string
 }
 
 interface TrackerBoard {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,6 +13,7 @@ import type {
   CloseWarningTarget,
   EditorFileLoadResult,
   EditorFileSaveResult,
+  TabCloseAllPreflightResult,
   TabClosePreflightResult,
 } from '../main/commands/types'
 
@@ -328,6 +329,14 @@ const api = {
       worktreePath,
       tabId,
     }) as Promise<TabClosePreflightResult>,
+  tabPrepareCloseAllForWorktree: (
+    worktreePath: string,
+    options?: { confirmedActiveProcesses?: boolean },
+  ) =>
+    ipcRenderer.invoke('tab:command:prepareCloseAllForWorktree', {
+      worktreePath,
+      confirmedActiveProcesses: options?.confirmedActiveProcesses,
+    }) as Promise<TabCloseAllPreflightResult>,
   tabGetCloseWarning: (worktreePath: string, target: CloseWarningTarget) =>
     ipcRenderer.invoke('tab:command:getCloseWarning', {
       worktreePath,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,14 @@ import type { CanopySkill } from '../main/skills/types'
 import type { RemoteSessionStatus } from '../main/remote/types'
 import type { AgentProfileMasked, ProfileInput } from '../main/profiles/types'
 import type { AgentType } from '../main/agents/types'
+import type {
+  AppStateSnapshot,
+  CloseWarningResult,
+  CloseWarningTarget,
+  EditorFileLoadResult,
+  EditorFileSaveResult,
+  TabClosePreflightResult,
+} from '../main/commands/types'
 
 const api = {
   // PTY
@@ -16,8 +24,6 @@ const api = {
     ipcRenderer.invoke('pty:kill', { sessionId, killTmux }),
   writePty: (sessionId: string, data: string) =>
     ipcRenderer.invoke('pty:write', { sessionId, data }),
-  hasChildProcess: (sessionId: string) =>
-    ipcRenderer.invoke('pty:hasChildProcess', { sessionId }) as Promise<boolean>,
   getPtyDimensions: (sessionId: string) =>
     ipcRenderer.invoke('pty:getDimensions', { sessionId }) as Promise<{
       cols: number
@@ -64,6 +70,28 @@ const api = {
     ipcRenderer.invoke('workspace:command:selectWorktree', { path }),
   workspaceInitGitRepo: (path: string) =>
     ipcRenderer.invoke('workspace:command:initGitRepo', { path }),
+  getAppState: () => ipcRenderer.invoke('app:getState') as Promise<AppStateSnapshot>,
+  getStartupRestoreState: () =>
+    ipcRenderer.invoke('app:getStartupRestoreState') as Promise<{ restoring: boolean }>,
+  completeStartupRestore: () => ipcRenderer.invoke('app:completeStartupRestore') as Promise<void>,
+  onAppStateChanged: (callback: (snapshot: AppStateSnapshot) => void) => {
+    const handler = (_event: IpcRendererEvent, snapshot: AppStateSnapshot): void =>
+      callback(snapshot)
+    ipcRenderer.on('app:stateChanged', handler)
+    return (): void => {
+      ipcRenderer.removeListener('app:stateChanged', handler)
+    }
+  },
+  fileTreeReadDir: (dirPath: string) => ipcRenderer.invoke('fileTree:readDir', { dirPath }),
+  fileTreeCreateFile: (filePath: string) => ipcRenderer.invoke('fileTree:createFile', { filePath }),
+  fileTreeCreateDirectory: (dirPath: string) =>
+    ipcRenderer.invoke('fileTree:createDirectory', { dirPath }),
+  fileTreeGetGitStatus: (repoRoot: string, worktreePath: string) =>
+    ipcRenderer.invoke('fileTree:getGitStatus', { repoRoot, worktreePath }) as Promise<{
+      statuses: Record<string, string>
+      changedDirs: string[]
+      affectedPaths: string[]
+    }>,
 
   // Preferences
   getPref: (key: string) => ipcRenderer.invoke('db:prefs:get', { key }),
@@ -112,19 +140,169 @@ const api = {
       profileId?: string
       workspaceName?: string
       branch?: string
-      tabs?: unknown
-      activeTabId?: string | null
     },
-  ) => {
-    const { tabs, activeTabId, ...commandOptions } = options ?? {}
-    return ipcRenderer.invoke('tab:command:openTool', {
+  ) =>
+    ipcRenderer.invoke('tab:command:openTool', {
       toolId,
       worktreePath,
-      options: commandOptions,
-      tabs,
-      activeTabId,
-    })
-  },
+      options,
+    }),
+  tabOpenDiff: (worktreePath: string) =>
+    ipcRenderer.invoke('tab:command:openDiff', {
+      worktreePath,
+    }),
+  tabOpenSessionTab: (worktreePath: string, name: string, sessionId: string) =>
+    ipcRenderer.invoke('tab:command:openSessionTab', {
+      worktreePath,
+      name,
+      sessionId,
+    }),
+  tabOpenEditorFile: (worktreePath: string, filePath: string) =>
+    ipcRenderer.invoke('tab:command:openEditorFile', {
+      worktreePath,
+      filePath,
+    }),
+  tabDetachEditorFile: (worktreePath: string, paneId: string, filePath: string) =>
+    ipcRenderer.invoke('tab:command:detachEditorFile', {
+      worktreePath,
+      paneId,
+      filePath,
+    }),
+  tabCloseEditorFile: (worktreePath: string, paneId: string, filePath: string) =>
+    ipcRenderer.invoke('tab:command:closeEditorFile', {
+      worktreePath,
+      paneId,
+      filePath,
+    }),
+  tabPrepareCloseEditorFile: (worktreePath: string, paneId: string, filePath: string) =>
+    ipcRenderer.invoke('tab:command:prepareCloseEditorFile', {
+      worktreePath,
+      paneId,
+      filePath,
+    }) as Promise<TabClosePreflightResult>,
+  tabMoveEditorFile: (worktreePath: string, paneId: string, filePath: string, toIndex: number) =>
+    ipcRenderer.invoke('tab:command:moveEditorFile', {
+      worktreePath,
+      paneId,
+      filePath,
+      toIndex,
+    }),
+  tabMoveEditorFileBetweenPanes: (
+    worktreePath: string,
+    sourcePaneId: string,
+    targetPaneId: string,
+    filePath: string,
+    toIndex: number,
+  ) =>
+    ipcRenderer.invoke('tab:command:moveEditorFileBetweenPanes', {
+      worktreePath,
+      sourcePaneId,
+      targetPaneId,
+      filePath,
+      toIndex,
+    }),
+  tabSetActiveEditorFile: (worktreePath: string, paneId: string, filePath: string) =>
+    ipcRenderer.invoke('tab:command:setActiveEditorFile', {
+      worktreePath,
+      paneId,
+      filePath,
+    }),
+  tabUpdateEditorFileState: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    patch: unknown,
+  ) =>
+    ipcRenderer.invoke('tab:command:updateEditorFileState', {
+      worktreePath,
+      paneId,
+      filePath,
+      patch,
+    }),
+  tabLoadEditorFile: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    options?: { maxBytes?: number },
+  ) =>
+    ipcRenderer.invoke('tab:command:loadEditorFile', {
+      worktreePath,
+      paneId,
+      filePath,
+      options,
+    }) as Promise<EditorFileLoadResult>,
+  tabSaveEditorFile: (
+    worktreePath: string,
+    paneId: string,
+    filePath: string,
+    options: {
+      content: string
+      fileLineEnding?: 'LF' | 'CRLF'
+      expectedMtimeMs?: number
+    },
+  ) =>
+    ipcRenderer.invoke('tab:command:saveEditorFile', {
+      worktreePath,
+      paneId,
+      filePath,
+      options,
+    }) as Promise<EditorFileSaveResult>,
+  tabUpdatePaneTitle: (worktreePath: string, sessionId: string, title: string) =>
+    ipcRenderer.invoke('tab:command:updatePaneTitle', {
+      worktreePath,
+      sessionId,
+      title,
+    }),
+  tabUpdatePaneUrl: (worktreePath: string, sessionId: string, url: string) =>
+    ipcRenderer.invoke('tab:command:updatePaneUrl', {
+      worktreePath,
+      sessionId,
+      url,
+    }),
+  tabUpdateTmuxSessionName: (worktreePath: string, oldName: string, newName: string) =>
+    ipcRenderer.invoke('tab:command:updateTmuxSessionName', {
+      worktreePath,
+      oldName,
+      newName,
+    }),
+  tabHandlePtyExit: (
+    worktreePath: string,
+    sessionId: string,
+    exitCode: number,
+    tmuxSessionName?: string,
+  ) =>
+    ipcRenderer.invoke('tab:command:handlePtyExit', {
+      worktreePath,
+      sessionId,
+      exitCode,
+      tmuxSessionName,
+    }),
+  tabKillTmuxPane: (worktreePath: string, tabId: string, paneId: string) =>
+    ipcRenderer.invoke('tab:command:killTmuxPane', {
+      worktreePath,
+      tabId,
+      paneId,
+    }),
+  tabReattachTmuxPane: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+    },
+  ) =>
+    ipcRenderer.invoke('tab:command:reattachTmuxPane', {
+      worktreePath,
+      tabId,
+      paneId,
+      options,
+    }),
+  tabToggleFocusedInspector: (worktreePath: string, tabId: string) =>
+    ipcRenderer.invoke('tab:command:toggleFocusedInspector', {
+      worktreePath,
+      tabId,
+    }),
   tabRestartPane: (
     worktreePath: string,
     tabId: string,
@@ -132,30 +310,100 @@ const api = {
     options?: {
       workspaceName?: string
       branch?: string
-      tabs?: unknown
-      activeTabId?: string | null
     },
-  ) => {
-    const { tabs, activeTabId, ...commandOptions } = options ?? {}
-    return ipcRenderer.invoke('tab:command:restartPane', {
+  ) =>
+    ipcRenderer.invoke('tab:command:restartPane', {
       worktreePath,
       tabId,
       paneId,
-      options: commandOptions,
-      tabs,
-      activeTabId,
-    })
-  },
-  tabCloseTab: (
-    worktreePath: string,
-    tabId: string,
-    options?: { tabs?: unknown; activeTabId?: string | null },
-  ) =>
+      options,
+    }),
+  tabCloseTab: (worktreePath: string, tabId: string) =>
     ipcRenderer.invoke('tab:command:closeTab', {
       worktreePath,
       tabId,
-      tabs: options?.tabs,
-      activeTabId: options?.activeTabId,
+    }),
+  tabPrepareCloseTab: (worktreePath: string, tabId: string) =>
+    ipcRenderer.invoke('tab:command:prepareCloseTab', {
+      worktreePath,
+      tabId,
+    }) as Promise<TabClosePreflightResult>,
+  tabGetCloseWarning: (worktreePath: string, target: CloseWarningTarget) =>
+    ipcRenderer.invoke('tab:command:getCloseWarning', {
+      worktreePath,
+      target,
+    }) as Promise<CloseWarningResult>,
+  tabReopenClosedTab: (
+    worktreePath: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+    },
+  ) =>
+    ipcRenderer.invoke('tab:command:reopenClosedTab', {
+      worktreePath,
+      options,
+    }),
+  tabClosePane: (worktreePath: string, tabId: string, paneId: string) =>
+    ipcRenderer.invoke('tab:command:closePane', {
+      worktreePath,
+      tabId,
+      paneId,
+    }),
+  tabCloseAllForWorktree: (worktreePath: string) =>
+    ipcRenderer.invoke('tab:command:closeAllForWorktree', {
+      worktreePath,
+    }),
+  tabSetActiveTab: (worktreePath: string, tabId: string) =>
+    ipcRenderer.invoke('tab:command:setActiveTab', {
+      worktreePath,
+      tabId,
+    }),
+  tabMoveTab: (worktreePath: string, fromIndex: number, toIndex: number) =>
+    ipcRenderer.invoke('tab:command:moveTab', {
+      worktreePath,
+      fromIndex,
+      toIndex,
+    }),
+  tabMoveTabToSplit: (
+    worktreePath: string,
+    sourceTabId: string,
+    targetTabId: string,
+    targetPaneId: string,
+    direction: 'horizontal' | 'vertical',
+    position: 'first' | 'second',
+  ) =>
+    ipcRenderer.invoke('tab:command:moveTabToSplit', {
+      worktreePath,
+      sourceTabId,
+      targetTabId,
+      targetPaneId,
+      direction,
+      position,
+    }),
+  tabMovePaneToTarget: (
+    worktreePath: string,
+    sourceTabId: string,
+    sourcePaneId: string,
+    targetTabId: string,
+    targetPaneId: string,
+    direction: 'horizontal' | 'vertical',
+    position: 'first' | 'second',
+  ) =>
+    ipcRenderer.invoke('tab:command:movePaneToTarget', {
+      worktreePath,
+      sourceTabId,
+      sourcePaneId,
+      targetTabId,
+      targetPaneId,
+      direction,
+      position,
+    }),
+  tabDetachPaneToTab: (worktreePath: string, sourceTabId: string, sourcePaneId: string) =>
+    ipcRenderer.invoke('tab:command:detachPaneToTab', {
+      worktreePath,
+      sourceTabId,
+      sourcePaneId,
     }),
   tabSpawnPane: (
     toolId: string,
@@ -168,11 +416,52 @@ const api = {
       resumeSessionId?: string
     },
   ) => ipcRenderer.invoke('tab:command:spawnPane', { toolId, worktreePath, options }),
-  tabSaveLayout: (worktreePath: string, layoutJson: string) =>
-    ipcRenderer.invoke('tab:command:saveLayout', { worktreePath, layoutJson }),
-  tabDeleteLayout: (worktreePath: string) =>
-    ipcRenderer.invoke('tab:command:deleteLayout', { worktreePath }),
-
+  tabSplitPane: (
+    worktreePath: string,
+    tabId: string,
+    paneId: string,
+    direction: 'horizontal' | 'vertical',
+  ) => ipcRenderer.invoke('tab:command:splitPane', { worktreePath, tabId, paneId, direction }),
+  tabFocusPane: (worktreePath: string, tabId: string, paneId: string) =>
+    ipcRenderer.invoke('tab:command:focusPane', { worktreePath, tabId, paneId }),
+  tabNavigatePaneFocus: (
+    worktreePath: string,
+    tabId: string,
+    direction: 'left' | 'right' | 'up' | 'down',
+  ) => ipcRenderer.invoke('tab:command:navigatePaneFocus', { worktreePath, tabId, direction }),
+  tabUpdateSplitRatio: (worktreePath: string, tabId: string, splitId: string, ratio: number) =>
+    ipcRenderer.invoke('tab:command:updateSplitRatio', { worktreePath, tabId, splitId, ratio }),
+  tabRestoreLayout: (
+    worktreePath: string,
+    layoutJson: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+    },
+  ) =>
+    ipcRenderer.invoke('tab:command:restoreLayout', {
+      worktreePath,
+      layoutJson,
+      options,
+    }),
+  tabResumeSuspendedTab: (
+    worktreePath: string,
+    tabId: string,
+    options?: {
+      workspaceName?: string
+      branch?: string
+    },
+  ) =>
+    ipcRenderer.invoke('tab:command:resumeSuspendedTab', {
+      worktreePath,
+      tabId,
+      options,
+    }),
+  tabKillAll: () => ipcRenderer.invoke('tab:command:killAll'),
+  tabFocusSession: (sessionId: string) =>
+    ipcRenderer.invoke('tab:command:focusSession', { sessionId }),
+  tabSaveCurrentLayout: (worktreePath: string) =>
+    ipcRenderer.invoke('tab:command:saveCurrentLayout', { worktreePath }),
   agentSendTaskContext: (payload: { text: string; worktreePath?: string; sessionId?: string }) =>
     ipcRenderer.invoke('agent:command:sendTaskContext', payload),
   agentSendReviewContext: (payload: { text: string; worktreePath?: string; sessionId?: string }) =>
@@ -402,20 +691,42 @@ const api = {
   gitPush: (repoRoot: string) => ipcRenderer.invoke('git:push', { repoRoot }),
   gitPull: (repoRoot: string, rebase: boolean) =>
     ipcRenderer.invoke('git:pull', { repoRoot, rebase }),
+  gitPullWithPreferences: (payload: { repoRoot: string }) =>
+    ipcRenderer.invoke('git:pullWithPreferences', payload),
+  gitCommitWorktree: (payload: { repoRoot: string; message: string; stageAll?: boolean }) =>
+    ipcRenderer.invoke('git:commitWorktree', payload),
+  gitPushWorktree: (payload: { repoRoot: string }) =>
+    ipcRenderer.invoke('git:pushWorktree', payload),
+  gitFetchWorktree: (payload: { repoRoot: string }) =>
+    ipcRenderer.invoke('git:fetchWorktree', payload),
   gitFetch: (repoRoot: string) => ipcRenderer.invoke('git:fetch', { repoRoot }),
   gitFetchAll: (repoRoot: string) => ipcRenderer.invoke('git:fetchAll', { repoRoot }),
+  gitStashWorktree: (payload: { repoRoot: string }) =>
+    ipcRenderer.invoke('git:stashWorktree', payload),
   gitStash: (repoRoot: string) => ipcRenderer.invoke('git:stash', { repoRoot }),
+  gitStashPopWorktree: (payload: { repoRoot: string }) =>
+    ipcRenderer.invoke('git:stashPopWorktree', payload),
   gitStashPop: (repoRoot: string) => ipcRenderer.invoke('git:stashPop', { repoRoot }),
   gitBranches: (repoRoot: string) => ipcRenderer.invoke('git:branches', { repoRoot }),
   gitBranchCreate: (repoRoot: string, name: string, baseBranch: string) =>
     ipcRenderer.invoke('git:branchCreate', { repoRoot, name, baseBranch }),
+  gitBranchCreateFromHead: (payload: { repoRoot: string; branch: string }) =>
+    ipcRenderer.invoke('git:branchCreateFromHead', payload),
   gitCheckout: (repoRoot: string, branch: string) =>
     ipcRenderer.invoke('git:checkout', { repoRoot, branch }),
   gitBranchDelete: (repoRoot: string, name: string, force: boolean) =>
     ipcRenderer.invoke('git:branchDelete', { repoRoot, name, force }),
+  gitBranchPrepareDelete: (payload: { repoRoot: string; branch: string }) =>
+    ipcRenderer.invoke('git:branchPrepareDelete', payload),
+  gitBranchDeleteWithPreflight: (payload: {
+    repoRoot: string
+    branch: string
+    forceIfUnmerged?: boolean
+  }) => ipcRenderer.invoke('git:branchDeleteWithPreflight', payload),
   gitBranchDeleteRemote: (repoRoot: string, remote: string, name: string) =>
     ipcRenderer.invoke('git:branchDeleteRemote', { repoRoot, remote, name }),
   gitPushInfo: (repoRoot: string) => ipcRenderer.invoke('git:pushInfo', { repoRoot }),
+  gitPreparePush: (payload: { repoRoot: string }) => ipcRenderer.invoke('git:preparePush', payload),
   gitBranchMerged: (repoRoot: string, branch: string) =>
     ipcRenderer.invoke('git:branchMerged', { repoRoot, branch }),
   gitWorktreeAdd: (repoRoot: string, path: string, branch: string, baseBranch: string) =>
@@ -434,10 +745,48 @@ const api = {
     }),
   gitWorktreeRemove: (repoRoot: string, path: string, force: boolean) =>
     ipcRenderer.invoke('git:worktreeRemove', { repoRoot, path, force }),
+  worktreeCreate: (
+    payload:
+      | {
+          repoRoot: string
+          worktreePath: string
+          mode: 'new'
+          branch: string
+          baseBranch: string
+        }
+      | {
+          repoRoot: string
+          worktreePath: string
+          mode: 'existing'
+          branch: string
+          createLocalTracking?: boolean
+        },
+  ) => ipcRenderer.invoke('worktree:create', payload),
+  worktreePrepareRemove: (payload: { repoRoot: string; worktreePath: string; branch: string }) =>
+    ipcRenderer.invoke('worktree:prepareRemove', payload),
+  worktreeGetMergedBranches: (payload: { repoRoot: string; branches: string[] }) =>
+    ipcRenderer.invoke('worktree:getMergedBranches', payload),
+  worktreeListBranches: (payload: { repoRoot: string }) =>
+    ipcRenderer.invoke('worktree:listBranches', payload),
+  worktreeRefreshBranches: (payload: { repoRoot: string }) =>
+    ipcRenderer.invoke('worktree:refreshBranches', payload),
+  worktreeRemoveWithBranch: (payload: {
+    repoRoot: string
+    worktreePath: string
+    branch?: string
+    deleteBranch?: boolean
+    forceOnFailure?: boolean
+  }) => ipcRenderer.invoke('worktree:removeWithBranch', payload),
   gitUnmergedCommits: (repoRoot: string, branch: string) =>
     ipcRenderer.invoke('git:unmergedCommits', { repoRoot, branch }),
   gitStatusPorcelain: (repoRoot: string, worktreePath?: string) =>
     ipcRenderer.invoke('git:statusPorcelain', { repoRoot, worktreePath }),
+  changesGetDiff: (payload: { worktreePath: string }) =>
+    ipcRenderer.invoke('changes:getDiff', payload),
+  changesStageFile: (payload: { worktreePath: string; filePath: string }) =>
+    ipcRenderer.invoke('changes:stageFile', payload),
+  changesRevertFile: (payload: { worktreePath: string; filePath: string }) =>
+    ipcRenderer.invoke('changes:revertFile', payload),
   gitDiff: (repoRoot: string) => ipcRenderer.invoke('git:diff', { repoRoot }),
   gitDiffFile: (repoRoot: string, filePath: string) =>
     ipcRenderer.invoke('git:diffFile', { repoRoot, filePath }),
@@ -751,20 +1100,10 @@ const api = {
   },
 
   // Filesystem
-  readDir: (dirPath: string) => ipcRenderer.invoke('fs:readDir', { dirPath }),
-  readFile: (filePath: string, maxBytes?: number) =>
-    ipcRenderer.invoke('fs:readFile', { filePath, maxBytes }),
-  writeFile: (filePath: string, content: string, expectedMtimeMs?: number) =>
-    ipcRenderer.invoke('fs:writeFile', { filePath, content, expectedMtimeMs }),
-  createFile: (filePath: string) => ipcRenderer.invoke('fs:createFile', { filePath }),
-  mkdir: (dirPath: string) => ipcRenderer.invoke('fs:mkdir', { dirPath }),
-  statFile: (filePath: string) => ipcRenderer.invoke('fs:stat', { filePath }),
   quickOpenListFiles: (worktreePath: string, force?: boolean) =>
     ipcRenderer.invoke('quickOpen:listFiles', { worktreePath, force }) as Promise<string[]>,
   quickOpenInvalidateCache: (worktreePath: string) =>
     ipcRenderer.invoke('quickOpen:invalidateCache', { worktreePath }) as Promise<void>,
-  confirmUnsavedChanges: (filePaths: string[]) =>
-    ipcRenderer.invoke('dialog:confirmUnsavedChanges', { filePaths }),
 
   // Repo Config
   repoConfigLoad: (repoRoot: string) => ipcRenderer.invoke('repoConfig:load', { repoRoot }),
@@ -893,6 +1232,20 @@ const api = {
     }) as Promise<string>,
   taskTrackerCleanupAttachments: (filePaths: string[]) =>
     ipcRenderer.invoke('taskTracker:cleanupAttachments', { filePaths }),
+  taskTrackerBuildTaskContext: (payload: {
+    connectionId: string
+    task: {
+      key: string
+      summary: string
+      description: string
+      status: string
+      priority: string
+      type: string
+      url?: string
+    }
+    repoRoot?: string
+    trackerId?: string
+  }) => ipcRenderer.invoke('taskTracker:buildTaskContext', payload) as Promise<string>,
   taskTrackerResolveBranchName: (
     connectionId: string,
     task: { key: string; type: string; [k: string]: unknown },
@@ -907,6 +1260,31 @@ const api = {
       branchType,
       repoRoot,
     }),
+  taskTrackerPrepareBranchFromTask: (payload: {
+    connectionId: string
+    task: { key: string; type: string; [k: string]: unknown }
+    boardId?: string
+    branchType?: string
+    repoRoot: string
+  }) => ipcRenderer.invoke('taskTracker:prepareBranchFromTask', payload),
+  taskTrackerCreateBranchFromTask: (payload: {
+    connectionId: string
+    task: { key: string; type: string; [k: string]: unknown }
+    boardId?: string
+    branchType?: string
+    repoRoot: string
+    baseBranch: string
+    stashBeforeCreate?: boolean
+  }) => ipcRenderer.invoke('taskTracker:createBranchFromTask', payload),
+  taskTrackerCreateWorktreeFromTask: (payload: {
+    connectionId: string
+    task: { key: string; type: string; [k: string]: unknown }
+    boardId?: string
+    branchType?: string
+    repoRoot: string
+    worktreePath: string
+    baseBranch: string
+  }) => ipcRenderer.invoke('taskTracker:createWorktreeFromTask', payload),
   taskTrackerResolveBranchType: (
     taskType: string,
     connectionId?: string,

--- a/src/renderer/src/components/dashboard/WelcomeDashboard.svelte
+++ b/src/renderer/src/components/dashboard/WelcomeDashboard.svelte
@@ -46,8 +46,8 @@
   const showFilter = $derived(workspaces.length > 4)
 
   $effect(() => {
-    void filteredWorkspaces
-    if (selectedIndex >= filteredWorkspaces.length) selectedIndex = 0
+    const count = filteredWorkspaces.length
+    if (selectedIndex >= count && selectedIndex !== 0) selectedIndex = 0
   })
 
   onMount(async () => {

--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -27,7 +27,7 @@
   async function refresh(): Promise<void> {
     loading = true
     try {
-      diff = await window.api.gitDiff(worktreePath)
+      diff = await window.api.changesGetDiff({ worktreePath })
     } catch {
       diff = null
     } finally {
@@ -130,7 +130,7 @@
   async function handleStage(e: Event, path: string): Promise<void> {
     e.stopPropagation()
     try {
-      await window.api.gitStageFile(worktreePath, path)
+      await window.api.changesStageFile({ worktreePath, filePath: path })
       await refresh()
     } catch (err) {
       console.error('Failed to stage file:', err)
@@ -147,7 +147,7 @@
     })
     if (!ok) return
     try {
-      await window.api.gitRevertFile(worktreePath, path)
+      await window.api.changesRevertFile({ worktreePath, filePath: path })
       await refresh()
     } catch (err) {
       console.error('Failed to revert file:', err)

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -46,7 +46,7 @@
   async function refresh(): Promise<void> {
     loading = true
     try {
-      const result = await window.api.gitDiff(worktreePath)
+      const result = await window.api.changesGetDiff({ worktreePath })
       files = result.files
     } catch {
       files = []

--- a/src/renderer/src/components/editor/EditorPane.svelte
+++ b/src/renderer/src/components/editor/EditorPane.svelte
@@ -6,6 +6,9 @@
     findEditorPane,
     setActiveEditorFile,
     updateEditorFileState,
+    loadEditorFile,
+    saveEditorFile,
+    prepareCloseEditorFile,
     closeEditorFile,
     detachEditorFile,
     moveEditorFile,
@@ -119,7 +122,12 @@
     fileDeleted = false
     externalChangeDetected = false
     try {
-      const readResult = await window.api.readFile(path, MAX_EDIT_BYTES)
+      const readResult = await loadEditorFile(paneId, path, MAX_EDIT_BYTES)
+      if (!readResult.ok) {
+        error = readResult.message
+        return
+      }
+
       if (readResult.binary) {
         binary = true
         fileSize = readResult.size
@@ -139,18 +147,9 @@
         }
       }
 
-      let statResult: { mtimeMs: number; size: number; canWrite: boolean } | null = null
-      if (typeof window.api.statFile === 'function') {
-        try {
-          statResult = await window.api.statFile(path)
-        } catch {
-          statResult = null
-        }
-      }
-      canWrite = statResult?.canWrite ?? true
-      fileMtimeMs = statResult?.mtimeMs ?? 0
+      canWrite = readResult.canWrite
+      fileMtimeMs = readResult.mtimeMs
       dirty = false
-      persistCurrentFileState()
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to read file'
     } finally {
@@ -206,12 +205,10 @@
     if (!dirty || !canEdit) return
     saveError = null
     const path = activeFilePath
-    const contentToWrite =
-      fileLineEnding === 'CRLF' ? editedContent.replace(/\r?\n/g, '\r\n') : editedContent
     skipNextWatcherEvent = true
-    let result: Awaited<ReturnType<typeof window.api.writeFile>>
+    let result: Awaited<ReturnType<typeof saveEditorFile>>
     try {
-      result = await window.api.writeFile(path, contentToWrite, fileMtimeMs)
+      result = await saveEditorFile(paneId, path, editedContent, fileLineEnding, fileMtimeMs)
     } catch (e) {
       // Only reached on true IPC failures (e.g. access denied from
       // validatePathAccess). Expected outcomes (stale writes, write errors)
@@ -225,13 +222,6 @@
       fileMtimeMs = result.mtimeMs
       fileSize = result.size
       dirty = false
-      updateEditorFileState(paneId, path, {
-        dirty: false,
-        originalContent: editedContent,
-        currentContent: editedContent,
-        fileMtimeMs: result.mtimeMs,
-        externalChangeDetected: false,
-      })
       setTimeout(() => {
         skipNextWatcherEvent = false
       }, 1500)
@@ -273,37 +263,24 @@
 
   async function handleSubTabClose(evt: Event, path: string): Promise<void> {
     evt.stopPropagation()
-    const state = editorFiles.find((f) => f.filePath === path)
-    if (state?.dirty) {
-      const choice = await window.api.confirmUnsavedChanges([path])
-      if (choice === 'cancel') return
-      if (choice === 'save') {
-        const contentToWrite =
-          state.fileLineEnding === 'CRLF'
-            ? (state.currentContent ?? '').replace(/\r?\n/g, '\r\n')
-            : (state.currentContent ?? '')
-        skipNextWatcherEvent = true
-        let writeResult: Awaited<ReturnType<typeof window.api.writeFile>>
-        try {
-          writeResult = await window.api.writeFile(path, contentToWrite, state.fileMtimeMs)
-        } catch (e) {
-          skipNextWatcherEvent = false
-          saveError = `Failed to save: ${e instanceof Error ? e.message : String(e)}`
-          return
+    skipNextWatcherEvent = true
+    try {
+      const preflight = await prepareCloseEditorFile(paneId, path)
+      if (!preflight.ok) {
+        if (preflight.reason === 'save-failed') {
+          saveError = `Failed to save ${preflight.failedCount} file(s).`
         }
-        if (!writeResult.ok) {
-          skipNextWatcherEvent = false
-          saveError =
-            writeResult.tag === 'StaleWrite'
-              ? 'File changed on disk — reload before saving.'
-              : `Failed to save: ${writeResult.message}`
-          return
-        }
-        setTimeout(() => {
-          skipNextWatcherEvent = false
-        }, 1500)
+        skipNextWatcherEvent = false
+        return
       }
+    } catch (e) {
+      skipNextWatcherEvent = false
+      saveError = `Failed to save: ${e instanceof Error ? e.message : String(e)}`
+      return
     }
+    setTimeout(() => {
+      skipNextWatcherEvent = false
+    }, 1500)
     editorRef?.closeBuffer(path)
     closeEditorFile(paneId, path)
   }

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -26,6 +26,7 @@
   import WelcomeDashboard from '../dashboard/WelcomeDashboard.svelte'
   import RightPanel from './RightPanel.svelte'
   import Toast from '../shared/Toast.svelte'
+  import { Loader2 } from '@lucide/svelte'
   import { getPref, setPref } from '../../lib/stores/preferences.svelte'
   import { addToast } from '../../lib/stores/toast.svelte'
   import {
@@ -43,13 +44,12 @@
     projects,
     attachProject,
     restoreProjects,
-    updateGitInfoForProject,
+    initWorkspaceStateSubscription,
     toggleSidebar,
     toggleRightPanel,
   } from '../../lib/stores/workspace.svelte'
   import {
     activeTabId,
-    ensureDefaultTab,
     openTool,
     reopenClosedTab,
     switchTabByIndex,
@@ -65,6 +65,7 @@
     updateSplitRatio,
     focusSessionByPtyId,
     saveAllLayouts,
+    type TabInfo,
   } from '../../lib/stores/tabs.svelte'
   import { findLeaf } from '../../lib/stores/splitTree'
   import { initRemoteSessionListeners } from '../../lib/stores/remoteSession.svelte'
@@ -81,13 +82,29 @@
   import { initToolStore, destroyToolStore } from '../../lib/stores/tools.svelte'
   import { initSkillStore, destroySkillStore } from '../../lib/stores/skills.svelte'
   import { initProfileStore, destroyProfileStore } from '../../lib/stores/profiles.svelte'
+  import { isMacPlatform } from '../../lib/platform'
 
   onMount(() => {
+    let disposed = false
     initToolStore()
     initSkillStore()
     initProfileStore()
+    const stopWorkspaceStateSubscription = initWorkspaceStateSubscription()
     const stopRemoteListeners = initRemoteSessionListeners()
+    window.api
+      .getStartupRestoreState()
+      .then((state) => {
+        if (disposed || startupRestoreState !== 'checking') return
+        startupRestoreState = state.restoring ? 'restoring' : 'ready'
+      })
+      .catch(() => {
+        if (!disposed && startupRestoreState !== 'ready') {
+          startupRestoreState = 'ready'
+        }
+      })
     return () => {
+      disposed = true
+      stopWorkspaceStateSubscription()
       destroySkillStore()
       stopRemoteListeners()
       destroyToolStore()
@@ -95,9 +112,22 @@
     }
   })
 
-  const isMac = navigator.userAgent.includes('Mac')
+  const isMac = isMacPlatform()
+  const EMPTY_TABS: TabInfo[] = []
   let paletteOpen = $state(false)
   let quickOpenOpen = $state(false)
+  let startupRestoreState = $state<'checking' | 'restoring' | 'ready'>('checking')
+  let startupMessage = $derived(
+    startupRestoreState === 'restoring'
+      ? {
+          title: 'Restoring previous session',
+          description: 'Reopening projects, tabs, and terminal layouts...',
+        }
+      : {
+          title: 'Starting Canopy',
+          description: 'Checking for a previous session...',
+        },
+  )
 
   // Sidebar resize state
   const SIDEBAR_MIN = 150
@@ -170,26 +200,8 @@
   let currentWorktreeTabs = $derived(
     workspaceState.selectedWorktreePath
       ? getTabsForWorktree(workspaceState.selectedWorktreePath)
-      : [],
+      : EMPTY_TABS,
   )
-
-  // Auto-create default tab when selected worktree changes
-  $effect(() => {
-    const path = workspaceState.selectedWorktreePath
-    if (path) {
-      ensureDefaultTab(path)
-    }
-  })
-
-  // Subscribe to git:changed push events (all projects)
-  $effect(() => {
-    const unsubscribe = window.api.onGitChanged((info) => {
-      if (info.repoRoot) {
-        updateGitInfoForProject(info.repoRoot, info)
-      }
-    })
-    return unsubscribe
-  })
 
   // Subscribe to pty:exit push events
   $effect(() => {
@@ -274,7 +286,17 @@
   // Restore a whole window's projects in parallel, then focus the saved worktree once.
   $effect(() => {
     const unsubscribe = window.api.onRestoreWindow(async (data) => {
-      await restoreProjects(data.paths, data.activeWorktreePath, data.removedPaths)
+      if (data.paths.length > 0) {
+        startupRestoreState = 'restoring'
+      }
+      try {
+        await restoreProjects(data.paths, data.activeWorktreePath, data.removedPaths)
+      } finally {
+        if (data.paths.length > 0) {
+          void window.api.completeStartupRestore().catch(() => undefined)
+        }
+        startupRestoreState = 'ready'
+      }
     })
     return unsubscribe
   })
@@ -375,18 +397,31 @@
 
   // Global keyboard shortcuts
   function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      if (paletteOpen) {
+        e.preventDefault()
+        paletteOpen = false
+        return
+      }
+      if (quickOpenOpen) {
+        e.preventDefault()
+        quickOpenOpen = false
+        return
+      }
+    }
+
     const mod = isMac ? e.metaKey : e.ctrlKey
     if (!mod) return
 
     // Cmd+K: toggle command palette
-    if (e.key === 'k') {
+    if (e.key === 'k' || e.key === 'K') {
       e.preventDefault()
       paletteOpen = !paletteOpen
       return
     }
 
     // Cmd+P: toggle quick open (file picker)
-    if (e.key === 'p' && !e.shiftKey) {
+    if ((e.key === 'p' || e.key === 'P') && !e.shiftKey) {
       e.preventDefault()
       quickOpenOpen = !quickOpenOpen
       return
@@ -584,73 +619,87 @@
 <Toast />
 
 <main class="flex flex-row flex-1 min-h-0 overflow-hidden">
-  {#if workspaceState.sidebarOpen && projects.length > 0}
-    <Sidebar onLaunchTool={handleLaunchTool} width={sidebarWidth} />
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
+  {#if startupRestoreState !== 'ready'}
     <div
-      class="w-1 cursor-col-resize bg-transparent flex-shrink-0 transition-colors duration-base hover:bg-accent-muted"
-      class:bg-accent-muted={sidebarDragging}
-      onpointerdown={handleSidebarPointerDown}
-      onpointermove={handleSidebarPointerMove}
-      onpointerup={handleSidebarPointerUp}
-      onpointercancel={handleSidebarPointerUp}
-    ></div>
-  {/if}
-
-  <div class="flex-1 min-w-0 flex flex-col">
-    {#if workspaceState.selectedWorktreePath}
-      <TabBar worktreePath={workspaceState.selectedWorktreePath} />
+      class="flex flex-1 min-w-0 flex-col items-center justify-center gap-3 bg-bg text-center"
+      role="status"
+      aria-live="polite"
+    >
+      <Loader2 size={18} class="animate-spin text-text-faint motion-reduce:animate-none" />
+      <div class="flex flex-col items-center gap-1">
+        <p class="m-0 text-sm font-medium text-text">{startupMessage.title}</p>
+        <p class="m-0 text-xs text-text-faint">{startupMessage.description}</p>
+      </div>
+    </div>
+  {:else}
+    {#if workspaceState.sidebarOpen && projects.length > 0}
+      <Sidebar onLaunchTool={handleLaunchTool} width={sidebarWidth} />
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="w-1 cursor-col-resize bg-transparent flex-shrink-0 transition-colors duration-base hover:bg-accent-muted"
+        class:bg-accent-muted={sidebarDragging}
+        onpointerdown={handleSidebarPointerDown}
+        onpointermove={handleSidebarPointerMove}
+        onpointerup={handleSidebarPointerUp}
+        onpointercancel={handleSidebarPointerUp}
+      ></div>
     {/if}
 
-    <div class="flex-1 min-h-0 flex flex-row">
-      <div class="flex-1 min-h-0 relative">
-        {#each allTabs as tab (tab.id)}
-          {#if !tab.suspended}
-            <div class="absolute inset-0 bg-bg" class:hidden={tab.id !== currentActiveTabId}>
-              <SplitPaneContainer
-                node={tab.rootSplit}
-                tabId={tab.id}
-                worktreePath={tab.worktreePath}
-                focusedPaneId={tab.focusedPaneId}
-                active={tab.id === currentActiveTabId}
-                onFocusPane={(paneId) => focusPane(tab.worktreePath, tab.id, paneId)}
-                onUpdateRatio={(paneId, ratio) =>
-                  updateSplitRatio(tab.worktreePath, tab.id, paneId, ratio)}
-              />
+    <div class="flex-1 min-w-0 flex flex-col">
+      {#if workspaceState.selectedWorktreePath}
+        <TabBar worktreePath={workspaceState.selectedWorktreePath} />
+      {/if}
+
+      <div class="flex-1 min-h-0 flex flex-row">
+        <div class="flex-1 min-h-0 relative">
+          {#each allTabs as tab (tab.id)}
+            {#if !tab.suspended}
+              <div class="absolute inset-0 bg-bg" class:hidden={tab.id !== currentActiveTabId}>
+                <SplitPaneContainer
+                  node={tab.rootSplit}
+                  tabId={tab.id}
+                  worktreePath={tab.worktreePath}
+                  focusedPaneId={tab.focusedPaneId}
+                  active={tab.id === currentActiveTabId}
+                  onFocusPane={(paneId) => focusPane(tab.worktreePath, tab.id, paneId)}
+                  onUpdateRatio={(paneId, ratio) =>
+                    updateSplitRatio(tab.worktreePath, tab.id, paneId, ratio)}
+                />
+              </div>
+            {/if}
+          {/each}
+
+          {#if projects.length === 0 && allTabs.length === 0}
+            <WelcomeDashboard />
+          {:else if workspaceState.selectedWorktreePath && currentWorktreeTabs.length === 0}
+            <div class="flex flex-col items-center justify-center h-full text-text-faint">
+              <p class="text-lg font-normal m-0">
+                Press {isMac ? 'Cmd' : 'Ctrl'}+T to open a new tab
+              </p>
+              <p class="text-sm font-normal mt-1.5 mb-0 text-text-faint">
+                {isMac ? 'Cmd' : 'Ctrl'}+K to open command palette
+              </p>
             </div>
           {/if}
-        {/each}
+        </div>
 
-        {#if projects.length === 0 && allTabs.length === 0}
-          <WelcomeDashboard />
-        {:else if workspaceState.selectedWorktreePath && currentWorktreeTabs.length === 0}
-          <div class="flex flex-col items-center justify-center h-full text-text-faint">
-            <p class="text-lg font-normal m-0">
-              Press {isMac ? 'Cmd' : 'Ctrl'}+T to open a new tab
-            </p>
-            <p class="text-sm font-normal mt-1.5 mb-0 text-text-faint">
-              {isMac ? 'Cmd' : 'Ctrl'}+K to open command palette
-            </p>
-          </div>
+        {#if workspaceState.rightPanelOpen && workspaceState.selectedWorktreePath}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="w-px cursor-col-resize bg-transparent flex-shrink-0 relative after:content-empty after:absolute after:inset-y-0 after:-inset-x-1 after:cursor-col-resize hover:bg-accent-muted"
+            class:bg-accent-muted={rpDragging}
+            onpointerdown={handleRpPointerDown}
+            onpointermove={handleRpPointerMove}
+            onpointerup={handleRpPointerUp}
+            onpointercancel={handleRpPointerUp}
+          ></div>
+          <RightPanel
+            agentState={activeAgentState}
+            width={rightPanelWidth}
+            worktreePath={workspaceState.selectedWorktreePath ?? ''}
+          />
         {/if}
       </div>
-
-      {#if workspaceState.rightPanelOpen && workspaceState.selectedWorktreePath}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-          class="w-px cursor-col-resize bg-transparent flex-shrink-0 relative after:content-empty after:absolute after:inset-y-0 after:-inset-x-1 after:cursor-col-resize hover:bg-accent-muted"
-          class:bg-accent-muted={rpDragging}
-          onpointerdown={handleRpPointerDown}
-          onpointermove={handleRpPointerMove}
-          onpointerup={handleRpPointerUp}
-          onpointercancel={handleRpPointerUp}
-        ></div>
-        <RightPanel
-          agentState={activeAgentState}
-          width={rightPanelWidth}
-          worktreePath={workspaceState.selectedWorktreePath ?? ''}
-        />
-      {/if}
     </div>
-  </div>
+  {/if}
 </main>

--- a/src/renderer/src/components/palette/CommandPalette.svelte
+++ b/src/renderer/src/components/palette/CommandPalette.svelte
@@ -21,9 +21,11 @@
     openTool,
     switchTab,
     getAllTabs,
+    getTabsForWorktree,
     getTabDisplayName,
     reopenClosedTab,
     splitFocusedPane,
+    closeAllTabsForWorktree,
   } from '../../lib/stores/tabs.svelte'
   import {
     confirm,
@@ -73,6 +75,10 @@
     Tabs: PanelLeft,
     App: Sliders,
     Terminal,
+  }
+
+  async function closeAllOpenTabsForWorktree(path: string): Promise<void> {
+    await closeAllTabsForWorktree(path)
   }
 
   let allItems = $derived.by((): PaletteItem[] => {
@@ -192,6 +198,8 @@
     })
 
     if (path) {
+      const currentWorktreeTabs = getTabsForWorktree(path)
+
       items.push({
         id: 'app:new-shell',
         label: 'New Shell Tab',
@@ -223,6 +231,18 @@
         shortcut: `${mod}+Shift+T`,
         action: () => reopenClosedTab(path),
       })
+
+      if (currentWorktreeTabs.length > 0) {
+        items.push({
+          id: 'app:close-worktree-tabs',
+          label: 'Close All Tabs in Worktree',
+          category: 'App',
+          description: `Close ${currentWorktreeTabs.length} open tab${
+            currentWorktreeTabs.length === 1 ? '' : 's'
+          } in the active worktree`,
+          action: () => closeAllOpenTabsForWorktree(path),
+        })
+      }
 
       items.push({
         id: 'app:split-vertical',
@@ -259,7 +279,11 @@
           })
           if (!result) return
           try {
-            await window.api.gitCommit(root, result.value, result.checked)
+            await window.api.gitCommitWorktree({
+              repoRoot: root,
+              message: result.value,
+              stageAll: result.checked,
+            })
           } catch (err) {
             await confirm({
               title: 'Git Error',
@@ -276,23 +300,13 @@
         category: 'Git',
         action: async () => {
           try {
-            const info = await window.api.gitPushInfo(root)
-            if (!info) {
-              const ok = await confirm({
-                title: 'Push',
-                message: 'No upstream branch — push and set tracking to origin?',
-              })
-              if (ok) {
-                await window.api.gitPush(root)
-              }
-              return
-            }
+            const preflight = await window.api.gitPreparePush({ repoRoot: root })
             const ok = await confirm({
               title: 'Push',
-              message: `Push ${info.commitCount} commit(s) to ${info.remote}/${info.branch}?`,
+              message: preflight.confirmationMessage,
             })
             if (ok) {
-              await window.api.gitPush(root)
+              await window.api.gitPushWorktree({ repoRoot: root })
             }
           } catch (err) {
             await confirm({
@@ -310,8 +324,7 @@
         category: 'Git',
         action: async () => {
           try {
-            const rebase = (await window.api.getPref('gitPullRebase')) !== 'false'
-            await window.api.gitPull(root, rebase)
+            await window.api.gitPullWithPreferences({ repoRoot: root })
           } catch (err) {
             await confirm({
               title: 'Git Error',
@@ -328,7 +341,7 @@
         category: 'Git',
         action: async () => {
           try {
-            await window.api.gitFetch(root)
+            await window.api.gitFetchWorktree({ repoRoot: root })
           } catch (err) {
             await confirm({
               title: 'Git Error',
@@ -345,7 +358,7 @@
         category: 'Git',
         action: async () => {
           try {
-            await window.api.gitStash(root)
+            await window.api.gitStashWorktree({ repoRoot: root })
           } catch (err) {
             await confirm({
               title: 'Git Error',
@@ -362,7 +375,7 @@
         category: 'Git',
         action: async () => {
           try {
-            await window.api.gitStashPop(root)
+            await window.api.gitStashPopWorktree({ repoRoot: root })
           } catch (err) {
             await confirm({
               title: 'Git Error',
@@ -392,7 +405,7 @@
           })
           if (!result) return
           try {
-            await window.api.gitBranchCreate(root, result.value, 'HEAD')
+            await window.api.gitBranchCreateFromHead({ repoRoot: root, branch: result.value })
           } catch (err) {
             await confirm({
               title: 'Git Error',
@@ -415,8 +428,11 @@
           })
           if (!result) return
           try {
-            const merged = await window.api.gitBranchMerged(root, result.value)
-            if (!merged) {
+            const preflight = await window.api.gitBranchPrepareDelete({
+              repoRoot: root,
+              branch: result.value,
+            })
+            if (preflight.forceRequired) {
               const force = await confirm({
                 title: 'Delete Unmerged Branch',
                 message: `Branch "${result.value}" has not been fully merged.\nForce delete?`,
@@ -424,10 +440,12 @@
                 destructive: true,
               })
               if (!force) return
-              await window.api.gitBranchDelete(root, result.value, true)
-            } else {
-              await window.api.gitBranchDelete(root, result.value, false)
             }
+            await window.api.gitBranchDeleteWithPreflight({
+              repoRoot: root,
+              branch: result.value,
+              forceIfUnmerged: preflight.forceRequired,
+            })
           } catch (err) {
             await confirm({
               title: 'Git Error',
@@ -457,17 +475,15 @@
             const wtPath = selectedWt.path
             const branch = selectedWt.branch
             try {
-              const status = await window.api.gitStatusPorcelain(root, wtPath)
-              const unmerged = await window.api.gitUnmergedCommits(root, branch)
-
-              const warnings: string[] = []
-              if (status.trim()) warnings.push('Has uncommitted changes.')
-              if (unmerged.length > 0)
-                warnings.push(`${unmerged.length} unmerged commit(s) not on any remote.`)
+              const preflight = await window.api.worktreePrepareRemove({
+                repoRoot: root,
+                worktreePath: wtPath,
+                branch,
+              })
 
               const msg =
-                warnings.length > 0
-                  ? warnings.join('\n') + '\n\nRemove this worktree?'
+                preflight.warnings.length > 0
+                  ? preflight.warnings.join('\n') + '\n\nRemove this worktree?'
                   : `Remove worktree "${branch}"?`
 
               const ok = await confirm({
@@ -475,23 +491,26 @@
                 message: msg,
                 details: wtPath,
                 confirmLabel: 'Remove',
-                destructive: warnings.length > 0,
+                destructive: preflight.forceRequired,
               })
               if (!ok) return
 
-              await window.api.gitWorktreeRemove(root, wtPath, warnings.length > 0)
-
-              const branchMerged = await window.api.gitBranchMerged(root, branch)
-              if (branchMerged) {
-                const del = await confirm({
+              let deleteBranch = false
+              if (preflight.canDeleteBranch) {
+                deleteBranch = await confirm({
                   title: 'Delete Branch?',
                   message: `Delete local branch "${branch}"? It has been fully merged.`,
                   confirmLabel: 'Delete Branch',
                 })
-                if (del) {
-                  await window.api.gitBranchDelete(root, branch, false)
-                }
               }
+
+              await window.api.worktreeRemoveWithBranch({
+                repoRoot: root,
+                worktreePath: wtPath,
+                branch,
+                deleteBranch,
+                forceOnFailure: preflight.forceRequired,
+              })
             } catch (err) {
               await confirm({
                 title: 'Git Error',

--- a/src/renderer/src/components/sidebar/FileTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/FileTreeSection.svelte
@@ -186,9 +186,9 @@
 
     try {
       if (isFolder) {
-        await window.api.mkdir(target)
+        await window.api.fileTreeCreateDirectory(target)
       } else {
-        await window.api.createFile(target)
+        await window.api.fileTreeCreateFile(target)
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)

--- a/src/renderer/src/components/sidebar/GitSection.svelte
+++ b/src/renderer/src/components/sidebar/GitSection.svelte
@@ -39,7 +39,11 @@
     if (!result) return
     loading = 'commit'
     try {
-      await window.api.gitCommit(worktreePath(), result.value, result.checked)
+      await window.api.gitCommitWorktree({
+        repoRoot: worktreePath(),
+        message: result.value,
+        stageAll: result.checked,
+      })
     } catch (err) {
       await gitError(err)
     } finally {
@@ -50,23 +54,14 @@
   async function doPush(): Promise<void> {
     loading = 'push'
     try {
-      const info = await window.api.gitPushInfo(worktreePath())
-      if (!info) {
-        const ok = await confirm({
-          title: 'Push',
-          message: 'No upstream branch — push and set tracking to origin?',
-        })
-        if (ok) {
-          await window.api.gitPush(worktreePath())
-        }
-        return
-      }
+      const root = worktreePath()
+      const preflight = await window.api.gitPreparePush({ repoRoot: root })
       const ok = await confirm({
         title: 'Push',
-        message: `Push ${info.commitCount} commit(s) to ${info.remote}/${info.branch}?`,
+        message: preflight.confirmationMessage,
       })
       if (ok) {
-        await window.api.gitPush(worktreePath())
+        await window.api.gitPushWorktree({ repoRoot: root })
       }
     } catch (err) {
       await gitError(err)
@@ -78,8 +73,7 @@
   async function doPull(): Promise<void> {
     loading = 'pull'
     try {
-      const rebase = (await window.api.getPref('gitPullRebase')) !== 'false'
-      await window.api.gitPull(worktreePath(), rebase)
+      await window.api.gitPullWithPreferences({ repoRoot: worktreePath() })
     } catch (err) {
       await gitError(err)
     } finally {
@@ -90,7 +84,7 @@
   async function doFetch(): Promise<void> {
     loading = 'fetch'
     try {
-      await window.api.gitFetch(worktreePath())
+      await window.api.gitFetchWorktree({ repoRoot: worktreePath() })
     } catch (err) {
       await gitError(err)
     } finally {
@@ -101,7 +95,7 @@
   async function doStash(): Promise<void> {
     loading = 'stash'
     try {
-      await window.api.gitStash(worktreePath())
+      await window.api.gitStashWorktree({ repoRoot: worktreePath() })
     } catch (err) {
       await gitError(err)
     } finally {
@@ -112,7 +106,7 @@
   async function doStashPop(): Promise<void> {
     loading = 'stashPop'
     try {
-      await window.api.gitStashPop(worktreePath())
+      await window.api.gitStashPopWorktree({ repoRoot: worktreePath() })
     } catch (err) {
       await gitError(err)
     } finally {

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { SvelteSet } from 'svelte/reactivity'
+  import { untrack } from 'svelte'
   import { ChevronRight, Square, Trash2, X } from '@lucide/svelte'
   import { fileManagerLabel } from '../../lib/platform'
   import {
@@ -79,20 +80,20 @@
 
   async function checkMergedStatus(project: ProjectState, signal: AbortSignal): Promise<void> {
     if (!project.isGitRepo || !project.repoRoot) return
-    const checks = project.worktrees
-      .filter((wt) => !wt.isMain)
-      .map(async (wt) => {
-        const merged = await window.api.gitBranchMerged(project.repoRoot!, wt.branch)
-        return { branch: wt.branch, merged }
-      })
-    const results = await Promise.all(checks)
+    const branches = project.worktrees
+      .filter((wt) => !wt.isMain && wt.branch !== '(detached)')
+      .map((wt) => wt.branch)
+    const result =
+      branches.length > 0
+        ? await window.api.worktreeGetMergedBranches({ repoRoot: project.repoRoot, branches })
+        : { mergedBranches: [] }
     if (signal.aborted) return
     // eslint-disable-next-line svelte/prefer-svelte-reactivity -- temporary local Set, not reactive state
     const next = new Set<string>()
-    for (const r of results) {
-      if (r.merged) next.add(r.branch)
+    for (const branch of result.mergedBranches) {
+      next.add(branch)
     }
-    mergedBranches = { ...mergedBranches, [project.workspace.path]: next }
+    mergedBranches = untrack(() => ({ ...mergedBranches, [project.workspace.path]: next }))
   }
 
   $effect(() => {
@@ -137,23 +138,22 @@
     if (!project.repoRoot || removingPaths.has(wt.path)) return
     removingPaths.add(wt.path)
 
-    await closeAllTabsForWorktree(wt.path)
-
-    const isDetached = wt.branch === '(detached)'
     try {
-      await window.api.gitWorktreeRemove(project.repoRoot, wt.path, false)
-      if (!isDetached) await window.api.gitBranchDelete(project.repoRoot, wt.branch, false)
-    } catch {
-      try {
-        await window.api.gitWorktreeRemove(project.repoRoot, wt.path, true)
-        if (!isDetached) await window.api.gitBranchDelete(project.repoRoot, wt.branch, true)
-      } catch {
-        removingPaths.delete(wt.path)
-        return
-      }
-    }
+      if (!(await closeAllTabsForWorktree(wt.path))) return
 
-    removingPaths.delete(wt.path)
+      const isDetached = wt.branch === '(detached)'
+      await window.api.worktreeRemoveWithBranch({
+        repoRoot: project.repoRoot,
+        worktreePath: wt.path,
+        branch: wt.branch,
+        deleteBranch: !isDetached,
+        forceOnFailure: true,
+      })
+    } catch {
+      return
+    } finally {
+      removingPaths.delete(wt.path)
+    }
 
     if (workspaceState.selectedWorktreePath === wt.path) {
       const main = project.worktrees.find((w) => w.isMain)

--- a/src/renderer/src/components/sidebar/WorktreeSection.svelte
+++ b/src/renderer/src/components/sidebar/WorktreeSection.svelte
@@ -19,18 +19,17 @@
     const repoRoot = workspaceState.repoRoot
     if (!repoRoot) return
 
-    const checks = workspaceState.worktrees
-      .filter((wt) => !wt.isMain)
-      .map(async (wt) => {
-        const merged = await window.api.gitBranchMerged(repoRoot, wt.branch)
-        return { branch: wt.branch, merged }
-      })
-
-    const results = await Promise.all(checks)
+    const branches = workspaceState.worktrees
+      .filter((wt) => !wt.isMain && wt.branch !== '(detached)')
+      .map((wt) => wt.branch)
+    const result =
+      branches.length > 0
+        ? await window.api.worktreeGetMergedBranches({ repoRoot, branches })
+        : { mergedBranches: [] }
     if (signal.aborted) return
     const next = new SvelteSet<string>()
-    for (const r of results) {
-      if (r.merged) next.add(r.branch)
+    for (const branch of result.mergedBranches) {
+      next.add(branch)
     }
     mergedBranches = next
   }
@@ -83,18 +82,18 @@
     })
     if (!ok) return
 
-    await closeAllTabsForWorktree(wt.path)
+    if (!(await closeAllTabsForWorktree(wt.path))) return
 
     try {
-      await window.api.gitWorktreeRemove(repoRoot, wt.path, false)
-      if (!isDetached) await window.api.gitBranchDelete(repoRoot, wt.branch, false)
+      await window.api.worktreeRemoveWithBranch({
+        repoRoot,
+        worktreePath: wt.path,
+        branch: wt.branch,
+        deleteBranch: !isDetached,
+        forceOnFailure: true,
+      })
     } catch {
-      try {
-        await window.api.gitWorktreeRemove(repoRoot, wt.path, true)
-        if (!isDetached) await window.api.gitBranchDelete(repoRoot, wt.branch, true)
-      } catch {
-        // Ignore — watcher will update the list
-      }
+      // Ignore — watcher will update the list
     }
 
     if (workspaceState.selectedWorktreePath === wt.path) {

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -9,7 +9,6 @@
   import { getTools, getToolAvailability } from '../../lib/stores/tools.svelte'
   import { isAiToolId, openTool } from '../../lib/stores/tabs.svelte'
   import { agentSessions } from '../../lib/agents/agentState.svelte'
-  import { fetchAndFormatTaskContext } from '../../lib/taskTracker/taskContext'
   import { setActiveTask } from '../../lib/stores/taskTracker.svelte'
   import { safeDirName } from '../../lib/sanitize'
 
@@ -75,7 +74,9 @@
         )
         .catch(() => null),
       window.api.taskTrackerFindTaskByKey(task.key).catch(() => null),
-      repoRoot ? window.api.gitBranches(repoRoot).catch(() => null) : Promise.resolve(null),
+      repoRoot
+        ? window.api.worktreeListBranches({ repoRoot }).catch(() => null)
+        : Promise.resolve(null),
     ])
 
     if (foundTask) fullTask = foundTask as Task
@@ -106,13 +107,14 @@
   async function updateBranchPreview(): Promise<void> {
     try {
       const plain = $state.snapshot(task) as Task
-      resolvedBranchName = await window.api.taskTrackerResolveBranchName(
+      const result = await window.api.taskTrackerPrepareBranchFromTask({
         connectionId,
-        plain,
-        selectedBoardId || undefined,
-        templateHasBranchType ? selectedBranchType : undefined,
-        workspaceState.repoRoot || undefined,
-      )
+        task: plain,
+        boardId: selectedBoardId || undefined,
+        branchType: templateHasBranchType ? selectedBranchType : undefined,
+        repoRoot: workspaceState.repoRoot || '',
+      })
+      resolvedBranchName = result.branchName
     } catch {
       resolvedBranchName = task.key
     }
@@ -152,8 +154,17 @@
     creatingWorktree = true
     setPref('taskTracker.lastAgent', selectedAgentId)
     try {
-      await window.api.gitWorktreeAdd(repoRoot, worktreePath, resolvedBranchName, baseBranch)
-      await setActiveTask(worktreePath, {
+      const branchTask = $state.snapshot(task) as Task
+      const created = await window.api.taskTrackerCreateWorktreeFromTask({
+        connectionId,
+        task: branchTask,
+        boardId: selectedBoardId || undefined,
+        branchType: templateHasBranchType ? selectedBranchType : undefined,
+        repoRoot,
+        worktreePath,
+        baseBranch,
+      })
+      await setActiveTask(created.worktreePath, {
         taskKey: fullTask.key,
         summary: fullTask.summary,
         connectionId,
@@ -164,7 +175,7 @@
         const wsId = workspaceState.workspace!.id
         addToast('Running worktree setup...')
         try {
-          await window.api.runWorktreeSetup(wsId, repoRoot, worktreePath)
+          await window.api.runWorktreeSetup(wsId, repoRoot, created.worktreePath)
           addToast('Worktree setup complete')
         } catch (e) {
           addToast('Worktree setup failed: ' + (e instanceof Error ? e.message : String(e)))
@@ -177,21 +188,21 @@
         const taskSnapshot = $state.snapshot(fullTask) as typeof fullTask
 
         try {
-          const tab = await openTool(agentId, worktreePath)
-          await selectWorktree(worktreePath)
+          const tab = await openTool(agentId, created.worktreePath)
+          await selectWorktree(created.worktreePath)
           const pane = tab.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
           if (pane) {
             const sessionId = pane.sessionId
             const ready = await waitForAgentIdle(sessionId)
             if (ready) {
-              const context = await fetchAndFormatTaskContext(
-                connId,
-                taskSnapshot,
-                workspaceState.repoRoot ?? undefined,
-              )
+              const context = await window.api.taskTrackerBuildTaskContext({
+                connectionId: connId,
+                task: taskSnapshot,
+                repoRoot: workspaceState.repoRoot ?? undefined,
+              })
               await window.api.agentSendTaskContext({
                 text: context,
-                worktreePath,
+                worktreePath: created.worktreePath,
                 sessionId,
               })
             }
@@ -200,7 +211,7 @@
           addToast('Failed to send task context to agent')
         }
       } else {
-        await selectWorktree(worktreePath)
+        await selectWorktree(created.worktreePath)
       }
 
       closeDialog()

--- a/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
@@ -7,7 +7,6 @@
   import { addToast } from '../../lib/stores/toast.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import { getActiveAgentPane, switchTab } from '../../lib/stores/tabs.svelte'
-  import { fetchAndFormatTaskContext } from '../../lib/taskTracker/taskContext'
   import BranchCreateForm from './BranchCreateForm.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
@@ -253,11 +252,11 @@
     e.stopPropagation()
     const result = getActiveAgentPane()
     if (!result) return
-    const context = await fetchAndFormatTaskContext(
+    const context = await window.api.taskTrackerBuildTaskContext({
       connectionId,
       task,
-      workspaceState.repoRoot ?? undefined,
-    )
+      repoRoot: workspaceState.repoRoot ?? undefined,
+    })
     await switchTab(result.tabId)
     await window.api.agentSendTaskContext({
       text: context,

--- a/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
+++ b/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
@@ -77,7 +77,7 @@
     containerEl?.focus()
     window.api.getHomedir().then((h) => (homedir = h))
     try {
-      const list = await window.api.gitBranches(repoRoot)
+      const list = await window.api.worktreeListBranches({ repoRoot })
       branches = { local: list.local, remote: list.remote }
       if (baseBranchProp) {
         selectedBase = baseBranchProp
@@ -92,8 +92,7 @@
   async function refreshBranches(): Promise<void> {
     refreshing = true
     try {
-      await window.api.gitFetchAll(repoRoot)
-      const list = await window.api.gitBranches(repoRoot)
+      const list = await window.api.worktreeRefreshBranches({ repoRoot })
       branches = { local: list.local, remote: list.remote }
     } catch {
       // fetch failed — keep existing branch list
@@ -175,8 +174,14 @@
     if (!newBranchName || branchNameError || !selectedBase) return
     step = 'creating'
     try {
-      await window.api.gitWorktreeAdd(repoRoot, worktreeDir, newBranchName, selectedBase)
-      createdPath = worktreeDirDisplay
+      const created = await window.api.worktreeCreate({
+        repoRoot,
+        worktreePath: worktreeDir,
+        mode: 'new',
+        branch: newBranchName,
+        baseBranch: selectedBase,
+      })
+      createdPath = created.worktreePath
 
       if (hasSetupConfig() && workspaceId) {
         step = 'setup'
@@ -195,8 +200,14 @@
     step = 'creating'
     try {
       const createLocalTracking = isRemoteOnly(selectedBase, branches)
-      await window.api.gitWorktreeCheckout(repoRoot, worktreeDir, selectedBase, createLocalTracking)
-      createdPath = worktreeDirDisplay
+      const created = await window.api.worktreeCreate({
+        repoRoot,
+        worktreePath: worktreeDir,
+        mode: 'existing',
+        branch: selectedBase,
+        createLocalTracking,
+      })
+      createdPath = created.worktreePath
 
       if (hasSetupConfig() && workspaceId) {
         step = 'setup'
@@ -224,7 +235,7 @@
     })
 
     try {
-      await window.api.runWorktreeSetup(workspaceId!, repoRoot, worktreeDirDisplay)
+      await window.api.runWorktreeSetup(workspaceId!, repoRoot, createdPath || worktreeDirDisplay)
     } catch (err) {
       setupErrors = [...setupErrors, err instanceof Error ? err.message : String(err)]
     }
@@ -241,10 +252,11 @@
     finishTimer = setTimeout(
       async () => {
         finishTimer = null
-        await openTool(getPref('newWorktree.toolId', 'shell'), worktreeDirDisplay).catch((err) => {
+        const targetPath = createdPath || worktreeDirDisplay
+        await openTool(getPref('newWorktree.toolId', 'shell'), targetPath).catch((err) => {
           console.error('Failed to launch tool after worktree creation:', err)
         })
-        selectWorktree(worktreeDirDisplay)
+        selectWorktree(targetPath)
         onClose()
       },
       setupErrors.length > 0 ? 2000 : 400,

--- a/src/renderer/src/lib/platform.ts
+++ b/src/renderer/src/lib/platform.ts
@@ -1,5 +1,10 @@
 import { match } from 'ts-pattern'
 
+export function isMacPlatform(): boolean {
+  if (window.api.platform === 'darwin') return true
+  return /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+}
+
 /** Platform-aware label for the native file manager action. */
 export function fileManagerLabel(): string {
   return match(window.api.platform)

--- a/src/renderer/src/lib/remote/HostRpcServer.ts
+++ b/src/renderer/src/lib/remote/HostRpcServer.ts
@@ -177,7 +177,7 @@ export class HostRpcServer {
     // reflects the new worktree list without waiting for the next delta.
     this.register('git.listBranches', async (params) => {
       const repoRoot = assertString(params, 'repoRoot', 'git.listBranches')
-      return await window.api.gitBranches(repoRoot)
+      return await window.api.worktreeListBranches({ repoRoot })
     })
 
     this.register('worktree.add', async (params) => {
@@ -185,7 +185,13 @@ export class HostRpcServer {
       const path = assertString(params, 'path', 'worktree.add')
       const branch = assertString(params, 'branch', 'worktree.add')
       const baseBranch = assertString(params, 'baseBranch', 'worktree.add')
-      await window.api.gitWorktreeAdd(repoRoot, path, branch, baseBranch)
+      await window.api.worktreeCreate({
+        repoRoot,
+        worktreePath: path,
+        mode: 'new',
+        branch,
+        baseBranch,
+      })
       provider.rebroadcast()
     })
 
@@ -198,7 +204,13 @@ export class HostRpcServer {
         'createLocalTracking',
         'worktree.addCheckout',
       )
-      await window.api.gitWorktreeCheckout(repoRoot, path, branch, createLocalTracking)
+      await window.api.worktreeCreate({
+        repoRoot,
+        worktreePath: path,
+        mode: 'existing',
+        branch,
+        createLocalTracking,
+      })
       provider.rebroadcast()
     })
 
@@ -206,7 +218,12 @@ export class HostRpcServer {
       const repoRoot = assertString(params, 'repoRoot', 'worktree.remove')
       const path = assertString(params, 'path', 'worktree.remove')
       const force = assertBoolean(params, 'force', 'worktree.remove')
-      await window.api.gitWorktreeRemove(repoRoot, path, force)
+      await window.api.worktreeRemoveWithBranch({
+        repoRoot,
+        worktreePath: path,
+        deleteBranch: false,
+        forceOnFailure: force,
+      })
       provider.rebroadcast()
     })
 

--- a/src/renderer/src/lib/stores/fileTree.svelte.ts
+++ b/src/renderer/src/lib/stores/fileTree.svelte.ts
@@ -70,26 +70,14 @@ function createFileTreeStore() {
   const gitChangedDirs = new SvelteSet<string>()
   let refreshTimer: ReturnType<typeof setTimeout> | null = null
 
-  function recomputeChangedDirs(): void {
-    gitChangedDirs.clear()
-    for (const filePath of gitFileStatus.keys()) {
-      const segments = filePath.split('/')
-      let dir = ''
-      for (let i = 0; i < segments.length - 1; i++) {
-        dir = dir === '' ? segments[i] : `${dir}/${segments[i]}`
-        gitChangedDirs.add(dir)
-      }
-    }
-  }
-
   async function expandDir(dirPath: string): Promise<void> {
     try {
-      const entries = await window.api.readDir(dirPath)
+      const entries = await window.api.fileTreeReadDir(dirPath)
       expandedDirs[dirPath] = entries
     } catch (e) {
       // Show empty rather than leaving in collapsed state
       expandedDirs[dirPath] = []
-      console.warn('readDir failed:', dirPath, e)
+      console.warn('fileTreeReadDir failed:', dirPath, e)
     }
   }
 
@@ -118,33 +106,21 @@ function createFileTreeStore() {
     if (!rootPath) return
     try {
       const previousPaths = [...gitFileStatus.keys()]
-      const porcelain = await window.api.gitStatusPorcelain(repoRoot, rootPath)
-      const nextStatuses: Record<string, string> = {}
+      const nextStatus = await window.api.fileTreeGetGitStatus(repoRoot, rootPath)
       // eslint-disable-next-line svelte/prefer-svelte-reactivity
-      const affectedPaths = new Set<string>()
-
-      const collectPaths = (rawPath: string): void => {
-        for (const part of rawPath.split(' -> ')) {
-          const normalized = part.trim()
-          if (normalized) affectedPaths.add(normalized)
-        }
-      }
+      const affectedPaths = new Set<string>(nextStatus.affectedPaths)
 
       gitFileStatus.clear()
-      for (const line of porcelain.split('\n')) {
-        if (line.length < 4) continue
-        const xy = line.substring(0, 2)
-        const fp = line.substring(3)
-        const status = xy[0] !== ' ' && xy[0] !== '?' ? xy[0] : xy[1]
-        const normalizedStatus = status === '?' ? '?' : status
-        nextStatuses[fp] = normalizedStatus
-        gitFileStatus.set(fp, normalizedStatus)
-        collectPaths(fp)
+      for (const [filePath, status] of Object.entries(nextStatus.statuses)) {
+        gitFileStatus.set(filePath, status)
       }
-      recomputeChangedDirs()
+      gitChangedDirs.clear()
+      for (const dir of nextStatus.changedDirs) {
+        gitChangedDirs.add(dir)
+      }
 
       for (const prevPath of previousPaths) {
-        if (!(prevPath in nextStatuses)) {
+        if (!(prevPath in nextStatus.statuses)) {
           affectedPaths.add(prevPath)
         }
       }

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -25,6 +25,7 @@ import type {
   EditorFileSaveResult,
   PaneSnapshot,
   SplitSnapshot,
+  TabCloseAllPreflightResult,
   TabClosePreflightResult,
   TabCommandResult,
   TabSnapshot,
@@ -91,6 +92,19 @@ export const tabsByWorktree: Record<string, TabInfo[]> = $state({})
 export const activeTabId: Record<string, string> = $state({})
 const EMPTY_TABS: TabInfo[] = []
 
+function editorFilesFromSnapshot(
+  snapshotFiles: PaneSnapshot['editorFiles'],
+  previousFiles: EditorFileState[] | undefined,
+): EditorFileState[] | undefined {
+  if (!snapshotFiles) return previousFiles?.map((file) => ({ ...file }))
+
+  const previousByPath = new Map(previousFiles?.map((file) => [file.filePath, file]) ?? [])
+  return snapshotFiles.map((file) => {
+    const previous = previousByPath.get(file.filePath)
+    return previous ? { ...file, ...previous, filePath: file.filePath } : { ...file }
+  })
+}
+
 function paneFromSnapshot(snapshot: PaneSnapshot, previous?: PaneSession): PaneSession {
   return {
     ...previous,
@@ -110,30 +124,41 @@ function paneFromSnapshot(snapshot: PaneSnapshot, previous?: PaneSession): PaneS
     inspectorOpen: snapshot.inspectorOpen,
     profileId: snapshot.profileId,
     profileName: snapshot.profileName,
-    editorFiles: previous?.editorFiles ?? snapshot.editorFiles?.map((file) => ({ ...file })),
+    editorFiles: editorFilesFromSnapshot(snapshot.editorFiles, previous?.editorFiles),
     editorActiveFile: snapshot.editorActiveFile ?? previous?.editorActiveFile,
   }
 }
 
-function splitFromSnapshot(snapshot: SplitSnapshot): SplitNode {
-  if (snapshot.type === 'leaf') return createLeaf(paneFromSnapshot(snapshot.pane))
+function previousPaneFromSplit(
+  previous: SplitNode | undefined,
+  paneId: string,
+): PaneSession | undefined {
+  return previous ? allPanes(previous).find((pane) => pane.id === paneId) : undefined
+}
+
+function splitFromSnapshot(snapshot: SplitSnapshot, previous?: SplitNode): SplitNode {
+  if (snapshot.type === 'leaf') {
+    return createLeaf(
+      paneFromSnapshot(snapshot.pane, previousPaneFromSplit(previous, snapshot.pane.id)),
+    )
+  }
   return {
     type: snapshot.direction === 'horizontal' ? 'hsplit' : 'vsplit',
     id: snapshot.id,
     ratio: snapshot.ratio,
-    first: splitFromSnapshot(snapshot.first),
-    second: splitFromSnapshot(snapshot.second),
+    first: splitFromSnapshot(snapshot.first, previous),
+    second: splitFromSnapshot(snapshot.second, previous),
   }
 }
 
-function tabFromSnapshot(snapshot: TabSnapshot): TabInfo {
+function tabFromSnapshot(snapshot: TabSnapshot, previous?: TabInfo): TabInfo {
   return {
     id: snapshot.id,
     toolId: snapshot.toolId,
     toolName: snapshot.toolName,
     name: snapshot.name,
     worktreePath: snapshot.worktreePath,
-    rootSplit: splitFromSnapshot(snapshot.rootSplit),
+    rootSplit: splitFromSnapshot(snapshot.rootSplit, previous?.rootSplit),
     focusedPaneId: snapshot.focusedPaneId,
     suspended: snapshot.suspended,
   }
@@ -141,7 +166,7 @@ function tabFromSnapshot(snapshot: TabSnapshot): TabInfo {
 
 export function applyTabsSnapshot(
   snapshot: TabStateSnapshot,
-  options: { force?: boolean; replaceAll?: boolean } = {},
+  options: { replaceAll?: boolean } = {},
 ): void {
   if (options.replaceAll) {
     const incomingWorktrees = Object.keys(snapshot.tabsByWorktree)
@@ -155,21 +180,15 @@ export function applyTabsSnapshot(
   }
 
   for (const [worktreePath, tabSnapshots] of Object.entries(snapshot.tabsByWorktree)) {
-    const currentTabs = tabsByWorktree[worktreePath] ?? []
-    const currentIds = currentTabs.map((tab) => tab.id).join('\0')
-    const snapshotIds = tabSnapshots.map((tab) => tab.id).join('\0')
+    const previousTabs = tabsByWorktree[worktreePath] ?? []
     const incomingActiveTabId = snapshot.activeTabIdByWorktree[worktreePath] ?? null
 
-    if (
-      !options.force &&
-      currentTabs.length > 0 &&
-      currentIds === snapshotIds &&
-      (activeTabId[worktreePath] ?? null) === incomingActiveTabId
-    ) {
-      continue
-    }
-
-    tabsByWorktree[worktreePath] = tabSnapshots.map(tabFromSnapshot)
+    tabsByWorktree[worktreePath] = tabSnapshots.map((tab) =>
+      tabFromSnapshot(
+        tab,
+        previousTabs.find((previous) => previous.id === tab.id),
+      ),
+    )
     for (const tab of tabsByWorktree[worktreePath]) {
       for (const pane of allPanes(tab.rootSplit)) initPaneRuntimeState(pane)
     }
@@ -189,13 +208,10 @@ function initPaneRuntimeState(pane: PaneSession): void {
 }
 
 function applyTabCommandResult(result: TabCommandResult): void {
-  applyTabsSnapshot(
-    {
-      tabsByWorktree: { [result.worktreePath]: result.tabs },
-      activeTabIdByWorktree: { [result.worktreePath]: result.activeTabId },
-    },
-    { force: true },
-  )
+  applyTabsSnapshot({
+    tabsByWorktree: { [result.worktreePath]: result.tabs },
+    activeTabIdByWorktree: { [result.worktreePath]: result.activeTabId },
+  })
 }
 
 function applyOpenedTabResult(result: TabCommandResult): TabInfo | null {
@@ -299,47 +315,41 @@ async function handleClosePreflightFailure(
   return false
 }
 
+async function handleCloseAllPreflightFailure(
+  preflight: TabCloseAllPreflightResult,
+  cancelledMessage: string,
+): Promise<boolean> {
+  if (!preflight.ok && preflight.reason === 'active-processes') return false
+  return handleClosePreflightFailure(preflight, cancelledMessage)
+}
+
 async function prepareCloseAllTabsForWorktree(
   worktreePath: string,
   tabs: TabInfo[],
 ): Promise<boolean> {
-  const openTabs = tabs.filter((tab) => !tab.suspended)
+  let preflight = await window.api.tabPrepareCloseAllForWorktree(worktreePath)
 
-  const closeWarnings = (
-    await Promise.all(
-      openTabs.map(async (tab) => {
-        const { description } = await window.api.tabGetCloseWarning(worktreePath, {
-          kind: 'tab',
-          tabId: tab.id,
-        })
-        return description ? { tabName: getTabDisplayName(tab), description } : null
-      }),
-    )
-  ).filter((entry): entry is { tabName: string; description: string } => entry !== null)
-
-  if (closeWarnings.length > 0) {
+  if (!preflight.ok && preflight.reason === 'active-processes') {
     const confirmed = await confirm({
       title: tabs.length === 1 ? 'Close tab?' : 'Close all tabs?',
       message:
-        closeWarnings.length === 1
-          ? `A tab has ${closeWarnings[0].description} that will be terminated.`
-          : `${closeWarnings.length} tabs have active processes that will be terminated.`,
-      details: closeWarnings
+        preflight.warnings.length === 1
+          ? `A tab has ${preflight.warnings[0].description} that will be terminated.`
+          : `${preflight.warnings.length} tabs have active processes that will be terminated.`,
+      details: preflight.warnings
         .map((warning) => `${warning.tabName}: ${warning.description}`)
         .join('\n'),
       confirmLabel: tabs.length === 1 ? 'Close Tab' : 'Close All Tabs',
       destructive: true,
     })
     if (!confirmed) return false
+
+    preflight = await window.api.tabPrepareCloseAllForWorktree(worktreePath, {
+      confirmedActiveProcesses: true,
+    })
   }
 
-  for (const tab of openTabs) {
-    const closePreflight = await window.api.tabPrepareCloseTab(worktreePath, tab.id)
-    const ok = await handleClosePreflightFailure(closePreflight, 'Close all tabs cancelled.')
-    if (!ok) return false
-  }
-
-  return true
+  return handleCloseAllPreflightFailure(preflight, 'Close all tabs cancelled.')
 }
 
 export async function closeTab(tabId: string): Promise<void> {
@@ -971,7 +981,7 @@ export async function killAllTabs(): Promise<void> {
   const allSessions = allTabsList.filter((t) => !t.suspended).flatMap((t) => allPanes(t.rootSplit))
   for (const p of allSessions) disposeEphemeralPaneState(p)
   const result = await window.api.tabKillAll()
-  applyTabsSnapshot(result, { force: true, replaceAll: true })
+  applyTabsSnapshot(result, { replaceAll: true })
 }
 
 export function focusSessionByPtyId(ptySessionId: string): void {

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -1,19 +1,11 @@
-import { match, P } from 'ts-pattern'
+import { match } from 'ts-pattern'
 import {
   type PaneSession,
   type SplitNode,
   type EditorFileState,
   createLeaf,
-  nextPaneId,
   allPanes,
   findLeaf,
-  splitPane as treeSplitPane,
-  removePane as treeRemovePane,
-  updatePane as treeUpdatePane,
-  updateRatio as treeUpdateRatio,
-  firstLeaf,
-  navigateFrom,
-  graftSubtree,
 } from './splitTree'
 import type { DropZone } from './dragState.svelte'
 import { recordFileOpen } from './quickOpenMru.svelte'
@@ -25,16 +17,18 @@ import {
   type AgentType,
 } from '../agents/agentState.svelte'
 import { confirm } from './dialogs.svelte'
-import { getPref } from './preferences.svelte'
 import { browserSessions } from '../browser/browserState.svelte'
 import { notesUiScope } from './notes.svelte'
-import { getProfileById } from './profiles.svelte'
 import { drawingsState } from './drawings.svelte'
 import type {
+  EditorFileLoadResult,
+  EditorFileSaveResult,
   PaneSnapshot,
   SplitSnapshot,
+  TabClosePreflightResult,
   TabCommandResult,
   TabSnapshot,
+  TabStateSnapshot,
 } from '../../../../main/commands/types'
 
 function hasRemainingDrawingPanes(excludeId: string): boolean {
@@ -63,58 +57,6 @@ function disposeEphemeralPaneState(pane: PaneSession): void {
 
 const AI_TOOL_IDS = new Set(['claude', 'codex', 'opencode', 'gemini'])
 export const isAiToolId = (id: string): boolean => AI_TOOL_IDS.has(id)
-
-const ACTIVE_CLAUDE_STATUSES = new Set([
-  'thinking',
-  'toolCalling',
-  'compacting',
-  'waitingPermission',
-])
-
-async function getActiveProcessDescription(panes: PaneSession[]): Promise<string | null> {
-  let busyClaude = 0
-  let activeShell = 0
-
-  await Promise.all(
-    panes.map(async (p) => {
-      if (!p.isRunning) return
-      if (AI_TOOL_IDS.has(p.toolId)) {
-        const s = agentSessions[p.sessionId]
-        if (s && ACTIVE_CLAUDE_STATUSES.has(s.status.type)) busyClaude++
-      } else {
-        try {
-          if (await window.api.hasChildProcess(p.sessionId)) activeShell++
-        } catch {
-          // Ignore — PTY may already be gone
-        }
-      }
-    }),
-  )
-
-  if (busyClaude === 0 && activeShell === 0) return null
-
-  const parts: string[] = []
-  if (busyClaude > 0) {
-    parts.push(`${busyClaude} active Claude session${busyClaude > 1 ? 's' : ''}`)
-  }
-  if (activeShell > 0) {
-    parts.push(`${activeShell} running process${activeShell > 1 ? 'es' : ''}`)
-  }
-  return parts.join(' and ')
-}
-
-// --- Layout serialization types ---
-
-interface SerializedLayout {
-  tabs: SerializedTab[]
-  activeTabIndex: number
-}
-
-interface SerializedTab {
-  toolId: string
-  toolName: string
-  rootSplit: SerializedSplitNode
-}
 
 type SerializedSplitNode =
   | {
@@ -145,88 +87,9 @@ export interface TabInfo {
   suspended?: SerializedSplitNode
 }
 
-interface ClosedTab {
-  toolId: string
-  toolName: string
-  worktreePath: string
-  closedAt: number
-}
-
-const MAX_CLOSED_TABS = 20
-
 export const tabsByWorktree: Record<string, TabInfo[]> = $state({})
 export const activeTabId: Record<string, string> = $state({})
-const closedTabs: Record<string, ClosedTab[]> = $state({})
-
-let tabCounter = 0
-function nextTabId(): string {
-  return `tab-${++tabCounter}`
-}
-
-function computeDisplayName(
-  toolName: string,
-  worktreePath: string,
-  toolId: string,
-  profileName?: string,
-): string {
-  const baseLabel =
-    profileName && profileName !== 'Default' ? `${toolName} (${profileName})` : toolName
-  const existing = tabsByWorktree[worktreePath] ?? []
-  const sameLabelCount = existing.filter(
-    (t) => t.name === baseLabel || t.name.startsWith(`${baseLabel} #`),
-  ).length
-  if (sameLabelCount === 0) return baseLabel
-  return `${baseLabel} #${sameLabelCount + 1}`
-}
-
-function paneToSnapshot(pane: PaneSession): PaneSnapshot {
-  return {
-    id: pane.id,
-    sessionId: pane.sessionId,
-    wsUrl: pane.wsUrl,
-    toolId: pane.toolId,
-    toolName: pane.toolName,
-    isRunning: pane.isRunning,
-    exitCode: pane.exitCode,
-    title: pane.title,
-    paneType: pane.paneType,
-    tmuxSessionName: pane.tmuxSessionName,
-    detached: pane.detached,
-    url: pane.url,
-    filePath: pane.filePath,
-    editorFiles: pane.editorFiles?.map((file) => ({ filePath: file.filePath })),
-    editorActiveFile: pane.editorActiveFile,
-    profileId: pane.profileId,
-    profileName: pane.profileName,
-  }
-}
-
-function splitToSnapshot(node: SplitNode): SplitSnapshot {
-  if (node.type === 'leaf') return { type: 'leaf', pane: paneToSnapshot(node.pane) }
-  return {
-    type: 'split',
-    direction: node.type === 'hsplit' ? 'horizontal' : 'vertical',
-    ratio: node.ratio,
-    first: splitToSnapshot(node.first),
-    second: splitToSnapshot(node.second),
-  }
-}
-
-function tabToSnapshot(tab: TabInfo): TabSnapshot {
-  return {
-    id: tab.id,
-    toolId: tab.toolId,
-    toolName: tab.toolName,
-    name: tab.name,
-    worktreePath: tab.worktreePath,
-    rootSplit: splitToSnapshot(tab.rootSplit),
-    focusedPaneId: tab.focusedPaneId,
-  }
-}
-
-function snapshotsForCommand(worktreePath: string): TabSnapshot[] {
-  return (tabsByWorktree[worktreePath] ?? []).map((tab) => tabToSnapshot(tab))
-}
+const EMPTY_TABS: TabInfo[] = []
 
 function paneFromSnapshot(snapshot: PaneSnapshot, previous?: PaneSession): PaneSession {
   return {
@@ -244,13 +107,10 @@ function paneFromSnapshot(snapshot: PaneSnapshot, previous?: PaneSession): PaneS
     url: snapshot.url,
     tmuxSessionName: snapshot.tmuxSessionName,
     detached: snapshot.detached,
+    inspectorOpen: snapshot.inspectorOpen,
     profileId: snapshot.profileId,
     profileName: snapshot.profileName,
-    editorFiles:
-      previous?.editorFiles ??
-      snapshot.editorFiles?.map((file) => ({
-        filePath: file.filePath,
-      })),
+    editorFiles: previous?.editorFiles ?? snapshot.editorFiles?.map((file) => ({ ...file })),
     editorActiveFile: snapshot.editorActiveFile ?? previous?.editorActiveFile,
   }
 }
@@ -259,7 +119,7 @@ function splitFromSnapshot(snapshot: SplitSnapshot): SplitNode {
   if (snapshot.type === 'leaf') return createLeaf(paneFromSnapshot(snapshot.pane))
   return {
     type: snapshot.direction === 'horizontal' ? 'hsplit' : 'vsplit',
-    id: `split-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    id: snapshot.id,
     ratio: snapshot.ratio,
     first: splitFromSnapshot(snapshot.first),
     second: splitFromSnapshot(snapshot.second),
@@ -275,6 +135,50 @@ function tabFromSnapshot(snapshot: TabSnapshot): TabInfo {
     worktreePath: snapshot.worktreePath,
     rootSplit: splitFromSnapshot(snapshot.rootSplit),
     focusedPaneId: snapshot.focusedPaneId,
+    suspended: snapshot.suspended,
+  }
+}
+
+export function applyTabsSnapshot(
+  snapshot: TabStateSnapshot,
+  options: { force?: boolean; replaceAll?: boolean } = {},
+): void {
+  if (options.replaceAll) {
+    const incomingWorktrees = Object.keys(snapshot.tabsByWorktree)
+    for (const worktreePath of Object.keys(tabsByWorktree)) {
+      if (!incomingWorktrees.includes(worktreePath)) delete tabsByWorktree[worktreePath]
+    }
+    const incomingActiveWorktrees = Object.keys(snapshot.activeTabIdByWorktree)
+    for (const worktreePath of Object.keys(activeTabId)) {
+      if (!incomingActiveWorktrees.includes(worktreePath)) delete activeTabId[worktreePath]
+    }
+  }
+
+  for (const [worktreePath, tabSnapshots] of Object.entries(snapshot.tabsByWorktree)) {
+    const currentTabs = tabsByWorktree[worktreePath] ?? []
+    const currentIds = currentTabs.map((tab) => tab.id).join('\0')
+    const snapshotIds = tabSnapshots.map((tab) => tab.id).join('\0')
+    const incomingActiveTabId = snapshot.activeTabIdByWorktree[worktreePath] ?? null
+
+    if (
+      !options.force &&
+      currentTabs.length > 0 &&
+      currentIds === snapshotIds &&
+      (activeTabId[worktreePath] ?? null) === incomingActiveTabId
+    ) {
+      continue
+    }
+
+    tabsByWorktree[worktreePath] = tabSnapshots.map(tabFromSnapshot)
+    for (const tab of tabsByWorktree[worktreePath]) {
+      for (const pane of allPanes(tab.rootSplit)) initPaneRuntimeState(pane)
+    }
+
+    if (incomingActiveTabId) {
+      activeTabId[worktreePath] = incomingActiveTabId
+    } else {
+      delete activeTabId[worktreePath]
+    }
   }
 }
 
@@ -284,15 +188,21 @@ function initPaneRuntimeState(pane: PaneSession): void {
   }
 }
 
+function applyTabCommandResult(result: TabCommandResult): void {
+  applyTabsSnapshot(
+    {
+      tabsByWorktree: { [result.worktreePath]: result.tabs },
+      activeTabIdByWorktree: { [result.worktreePath]: result.activeTabId },
+    },
+    { force: true },
+  )
+}
+
 function applyOpenedTabResult(result: TabCommandResult): TabInfo | null {
   const snapshot = result.openedTab
   if (!snapshot) return null
-  const tab = tabFromSnapshot(snapshot)
-  if (!tabsByWorktree[result.worktreePath]) tabsByWorktree[result.worktreePath] = []
-  tabsByWorktree[result.worktreePath].push(tab)
-  activeTabId[result.worktreePath] = result.activeTabId ?? tab.id
-  for (const pane of allPanes(tab.rootSplit)) initPaneRuntimeState(pane)
-  return tab
+  applyTabCommandResult(result)
+  return tabsByWorktree[result.worktreePath]?.find((tab) => tab.id === snapshot.id) ?? null
 }
 
 export function getActiveAgentPane(): { pane: PaneSession; tabId: string } | null {
@@ -333,8 +243,6 @@ export async function openTool(
     profileId: options?.profileId,
     workspaceName: project?.workspace.name ?? workspaceState.workspace?.name ?? '',
     branch: workspaceState.branch ?? undefined,
-    tabs: snapshotsForCommand(worktreePath),
-    activeTabId: activeTabId[worktreePath] ?? null,
   })
   const tab = applyOpenedTabResult(result)
   if (!tab) throw new Error('tab:command:openTool did not return an opened tab')
@@ -344,86 +252,94 @@ export async function openTool(
 }
 
 export function openTmuxTab(
-  tmuxSessionName: string,
+  _tmuxSessionName: string,
   sessionId: string,
-  wsUrl: string,
+  _wsUrl: string,
   worktreePath: string,
-): TabInfo {
-  const paneId = nextPaneId()
-  const pane: PaneSession = {
-    id: paneId,
-    sessionId,
-    wsUrl,
-    toolId: 'shell',
-    toolName: 'Shell',
-    isRunning: true,
-    exitCode: null,
-    title: null,
-    tmuxSessionName,
-  }
-
-  const id = nextTabId()
-  const name = computeDisplayName('Shell', worktreePath, 'shell')
-
-  const tab: TabInfo = {
-    id,
-    toolId: 'shell',
-    toolName: 'Shell',
-    name,
-    worktreePath,
-    rootSplit: createLeaf(pane),
-    focusedPaneId: paneId,
-  }
-
-  if (!tabsByWorktree[worktreePath]) {
-    tabsByWorktree[worktreePath] = []
-  }
-  tabsByWorktree[worktreePath].push(tab)
-  activeTabId[worktreePath] = id
-
-  scheduleSave(worktreePath)
-  return tab
+): void {
+  void openSessionTabInMain('Shell', sessionId, worktreePath).catch((err) => {
+    console.error(`[tabs] tabOpenSessionTab failed for "${worktreePath}":`, err)
+  })
 }
 
 export function openRunConfigTab(
   configName: string,
   sessionId: string,
-  wsUrl: string,
+  _wsUrl: string,
   worktreePath: string,
-): TabInfo {
-  const paneId = nextPaneId()
-  const pane: PaneSession = {
-    id: paneId,
-    sessionId,
-    wsUrl,
-    toolId: 'shell',
-    toolName: 'Shell',
-    isRunning: true,
-    exitCode: null,
-    title: null,
-  }
+): void {
+  void openSessionTabInMain(configName, sessionId, worktreePath).catch((err) => {
+    console.error(`[tabs] tabOpenSessionTab failed for "${worktreePath}":`, err)
+  })
+}
 
-  const id = nextTabId()
-  const name = computeDisplayName(configName, worktreePath, 'shell')
-
-  const tab: TabInfo = {
-    id,
-    toolId: 'shell',
-    toolName: configName,
-    name,
-    worktreePath,
-    rootSplit: createLeaf(pane),
-    focusedPaneId: paneId,
-  }
-
-  if (!tabsByWorktree[worktreePath]) {
-    tabsByWorktree[worktreePath] = []
-  }
-  tabsByWorktree[worktreePath].push(tab)
-  activeTabId[worktreePath] = id
-
-  scheduleSave(worktreePath)
+async function openSessionTabInMain(
+  name: string,
+  sessionId: string,
+  worktreePath: string,
+): Promise<TabInfo | null> {
+  const result = await window.api.tabOpenSessionTab(worktreePath, name, sessionId)
+  const tab = applyOpenedTabResult(result)
+  if (tab) scheduleSave(worktreePath)
   return tab
+}
+
+async function handleClosePreflightFailure(
+  preflight: TabClosePreflightResult,
+  cancelledMessage: string,
+): Promise<boolean> {
+  if (preflight.ok) return true
+  if (preflight.reason === 'save-failed') {
+    await confirm({
+      title: 'Save failed',
+      message: `Could not save ${preflight.failedCount} file(s). ${cancelledMessage}`,
+      confirmLabel: 'OK',
+    })
+  }
+  return false
+}
+
+async function prepareCloseAllTabsForWorktree(
+  worktreePath: string,
+  tabs: TabInfo[],
+): Promise<boolean> {
+  const openTabs = tabs.filter((tab) => !tab.suspended)
+
+  const closeWarnings = (
+    await Promise.all(
+      openTabs.map(async (tab) => {
+        const { description } = await window.api.tabGetCloseWarning(worktreePath, {
+          kind: 'tab',
+          tabId: tab.id,
+        })
+        return description ? { tabName: getTabDisplayName(tab), description } : null
+      }),
+    )
+  ).filter((entry): entry is { tabName: string; description: string } => entry !== null)
+
+  if (closeWarnings.length > 0) {
+    const confirmed = await confirm({
+      title: tabs.length === 1 ? 'Close tab?' : 'Close all tabs?',
+      message:
+        closeWarnings.length === 1
+          ? `A tab has ${closeWarnings[0].description} that will be terminated.`
+          : `${closeWarnings.length} tabs have active processes that will be terminated.`,
+      details: closeWarnings
+        .map((warning) => `${warning.tabName}: ${warning.description}`)
+        .join('\n'),
+      confirmLabel: tabs.length === 1 ? 'Close Tab' : 'Close All Tabs',
+      destructive: true,
+    })
+    if (!confirmed) return false
+  }
+
+  for (const tab of openTabs) {
+    const closePreflight = await window.api.tabPrepareCloseTab(worktreePath, tab.id)
+    const ok = await handleClosePreflightFailure(closePreflight, 'Close all tabs cancelled.')
+    if (!ok) return false
+  }
+
+  return true
 }
 
 export async function closeTab(tabId: string): Promise<void> {
@@ -434,94 +350,24 @@ export async function closeTab(tabId: string): Promise<void> {
     const tab = tabs[idx]
 
     if (tab.suspended) {
-      // Suspended tab: no live resources to clean up
-      if (!closedTabs[path]) closedTabs[path] = []
-      closedTabs[path].push({
-        toolId: tab.toolId,
-        toolName: tab.toolName,
-        worktreePath: path,
-        closedAt: Date.now(),
-      })
-      if (closedTabs[path].length > MAX_CLOSED_TABS) closedTabs[path].shift()
+      const result = await window.api.tabCloseTab(path, tabId)
 
-      tabsByWorktree[path].splice(idx, 1)
-
-      if (activeTabId[path] === tabId) {
-        const remaining = tabsByWorktree[path]
-        if (remaining.length > 0) {
-          const newIdx = Math.min(idx, remaining.length - 1)
-          const newActive = remaining[newIdx]
-          if (newActive.suspended && !(await resumeTab(newActive))) {
-            tabsByWorktree[path].splice(newIdx, 1)
-            const fallback = tabsByWorktree[path]
-            if (fallback.length > 0) {
-              activeTabId[path] = fallback[Math.min(newIdx, fallback.length - 1)].id
-            } else {
-              delete activeTabId[path]
-            }
-            scheduleSave(path)
-            return
-          }
-          activeTabId[path] = newActive.id
-        } else {
-          delete activeTabId[path]
-        }
-      }
-
+      applyTabCommandResult(result)
       scheduleSave(path)
       return
     }
 
-    // Check for active processes before closing
     const panes = allPanes(tab.rootSplit)
 
-    // Check for unsaved editor changes first
-    const dirtyFiles: Array<{ pane: PaneSession; file: EditorFileState }> = []
-    for (const p of panes) {
-      if (p.paneType !== 'editor') continue
-      for (const f of p.editorFiles ?? []) {
-        if (f.dirty === true) dirtyFiles.push({ pane: p, file: f })
-      }
-    }
-    if (dirtyFiles.length > 0) {
-      const choice = await window.api.confirmUnsavedChanges(dirtyFiles.map((d) => d.file.filePath))
-      if (choice === 'cancel') return
-      if (choice === 'save') {
-        const saveResults = await Promise.all(
-          dirtyFiles.map(async ({ file }) => {
-            try {
-              const content = file.currentContent ?? ''
-              const normalized =
-                file.fileLineEnding === 'CRLF' ? content.replace(/\r?\n/g, '\r\n') : content
-              const result = await window.api.writeFile(file.filePath, normalized, file.fileMtimeMs)
-              if (result.ok) return { ok: true as const }
-              const message =
-                result.tag === 'StaleWrite'
-                  ? 'File changed on disk — reload before saving'
-                  : result.message
-              return { ok: false as const, filePath: file.filePath, message }
-            } catch (e) {
-              return {
-                ok: false as const,
-                filePath: file.filePath,
-                message: e instanceof Error ? e.message : String(e),
-              }
-            }
-          }),
-        )
-        const failed = saveResults.filter((r) => !r.ok)
-        if (failed.length > 0) {
-          await confirm({
-            title: 'Save failed',
-            message: `Could not save ${failed.length} file(s). Tab close cancelled.`,
-            confirmLabel: 'OK',
-          })
-          return
-        }
-      }
+    const closePreflight = await window.api.tabPrepareCloseTab(path, tabId)
+    if (!(await handleClosePreflightFailure(closePreflight, 'Tab close cancelled.'))) {
+      return
     }
 
-    const description = await getActiveProcessDescription(panes)
+    const { description } = await window.api.tabGetCloseWarning(path, {
+      kind: 'tab',
+      tabId,
+    })
     if (description) {
       const confirmed = await confirm({
         title: 'Close tab?',
@@ -530,18 +376,6 @@ export async function closeTab(tabId: string): Promise<void> {
         destructive: true,
       })
       if (!confirmed) return
-    }
-
-    // Push to closed tabs stack
-    if (!closedTabs[path]) closedTabs[path] = []
-    closedTabs[path].push({
-      toolId: tab.toolId,
-      toolName: tab.toolName,
-      worktreePath: path,
-      closedAt: Date.now(),
-    })
-    if (closedTabs[path].length > MAX_CLOSED_TABS) {
-      closedTabs[path].shift()
     }
 
     // Kill all PTYs / destroy browser views and cleanup sessions
@@ -554,37 +388,9 @@ export async function closeTab(tabId: string): Promise<void> {
       }
       disposeEphemeralPaneState(p)
     }
-    await window.api.tabCloseTab(path, tabId, {
-      tabs: snapshotsForCommand(path),
-      activeTabId: activeTabId[path] ?? null,
-    })
+    const result = await window.api.tabCloseTab(path, tabId)
 
-    // Remove tab
-    tabsByWorktree[path].splice(idx, 1)
-
-    // If this was the active tab, switch to another
-    if (activeTabId[path] === tabId) {
-      const remaining = tabsByWorktree[path]
-      if (remaining.length > 0) {
-        const newIdx = Math.min(idx, remaining.length - 1)
-        const newActive = remaining[newIdx]
-        if (newActive.suspended && !(await resumeTab(newActive))) {
-          tabsByWorktree[path].splice(newIdx, 1)
-          const fallback = tabsByWorktree[path]
-          if (fallback.length > 0) {
-            activeTabId[path] = fallback[Math.min(newIdx, fallback.length - 1)].id
-          } else {
-            delete activeTabId[path]
-          }
-          scheduleSave(path)
-          return
-        }
-        activeTabId[path] = newActive.id
-      } else {
-        delete activeTabId[path]
-      }
-    }
-
+    applyTabCommandResult(result)
     scheduleSave(path)
     return
   }
@@ -595,20 +401,30 @@ export async function switchTab(tabId: string): Promise<void> {
     const tab = tabs.find((t) => t.id === tabId)
     if (tab) {
       if (tab.suspended && !(await resumeTab(tab))) return
-      activeTabId[path] = tabId
-      scheduleSave(path)
+      await setActiveTabInMain(path, tabId)
       return
     }
   }
 }
 
 export function moveTab(worktreePath: string, fromIndex: number, toIndex: number): void {
+  void moveTabInMain(worktreePath, fromIndex, toIndex).catch((err) => {
+    console.error(`[tabs] tabMoveTab failed for "${worktreePath}":`, err)
+  })
+}
+
+async function moveTabInMain(
+  worktreePath: string,
+  fromIndex: number,
+  toIndex: number,
+): Promise<void> {
   const tabs = tabsByWorktree[worktreePath]
   if (!tabs || fromIndex === toIndex) return
   if (fromIndex < 0 || fromIndex >= tabs.length) return
   if (toIndex < 0 || toIndex >= tabs.length) return
-  const [tab] = tabs.splice(fromIndex, 1)
-  tabs.splice(toIndex, 0, tab)
+
+  const result = await window.api.tabMoveTab(worktreePath, fromIndex, toIndex)
+  applyTabCommandResult(result)
   scheduleSave(worktreePath)
 }
 
@@ -617,7 +433,7 @@ export async function switchTabByIndex(worktreePath: string, index: number): Pro
   if (tabs && index >= 0 && index < tabs.length) {
     const tab = tabs[index]
     if (tab.suspended && !(await resumeTab(tab))) return
-    activeTabId[worktreePath] = tab.id
+    await setActiveTabInMain(worktreePath, tab.id)
   }
 }
 
@@ -630,7 +446,7 @@ export async function nextTab(worktreePath: string): Promise<void> {
   const nextIdx = (idx + 1) % tabs.length
   const tab = tabs[nextIdx]
   if (tab.suspended && !(await resumeTab(tab))) return
-  activeTabId[worktreePath] = tab.id
+  await setActiveTabInMain(worktreePath, tab.id)
 }
 
 export async function prevTab(worktreePath: string): Promise<void> {
@@ -642,119 +458,52 @@ export async function prevTab(worktreePath: string): Promise<void> {
   const prevIdx = (idx - 1 + tabs.length) % tabs.length
   const tab = tabs[prevIdx]
   if (tab.suspended && !(await resumeTab(tab))) return
-  activeTabId[worktreePath] = tab.id
+  await setActiveTabInMain(worktreePath, tab.id)
+}
+
+async function setActiveTabInMain(worktreePath: string, tabId: string): Promise<void> {
+  const result = await window.api.tabSetActiveTab(worktreePath, tabId)
+  applyTabCommandResult(result)
+  if (result.activeTabId === tabId) scheduleSave(worktreePath)
 }
 
 export async function reopenClosedTab(worktreePath: string): Promise<void> {
-  const stack = closedTabs[worktreePath]
-  if (!stack || stack.length === 0) return
-
-  const entry = stack.pop()!
-  await openTool(entry.toolId, worktreePath)
+  const project = getProjectForWorktree(worktreePath)
+  const result = await window.api.tabReopenClosedTab(worktreePath, {
+    workspaceName: project?.workspace.name ?? workspaceState.workspace?.name ?? '',
+    branch: workspaceState.branch ?? undefined,
+  })
+  if (!result.openedTab) return
+  applyTabCommandResult(result)
+  scheduleSave(worktreePath)
 }
 
 export const pendingEditorJumps = $state<Record<string, number>>({})
 
 export function openFile(filePath: string, worktreePath: string, opts?: { line?: number }): void {
-  // Record MRU entry as a relative path (matches what Quick Open shows)
   const relPath = filePath.startsWith(worktreePath + '/')
     ? filePath.slice(worktreePath.length + 1)
     : filePath
   recordFileOpen(worktreePath, relPath)
-  const tabs = (tabsByWorktree[worktreePath] ?? []).filter((t) => !t.suspended)
 
-  // 1. File already open somewhere in a live tab — focus it
-  for (const tab of tabs) {
-    const panes = allPanes(tab.rootSplit)
-    const existing = panes.find(
-      (p) =>
-        p.paneType === 'editor' &&
-        (p.filePath === filePath || p.editorFiles?.some((f) => f.filePath === filePath)),
-    )
-    if (existing) {
-      activeTabId[worktreePath] = tab.id
-      tab.focusedPaneId = existing.id
-      tab.rootSplit = treeUpdatePane(tab.rootSplit, existing.id, (p) => ({
-        ...p,
-        editorActiveFile: filePath,
-        editorFiles: ensureFileInList(p.editorFiles, filePath, p.filePath),
-        filePath,
-      }))
-      if (opts?.line) pendingEditorJumps[existing.id] = opts.line
-      return
-    }
-  }
-
-  // 2. Active tab in this worktree has an editor pane — add as sub-tab
-  const activeId = activeTabId[worktreePath]
-  const activeTab = tabs.find((t) => t.id === activeId)
-  if (activeTab) {
-    const panes = allPanes(activeTab.rootSplit)
-    const focusedEditor =
-      panes.find((p) => p.id === activeTab.focusedPaneId && p.paneType === 'editor') ??
-      panes.find((p) => p.paneType === 'editor')
-    if (focusedEditor) {
-      activeTab.rootSplit = treeUpdatePane(activeTab.rootSplit, focusedEditor.id, (p) => ({
-        ...p,
-        editorActiveFile: filePath,
-        editorFiles: ensureFileInList(p.editorFiles, filePath, p.filePath),
-        filePath,
-      }))
-      activeTab.focusedPaneId = focusedEditor.id
-      if (opts?.line) pendingEditorJumps[focusedEditor.id] = opts.line
-      scheduleSave(worktreePath)
-      return
-    }
-  }
-
-  // 3. Otherwise — create a new editor tab
-  const paneId = nextPaneId()
-  const EDITOR_LABEL = 'Editor'
-  const pane: PaneSession = {
-    id: paneId,
-    sessionId: '',
-    wsUrl: '',
-    toolId: 'editor',
-    toolName: EDITOR_LABEL,
-    isRunning: true,
-    exitCode: null,
-    title: null,
-    paneType: 'editor',
-    filePath,
-    editorFiles: [{ filePath }],
-    editorActiveFile: filePath,
-  }
-
-  const id = nextTabId()
-  const name = computeDisplayName(EDITOR_LABEL, worktreePath, 'editor')
-
-  const tab: TabInfo = {
-    id,
-    toolId: 'editor',
-    toolName: EDITOR_LABEL,
-    name,
-    worktreePath,
-    rootSplit: createLeaf(pane),
-    focusedPaneId: paneId,
-  }
-
-  if (!tabsByWorktree[worktreePath]) {
-    tabsByWorktree[worktreePath] = []
-  }
-  tabsByWorktree[worktreePath].push(tab)
-  activeTabId[worktreePath] = id
-  if (opts?.line) pendingEditorJumps[paneId] = opts.line
-  scheduleSave(worktreePath)
+  void openFileInMain(filePath, worktreePath, opts).catch((err) => {
+    console.error(`[tabs] tabOpenEditorFile failed for "${worktreePath}":`, err)
+  })
 }
 
-function ensureFileInList(
-  list: EditorFileState[] | undefined,
+async function openFileInMain(
   filePath: string,
-  legacySingle: string | undefined,
-): EditorFileState[] {
-  const base = list ?? (legacySingle ? [{ filePath: legacySingle }] : [])
-  if (base.some((f) => f.filePath === filePath)) return base
-  return [...base, { filePath }]
+  worktreePath: string,
+  opts?: { line?: number },
+): Promise<void> {
+  const result = await window.api.tabOpenEditorFile(worktreePath, filePath)
+
+  applyTabCommandResult(result)
+  const active = result.tabs.find((tab) => tab.id === result.activeTabId)
+  if (opts?.line && active) {
+    pendingEditorJumps[active.focusedPaneId] = opts.line
+  }
+  scheduleSave(worktreePath)
 }
 
 export function moveEditorFileBetweenPanes(
@@ -767,84 +516,43 @@ export function moveEditorFileBetweenPanes(
     moveEditorFile(targetPaneId, filePath, toIndex)
     return
   }
-  // Locate both panes and capture the file state from the source
-  let sourceTab: TabInfo | null = null
-  let sourcePane: PaneSession | null = null
+
+  void moveEditorFileBetweenPanesInMain(sourcePaneId, targetPaneId, filePath, toIndex).catch(
+    (err) => {
+      console.error(`[tabs] tabMoveEditorFileBetweenPanes failed for pane "${sourcePaneId}":`, err)
+    },
+  )
+}
+
+async function moveEditorFileBetweenPanesInMain(
+  sourcePaneId: string,
+  targetPaneId: string,
+  filePath: string,
+  toIndex: number,
+): Promise<void> {
   let sourceWorktree: string | null = null
-  let targetTab: TabInfo | null = null
   let targetWorktree: string | null = null
   for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
     for (const tab of tabs) {
       const pane = findLeaf(tab.rootSplit, sourcePaneId)
-      if (pane) {
-        sourceTab = tab
-        sourcePane = pane
+      if (pane?.editorFiles?.some((file) => file.filePath === filePath)) {
         sourceWorktree = worktreePath
       }
       if (findLeaf(tab.rootSplit, targetPaneId)) {
-        targetTab = tab
         targetWorktree = worktreePath
       }
     }
   }
-  if (!sourcePane || !sourceTab || !targetTab || !sourceWorktree || !targetWorktree) return
-  const movingFile = (sourcePane.editorFiles ?? []).find((f) => f.filePath === filePath)
-  if (!movingFile) return
+  if (!sourceWorktree || !targetWorktree || sourceWorktree !== targetWorktree) return
 
-  // Remove file from source pane; if empty, collapse the pane (or close the tab)
-  const remaining = (sourcePane.editorFiles ?? []).filter((f) => f.filePath !== filePath)
-  if (remaining.length === 0) {
-    const removed = treeRemovePane(sourceTab.rootSplit, sourcePaneId)
-    if (removed) {
-      if (removed.tree === null) {
-        void closeTab(sourceTab.id)
-      } else {
-        sourceTab.rootSplit = removed.tree
-        if (sourceTab.focusedPaneId === sourcePaneId) {
-          sourceTab.focusedPaneId = firstLeaf(removed.tree).id
-        }
-        scheduleSave(sourceWorktree)
-      }
-    }
-  } else {
-    const newActive =
-      sourcePane.editorActiveFile === filePath
-        ? remaining[Math.max(0, remaining.length - 1)].filePath
-        : sourcePane.editorActiveFile
-    sourceTab.rootSplit = treeUpdatePane(sourceTab.rootSplit, sourcePaneId, (p) => ({
-      ...p,
-      editorFiles: remaining,
-      editorActiveFile: newActive,
-      filePath: newActive,
-    }))
-    scheduleSave(sourceWorktree)
-  }
-
-  // Add file to target pane at toIndex
-  const targetPane = findLeaf(targetTab.rootSplit, targetPaneId)
-  if (!targetPane) return
-  const targetFiles = targetPane.editorFiles ?? []
-  const clamped = Math.max(0, Math.min(toIndex, targetFiles.length))
-  const next = [...targetFiles]
-  // Deduplicate — if file already exists in target, just focus it
-  const existingIdx = next.findIndex((f) => f.filePath === filePath)
-  if (existingIdx >= 0) {
-    targetTab.rootSplit = treeUpdatePane(targetTab.rootSplit, targetPaneId, (p) => ({
-      ...p,
-      editorActiveFile: filePath,
-      filePath,
-    }))
-  } else {
-    next.splice(clamped, 0, movingFile)
-    targetTab.rootSplit = treeUpdatePane(targetTab.rootSplit, targetPaneId, (p) => ({
-      ...p,
-      editorFiles: next,
-      editorActiveFile: filePath,
-      filePath,
-    }))
-  }
-  targetTab.focusedPaneId = targetPaneId
-  activeTabId[targetWorktree] = targetTab.id
+  const result = await window.api.tabMoveEditorFileBetweenPanes(
+    targetWorktree,
+    sourcePaneId,
+    targetPaneId,
+    filePath,
+    toIndex,
+  )
+  applyTabCommandResult(result)
   scheduleSave(targetWorktree)
 }
 
@@ -883,23 +591,25 @@ export function mergeTabIntoEditorPane(
 }
 
 export function moveEditorFile(paneId: string, filePath: string, toIndex: number): void {
+  void moveEditorFileInMain(paneId, filePath, toIndex).catch((err) => {
+    console.error(`[tabs] tabMoveEditorFile failed for pane "${paneId}":`, err)
+  })
+}
+
+async function moveEditorFileInMain(
+  paneId: string,
+  filePath: string,
+  toIndex: number,
+): Promise<void> {
   for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
     for (const tab of tabs) {
       const existing = findLeaf(tab.rootSplit, paneId)
       if (!existing) continue
       const files = existing.editorFiles ?? []
-      const fromIndex = files.findIndex((f) => f.filePath === filePath)
-      if (fromIndex === -1) continue
-      const clamped = Math.max(0, Math.min(toIndex, files.length))
-      if (clamped === fromIndex || clamped === fromIndex + 1) return
-      const next = [...files]
-      const [moved] = next.splice(fromIndex, 1)
-      const insertAt = clamped > fromIndex ? clamped - 1 : clamped
-      next.splice(insertAt, 0, moved)
-      tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({
-        ...p,
-        editorFiles: next,
-      }))
+      if (!files.some((f) => f.filePath === filePath)) continue
+
+      const result = await window.api.tabMoveEditorFile(worktreePath, paneId, filePath, toIndex)
+      applyTabCommandResult(result)
       scheduleSave(worktreePath)
       return
     }
@@ -907,16 +617,20 @@ export function moveEditorFile(paneId: string, filePath: string, toIndex: number
 }
 
 export function setActiveEditorFile(paneId: string, filePath: string): void {
-  for (const tabs of Object.values(tabsByWorktree)) {
+  void setActiveEditorFileInMain(paneId, filePath).catch((err) => {
+    console.error(`[tabs] tabSetActiveEditorFile failed for pane "${paneId}":`, err)
+  })
+}
+
+async function setActiveEditorFileInMain(paneId: string, filePath: string): Promise<void> {
+  for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
     for (const tab of tabs) {
       const existing = findLeaf(tab.rootSplit, paneId)
       if (!existing) continue
       if (!existing.editorFiles?.some((f) => f.filePath === filePath)) continue
-      tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({
-        ...p,
-        editorActiveFile: filePath,
-        filePath,
-      }))
+
+      const result = await window.api.tabSetActiveEditorFile(worktreePath, paneId, filePath)
+      applyTabCommandResult(result)
       return
     }
   }
@@ -927,174 +641,151 @@ export function updateEditorFileState(
   filePath: string,
   patch: Partial<EditorFileState>,
 ): void {
-  for (const tabs of Object.values(tabsByWorktree)) {
-    for (const tab of tabs) {
-      const existing = findLeaf(tab.rootSplit, paneId)
-      if (!existing) continue
-      if (!existing.editorFiles?.some((f) => f.filePath === filePath)) continue
-      tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({
-        ...p,
-        editorFiles: (p.editorFiles ?? []).map((f) =>
-          f.filePath === filePath ? { ...f, ...patch } : f,
-        ),
-      }))
-      return
-    }
-  }
+  void updateEditorFileStateInMain(paneId, filePath, patch).catch((err) => {
+    console.error(`[tabs] tabUpdateEditorFileState failed for pane "${paneId}":`, err)
+  })
 }
 
-export function closeEditorFile(paneId: string, filePath: string): void {
+async function updateEditorFileStateInMain(
+  paneId: string,
+  filePath: string,
+  patch: Partial<EditorFileState>,
+): Promise<void> {
   for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
     for (const tab of tabs) {
       const existing = findLeaf(tab.rootSplit, paneId)
       if (!existing) continue
       if (!existing.editorFiles?.some((f) => f.filePath === filePath)) continue
-      const remaining = (existing.editorFiles ?? []).filter((f) => f.filePath !== filePath)
-      if (remaining.length === 0) {
-        // No files left — close the pane (or the tab if this was the only pane)
-        const removed = treeRemovePane(tab.rootSplit, paneId)
-        if (removed) {
-          if (removed.tree === null) {
-            // Tab now empty — close it
-            void closeTab(tab.id)
-          } else {
-            tab.rootSplit = removed.tree
-            if (tab.focusedPaneId === paneId) {
-              tab.focusedPaneId = firstLeaf(removed.tree).id
-            }
-            scheduleSave(worktreePath)
-          }
-        }
-        return
-      }
-      const newActive =
-        existing.editorActiveFile === filePath
-          ? remaining[Math.max(0, remaining.length - 1)].filePath
-          : existing.editorActiveFile
-      tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({
-        ...p,
-        editorFiles: remaining,
-        editorActiveFile: newActive,
-        filePath: newActive,
-      }))
-      scheduleSave(worktreePath)
+
+      const result = await window.api.tabUpdateEditorFileState(
+        worktreePath,
+        paneId,
+        filePath,
+        patch,
+      )
+      applyTabCommandResult(result)
+      return
+    }
+  }
+}
+
+export async function loadEditorFile(
+  paneId: string,
+  filePath: string,
+  maxBytes?: number,
+): Promise<EditorFileLoadResult> {
+  for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
+    for (const tab of tabs) {
+      const existing = findLeaf(tab.rootSplit, paneId)
+      if (!existing) continue
+      if (!existing.editorFiles?.some((f) => f.filePath === filePath)) continue
+
+      const result = await window.api.tabLoadEditorFile(worktreePath, paneId, filePath, {
+        maxBytes,
+      })
+      if (result.ok) applyTabCommandResult(result.result)
+      return result
+    }
+  }
+  return { ok: false, tag: 'ReadFailed', message: 'Editor file is not open' }
+}
+
+export async function saveEditorFile(
+  paneId: string,
+  filePath: string,
+  content: string,
+  fileLineEnding: 'LF' | 'CRLF',
+  expectedMtimeMs?: number,
+): Promise<EditorFileSaveResult> {
+  for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
+    for (const tab of tabs) {
+      const existing = findLeaf(tab.rootSplit, paneId)
+      if (!existing) continue
+      if (!existing.editorFiles?.some((f) => f.filePath === filePath)) continue
+
+      const result = await window.api.tabSaveEditorFile(worktreePath, paneId, filePath, {
+        content,
+        fileLineEnding,
+        expectedMtimeMs,
+      })
+      if (result.ok) applyTabCommandResult(result.result)
+      return result
+    }
+  }
+  return { ok: false, tag: 'WriteFailed', message: 'Editor file is not open' }
+}
+
+export async function prepareCloseEditorFile(
+  paneId: string,
+  filePath: string,
+): Promise<TabClosePreflightResult> {
+  for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
+    for (const tab of tabs) {
+      const existing = findLeaf(tab.rootSplit, paneId)
+      if (!existing) continue
+      if (!existing.editorFiles?.some((f) => f.filePath === filePath)) continue
+      return window.api.tabPrepareCloseEditorFile(worktreePath, paneId, filePath)
+    }
+  }
+  return { ok: true }
+}
+
+export function closeEditorFile(paneId: string, filePath: string): void {
+  void closeEditorFileInMain(paneId, filePath).catch((err) => {
+    console.error(`[tabs] tabCloseEditorFile failed for pane "${paneId}":`, err)
+  })
+}
+
+async function closeEditorFileInMain(paneId: string, filePath: string): Promise<void> {
+  for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
+    for (const tab of tabs) {
+      const existing = findLeaf(tab.rootSplit, paneId)
+      if (!existing) continue
+      if (!existing.editorFiles?.some((f) => f.filePath === filePath)) continue
+
+      const result = await window.api.tabCloseEditorFile(worktreePath, paneId, filePath)
+      applyTabCommandResult(result)
+      if (result.closedPaneId) scheduleSave(worktreePath)
       return
     }
   }
 }
 
 export function detachEditorFile(paneId: string, filePath: string): void {
+  void detachEditorFileInMain(paneId, filePath).catch((err) => {
+    console.error(`[tabs] tabDetachEditorFile failed for pane "${paneId}":`, err)
+  })
+}
+
+async function detachEditorFileInMain(paneId: string, filePath: string): Promise<void> {
   for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
     for (const tab of tabs) {
       const existing = findLeaf(tab.rootSplit, paneId)
       if (!existing) continue
       if (!existing.editorFiles?.some((f) => f.filePath === filePath)) continue
-      // Remove from this pane first
-      const remaining = (existing.editorFiles ?? []).filter((f) => f.filePath !== filePath)
-      if (remaining.length === 0) {
-        // Only file — no-op (already in its own pane/tab)
-        return
-      }
-      const newActive =
-        existing.editorActiveFile === filePath
-          ? remaining[Math.max(0, remaining.length - 1)].filePath
-          : existing.editorActiveFile
-      tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({
-        ...p,
-        editorFiles: remaining,
-        editorActiveFile: newActive,
-        filePath: newActive,
-      }))
 
-      // Create new editor tab for the detached file
-      const newPaneId = nextPaneId()
-      const EDITOR_LABEL = 'Editor'
-      const newPane: PaneSession = {
-        id: newPaneId,
-        sessionId: '',
-        wsUrl: '',
-        toolId: 'editor',
-        toolName: EDITOR_LABEL,
-        isRunning: true,
-        exitCode: null,
-        title: null,
-        paneType: 'editor',
-        filePath,
-        editorFiles: [{ filePath }],
-        editorActiveFile: filePath,
-      }
-      const newTabId = nextTabId()
-      const name = computeDisplayName(EDITOR_LABEL, worktreePath, 'editor')
-      const newTab: TabInfo = {
-        id: newTabId,
-        toolId: 'editor',
-        toolName: EDITOR_LABEL,
-        name,
-        worktreePath,
-        rootSplit: createLeaf(newPane),
-        focusedPaneId: newPaneId,
-      }
-      tabsByWorktree[worktreePath].push(newTab)
-      activeTabId[worktreePath] = newTabId
-      scheduleSave(worktreePath)
+      const result = await window.api.tabDetachEditorFile(worktreePath, paneId, filePath)
+      applyTabCommandResult(result)
+      if (result.openedTab) scheduleSave(worktreePath)
       return
     }
   }
 }
 
 export function openDiffTab(worktreePath: string, scrollToFile?: string): void {
-  // Check if a diff tab already exists — focus it
-  const tabs = (tabsByWorktree[worktreePath] ?? []).filter((t) => !t.suspended)
-  for (const tab of tabs) {
-    const panes = allPanes(tab.rootSplit)
-    const existing = panes.find((p) => p.paneType === 'diff')
-    if (existing) {
-      activeTabId[worktreePath] = tab.id
-      tab.focusedPaneId = existing.id
-      if (scrollToFile) {
-        workspaceState.diffScrollTarget = { path: scrollToFile, ts: Date.now() }
-      }
-      return
-    }
-  }
+  void openDiffTabInMain(worktreePath, scrollToFile).catch((err) => {
+    console.error(`[tabs] tabOpenDiff failed for "${worktreePath}":`, err)
+  })
+}
 
-  // Create single diff tab for all changes
-  const paneId = nextPaneId()
-  const pane: PaneSession = {
-    id: paneId,
-    sessionId: '',
-    wsUrl: '',
-    toolId: 'diff',
-    toolName: 'Diff',
-    isRunning: false,
-    exitCode: null,
-    title: null,
-    paneType: 'diff',
-  }
-
-  const id = nextTabId()
-  const name = computeDisplayName('Diff', worktreePath, 'diff')
-
-  const tab: TabInfo = {
-    id,
-    toolId: 'diff',
-    toolName: 'Diff',
-    name,
-    worktreePath,
-    rootSplit: createLeaf(pane),
-    focusedPaneId: paneId,
-  }
-
-  if (!tabsByWorktree[worktreePath]) {
-    tabsByWorktree[worktreePath] = []
-  }
-  tabsByWorktree[worktreePath].push(tab)
-  activeTabId[worktreePath] = id
-  scheduleSave(worktreePath)
+async function openDiffTabInMain(worktreePath: string, scrollToFile?: string): Promise<void> {
+  const result = await window.api.tabOpenDiff(worktreePath)
+  applyTabCommandResult(result)
 
   if (scrollToFile) {
     workspaceState.diffScrollTarget = { path: scrollToFile, ts: Date.now() }
   }
+  if (result.openedTab) scheduleSave(worktreePath)
 }
 
 export function getActiveTab(worktreePath: string): TabInfo | null {
@@ -1105,7 +796,7 @@ export function getActiveTab(worktreePath: string): TabInfo | null {
 }
 
 export function getTabsForWorktree(worktreePath: string): TabInfo[] {
-  return tabsByWorktree[worktreePath] ?? []
+  return tabsByWorktree[worktreePath] ?? EMPTY_TABS
 }
 
 export function getRunningCountByTool(worktreePath: string, toolId: string): number {
@@ -1129,19 +820,13 @@ export async function handlePtyExit(
       const panes = allPanes(tab.rootSplit)
       const pane = panes.find((p) => p.sessionId === sessionId)
       if (pane) {
-        const tmuxName = tmuxSessionName || pane.tmuxSessionName
-        // Check if the tmux session is actually still alive before marking detached
-        let detached = false
-        if (tmuxName) {
-          detached = await window.api.tmuxHasSession(tmuxName).catch(() => false)
-        }
-        tab.rootSplit = treeUpdatePane(tab.rootSplit, pane.id, (p) => ({
-          ...p,
-          isRunning: false,
+        const result = await window.api.tabHandlePtyExit(
+          worktreePath,
+          sessionId,
           exitCode,
-          detached,
-          tmuxSessionName: detached ? p.tmuxSessionName : undefined,
-        }))
+          tmuxSessionName,
+        )
+        applyTabCommandResult(result)
         // Persist updated state so dead tabs are excluded from saved layout
         scheduleSave(worktreePath)
         return
@@ -1169,8 +854,6 @@ export async function restartPane(
   const result = await window.api.tabRestartPane(worktreePath, tabId, paneId, {
     workspaceName: project?.workspace.name ?? workspaceState.workspace?.name ?? '',
     branch: workspaceState.branch ?? undefined,
-    tabs: snapshotsForCommand(worktreePath),
-    activeTabId: activeTabId[worktreePath] ?? null,
   })
   if (!result.restartedPane) return
 
@@ -1181,12 +864,7 @@ export async function restartPane(
     delete browserSessions[pane.sessionId]
   }
 
-  tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (prev) => {
-    const next = paneFromSnapshot(result.restartedPane!, prev)
-    initPaneRuntimeState(next)
-    return next
-  })
-
+  applyTabCommandResult(result)
   scheduleSave(worktreePath)
 }
 
@@ -1203,30 +881,12 @@ export async function reattachTmuxPane(
   const pane = panes.find((p) => p.id === paneId)
   if (!pane?.tmuxSessionName) return
 
-  const exists = await window.api.tmuxHasSession(pane.tmuxSessionName)
-  if (exists) {
-    const result = await window.api.tmuxAttach(pane.tmuxSessionName)
-    tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({
-      ...p,
-      sessionId: result.sessionId,
-      wsUrl: result.wsUrl,
-      isRunning: true,
-      exitCode: null,
-      detached: false,
-    }))
-  } else {
-    // Tmux session gone, spawn fresh
-    const result = await window.api.tabSpawnPane(pane.toolId, worktreePath)
-    tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({
-      ...p,
-      sessionId: result.sessionId,
-      wsUrl: result.wsUrl,
-      isRunning: true,
-      exitCode: null,
-      detached: false,
-      tmuxSessionName: result.tmuxSessionName,
-    }))
-  }
+  const project = getProjectForWorktree(worktreePath)
+  const result = await window.api.tabReattachTmuxPane(worktreePath, tabId, paneId, {
+    workspaceName: project?.workspace.name ?? workspaceState.workspace?.name ?? '',
+    branch: workspaceState.branch ?? undefined,
+  })
+  applyTabCommandResult(result)
   scheduleSave(worktreePath)
 }
 
@@ -1243,17 +903,8 @@ export async function killTmuxPane(
   const pane = panes.find((p) => p.id === paneId)
   if (!pane?.tmuxSessionName) return
 
-  try {
-    await window.api.tmuxKillSession(pane.tmuxSessionName)
-  } catch {
-    // Session may already be gone
-  }
-  tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({
-    ...p,
-    isRunning: false,
-    detached: false,
-    tmuxSessionName: undefined,
-  }))
+  const result = await window.api.tabKillTmuxPane(worktreePath, tabId, paneId)
+  applyTabCommandResult(result)
   scheduleSave(worktreePath)
 }
 
@@ -1273,20 +924,17 @@ export async function restartTab(tabId: string): Promise<void> {
   }
 }
 
-export async function ensureDefaultTab(worktreePath: string): Promise<void> {
-  const tabs = tabsByWorktree[worktreePath]
-  if (tabs && tabs.length > 0) return
-  await openTool(getPref('newTab.toolId', 'shell'), worktreePath)
-}
-
 async function resumeTab(tab: TabInfo): Promise<boolean> {
   if (!tab.suspended) return true
-  const serialized = tab.suspended
   try {
-    const rootSplit = await restoreSplitNode(serialized, tab.worktreePath)
-    tab.rootSplit = rootSplit
-    tab.focusedPaneId = firstLeaf(rootSplit).id
-    tab.suspended = undefined
+    const project = getProjectForWorktree(tab.worktreePath)
+    const result = await window.api.tabResumeSuspendedTab(tab.worktreePath, tab.id, {
+      workspaceName: project?.workspace.name ?? workspaceState.workspace?.name ?? '',
+      branch: workspaceState.branch ?? undefined,
+    })
+    const resumed = result.tabs.find((candidate) => candidate.id === tab.id)
+    if (resumed?.suspended) return false
+    applyTabCommandResult(result)
     return true
   } catch (err) {
     console.error('Failed to resume suspended tab:', err)
@@ -1294,77 +942,65 @@ async function resumeTab(tab: TabInfo): Promise<boolean> {
   }
 }
 
-export async function closeAllTabsForWorktree(worktreePath: string): Promise<void> {
+export async function closeAllTabsForWorktree(worktreePath: string): Promise<boolean> {
   const tabs = tabsByWorktree[worktreePath]
-  if (!tabs || tabs.length === 0) return
+  if (!tabs || tabs.length === 0) return true
 
-  const allSessions = tabs.filter((t) => !t.suspended).flatMap((t) => allPanes(t.rootSplit))
+  if (!(await prepareCloseAllTabsForWorktree(worktreePath, [...tabs]))) return false
+
+  const currentTabs = tabsByWorktree[worktreePath] ?? []
+  const allSessions = currentTabs.filter((t) => !t.suspended).flatMap((t) => allPanes(t.rootSplit))
   for (const p of allSessions) {
     if (agentSessions[p.sessionId]) removeAgentSession(p.sessionId)
     if (p.paneType === 'browser') delete browserSessions[p.sessionId]
     disposeEphemeralPaneState(p)
   }
-  await Promise.allSettled(
-    allSessions
-      .filter((p) => p.paneType !== 'editor' && p.paneType !== 'notes' && p.paneType !== 'drawing')
-      .map((p) => {
-        if (p.paneType === 'browser') return window.api.teardownBrowserWebview(p.sessionId)
-        return window.api.killPty(p.sessionId, true)
-      }),
-  )
+
+  const result = await window.api.tabCloseAllForWorktree(worktreePath)
 
   if (saveTimers[worktreePath]) {
     clearTimeout(saveTimers[worktreePath])
     delete saveTimers[worktreePath]
   }
-  delete tabsByWorktree[worktreePath]
-  delete activeTabId[worktreePath]
-
-  const wsId = getProjectForWorktree(worktreePath)?.workspace.id
-  if (wsId) {
-    window.api.tabDeleteLayout(worktreePath).catch(() => {})
-  }
+  applyTabCommandResult(result)
+  return true
 }
 
 export async function killAllTabs(): Promise<void> {
   const allTabsList = Object.values(tabsByWorktree).flat()
   const allSessions = allTabsList.filter((t) => !t.suspended).flatMap((t) => allPanes(t.rootSplit))
   for (const p of allSessions) disposeEphemeralPaneState(p)
-  await Promise.all(
-    allSessions
-      .filter((p) => p.paneType !== 'editor' && p.paneType !== 'notes' && p.paneType !== 'drawing')
-      .map((p) => {
-        if (p.paneType === 'browser') return window.api.teardownBrowserWebview(p.sessionId)
-        return window.api.killPty(p.sessionId, true)
-      }),
-  )
-  for (const path of Object.keys(tabsByWorktree)) {
-    delete tabsByWorktree[path]
-    delete activeTabId[path]
-  }
+  const result = await window.api.tabKillAll()
+  applyTabsSnapshot(result, { force: true, replaceAll: true })
 }
 
-export function focusSessionByPtyId(ptySessionId: string): boolean {
-  for (const [path, tabs] of Object.entries(tabsByWorktree)) {
-    for (const tab of tabs) {
-      const panes = allPanes(tab.rootSplit)
-      const pane = panes.find((p) => p.sessionId === ptySessionId)
-      if (pane) {
-        // Use selectWorktree to fully update project context (sidebar, git info, etc.)
-        selectWorktree(path).catch((err) => {
-          console.error('[tabs] selectWorktree failed after focusSession:', err)
-        })
-        activeTabId[path] = tab.id
-        tab.focusedPaneId = pane.id
-        return true
-      }
-    }
-  }
-  return false
+export function focusSessionByPtyId(ptySessionId: string): void {
+  void focusSessionByPtyIdInMain(ptySessionId).catch((err) => {
+    console.error(`[tabs] tabFocusSession failed for "${ptySessionId}":`, err)
+  })
+}
+
+async function focusSessionByPtyIdInMain(ptySessionId: string): Promise<void> {
+  const result = await window.api.tabFocusSession(ptySessionId)
+  if (!result) return
+
+  // Use selectWorktree to fully update project context (sidebar, git info, etc.)
+  await selectWorktree(result.worktreePath).catch((err) => {
+    console.error('[tabs] selectWorktree failed after focusSession:', err)
+  })
+  applyTabCommandResult(result)
 }
 
 export function getAllTabs(): TabInfo[] {
-  return Object.values(tabsByWorktree).flat()
+  const groups = Object.values(tabsByWorktree)
+  if (groups.length === 0) return EMPTY_TABS
+  if (groups.length === 1) return groups[0] ?? EMPTY_TABS
+
+  let count = 0
+  for (const group of groups) count += group.length
+  if (count === 0) return EMPTY_TABS
+
+  return groups.flat()
 }
 
 export function findWorktreeForSession(sessionId: string): string | null {
@@ -1432,24 +1068,32 @@ export function toggleFocusedInspector(): void {
   if (!tab) return
   const pane = findLeaf(tab.rootSplit, tab.focusedPaneId)
   if (pane && AI_TOOL_IDS.has(pane.toolId)) {
-    tab.rootSplit = treeUpdatePane(tab.rootSplit, pane.id, (p) => ({
-      ...p,
-      inspectorOpen: p.inspectorOpen === false,
-    }))
+    void toggleFocusedInspectorInMain(path, tab.id).catch((err) => {
+      console.error(`[tabs] tabToggleFocusedInspector failed for tab "${tab.id}":`, err)
+    })
   }
 }
 
+async function toggleFocusedInspectorInMain(worktreePath: string, tabId: string): Promise<void> {
+  const result = await window.api.tabToggleFocusedInspector(worktreePath, tabId)
+  applyTabCommandResult(result)
+}
+
 export function updateTmuxSessionName(oldName: string, newName: string): void {
-  for (const tabs of Object.values(tabsByWorktree)) {
+  void updateTmuxSessionNameInMain(oldName, newName).catch((err) => {
+    console.error(`[tabs] tabUpdateTmuxSessionName failed for "${oldName}":`, err)
+  })
+}
+
+async function updateTmuxSessionNameInMain(oldName: string, newName: string): Promise<void> {
+  for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
     for (const tab of tabs) {
       const panes = allPanes(tab.rootSplit)
       const pane = panes.find((p) => p.tmuxSessionName === oldName)
       if (pane) {
-        tab.rootSplit = treeUpdatePane(tab.rootSplit, pane.id, (p) => ({
-          ...p,
-          tmuxSessionName: newName,
-        }))
-        scheduleSave(tab.worktreePath)
+        const result = await window.api.tabUpdateTmuxSessionName(worktreePath, oldName, newName)
+        applyTabCommandResult(result)
+        scheduleSave(worktreePath)
         return
       }
     }
@@ -1458,15 +1102,19 @@ export function updateTmuxSessionName(oldName: string, newName: string): void {
 
 export function updatePaneTitle(sessionId: string, title: string): void {
   if (!title) return
-  for (const tabs of Object.values(tabsByWorktree)) {
+  void updatePaneTitleInMain(sessionId, title).catch((err) => {
+    console.error(`[tabs] tabUpdatePaneTitle failed for session "${sessionId}":`, err)
+  })
+}
+
+async function updatePaneTitleInMain(sessionId: string, title: string): Promise<void> {
+  for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
     for (const tab of tabs) {
       const panes = allPanes(tab.rootSplit)
       const pane = panes.find((p) => p.sessionId === sessionId)
       if (pane) {
-        tab.rootSplit = treeUpdatePane(tab.rootSplit, pane.id, (p) => ({
-          ...p,
-          title,
-        }))
+        const result = await window.api.tabUpdatePaneTitle(worktreePath, sessionId, title)
+        applyTabCommandResult(result)
         // Forward title to main process for the notch overlay
         if (agentSessions[pane.sessionId]) {
           window.api.updateAgentTitle(sessionId, title)
@@ -1478,29 +1126,22 @@ export function updatePaneTitle(sessionId: string, title: string): void {
 }
 
 export function updateBrowserPaneUrl(sessionId: string, url: string): void {
-  for (const tabs of Object.values(tabsByWorktree)) {
+  void updateBrowserPaneUrlInMain(sessionId, url).catch((err) => {
+    console.error(`[tabs] tabUpdatePaneUrl failed for session "${sessionId}":`, err)
+  })
+}
+
+async function updateBrowserPaneUrlInMain(sessionId: string, url: string): Promise<void> {
+  for (const [worktreePath, tabs] of Object.entries(tabsByWorktree)) {
     for (const tab of tabs) {
       const panes = allPanes(tab.rootSplit)
       const pane = panes.find((p) => p.sessionId === sessionId)
       if (pane) {
-        tab.rootSplit = treeUpdatePane(tab.rootSplit, pane.id, (p) => ({
-          ...p,
-          url,
-        }))
-        scheduleSave(tab.worktreePath)
+        const result = await window.api.tabUpdatePaneUrl(worktreePath, sessionId, url)
+        applyTabCommandResult(result)
+        scheduleSave(worktreePath)
         return
       }
-    }
-  }
-}
-
-export function updateEditorPaneState(paneId: string, patch: Partial<PaneSession>): void {
-  for (const tabs of Object.values(tabsByWorktree)) {
-    for (const tab of tabs) {
-      const existing = findLeaf(tab.rootSplit, paneId)
-      if (!existing) continue
-      tab.rootSplit = treeUpdatePane(tab.rootSplit, paneId, (p) => ({ ...p, ...patch }))
-      return
     }
   }
 }
@@ -1515,21 +1156,7 @@ export function findEditorPane(paneId: string): PaneSession | null {
   return null
 }
 
-// --- Tab identity reconciliation ---
-
-function reconcileTabIdentity(tab: TabInfo): void {
-  const focused = findLeaf(tab.rootSplit, tab.focusedPaneId)
-  if (!focused || tab.toolId === focused.toolId) return
-  tab.toolId = focused.toolId
-  tab.toolName = focused.toolName
-  const tabs = tabsByWorktree[tab.worktreePath] ?? []
-  const sameCount = tabs.filter((t) => t !== tab && t.toolId === focused.toolId).length
-  tab.name = sameCount === 0 ? focused.toolName : `${focused.toolName} #${sameCount + 1}`
-}
-
 // --- Split pane operations ---
-
-const NO_SPLIT_TOOLS = new Set(['claude', 'codex', 'opencode', 'gemini'])
 
 export async function splitFocusedPane(
   worktreePath: string,
@@ -1542,33 +1169,13 @@ export async function splitFocusedPane(
   const tab = tabs.find((t) => t.id === tabId)
   if (!tab) return
 
-  // AI tools don't support splitting
-  if (NO_SPLIT_TOOLS.has(tab.toolId)) return
-
-  // Spawn a new shell session in the same worktree
-  const result = await window.api.tabSpawnPane('shell', worktreePath)
-  const paneId = nextPaneId()
-
-  const newPane: PaneSession = {
-    id: paneId,
-    sessionId: result.sessionId,
-    wsUrl: result.wsUrl,
-    toolId: 'shell',
-    toolName: result.toolName,
-    isRunning: true,
-    exitCode: null,
-    title: null,
-  }
-
-  const newTree = treeSplitPane(tab.rootSplit, tab.focusedPaneId, direction, newPane)
-  if (!newTree) {
-    // Max depth reached — kill the spawned PTY
-    await window.api.killPty(result.sessionId)
-    return
-  }
-
-  tab.rootSplit = newTree
-  tab.focusedPaneId = paneId
+  const result = await window.api.tabSplitPane(
+    worktreePath,
+    tab.id,
+    tab.focusedPaneId,
+    direction === 'hsplit' ? 'horizontal' : 'vertical',
+  )
+  applyTabCommandResult(result)
   scheduleSave(worktreePath)
 }
 
@@ -1586,67 +1193,29 @@ export async function closePane(
   const pane = findLeaf(tab.rootSplit, paneId)
   if (!pane) return
 
-  // Check if this pane has active process before closing
-  if (pane.isRunning) {
-    const description = await getActiveProcessDescription([pane])
-    if (description) {
-      const confirmed = await confirm({
-        title: 'Close pane?',
-        message: `This pane has ${description} that will be terminated.`,
-        confirmLabel: 'Close Pane',
-        destructive: true,
-      })
-      if (!confirmed) return
-    }
+  const { description } = await window.api.tabGetCloseWarning(worktreePath, {
+    kind: 'pane',
+    tabId,
+    paneId,
+  })
+  if (description) {
+    const confirmed = await confirm({
+      title: 'Close pane?',
+      message: `This pane has ${description} that will be terminated.`,
+      confirmLabel: 'Close Pane',
+      destructive: true,
+    })
+    if (!confirmed) return
   }
 
-  const result = treeRemovePane(tab.rootSplit, paneId)
-  if (!result) return
-  disposeEphemeralPaneState(result.removed)
+  const result = await window.api.tabClosePane(worktreePath, tabId, paneId)
+  if (!result.closedPaneId) return
 
-  // Kill the removed pane's PTY or destroy browser view (editor/notes/drawing panes have no session)
-  await match(result.removed)
-    .with({ paneType: P.union('editor', 'notes', 'drawing') }, () => {
-      // No-op — ephemeral or filesystem-backed only
-    })
-    .with({ paneType: 'browser' }, async (p) => {
-      delete browserSessions[p.sessionId]
-      await window.api.teardownBrowserWebview(p.sessionId)
-    })
-    .otherwise(async (p) => {
-      await window.api.killPty(p.sessionId, !!p.tmuxSessionName)
-    })
+  if (agentSessions[pane.sessionId]) removeAgentSession(pane.sessionId)
+  if (pane.paneType === 'browser') delete browserSessions[pane.sessionId]
+  disposeEphemeralPaneState(pane)
 
-  if (!result.tree) {
-    // Last pane — close the tab entirely
-    if (!closedTabs[worktreePath]) closedTabs[worktreePath] = []
-    closedTabs[worktreePath].push({
-      toolId: tab.toolId,
-      toolName: tab.toolName,
-      worktreePath,
-      closedAt: Date.now(),
-    })
-    if (closedTabs[worktreePath].length > MAX_CLOSED_TABS) {
-      closedTabs[worktreePath].shift()
-    }
-
-    const idx = tabs.findIndex((t) => t.id === tabId)
-    tabsByWorktree[worktreePath].splice(idx, 1)
-
-    const remaining = tabsByWorktree[worktreePath]
-    if (remaining.length > 0) {
-      const newIdx = Math.min(idx, remaining.length - 1)
-      activeTabId[worktreePath] = remaining[newIdx].id
-    } else {
-      delete activeTabId[worktreePath]
-    }
-  } else {
-    tab.rootSplit = result.tree
-    // Focus the first leaf in the remaining tree
-    tab.focusedPaneId = firstLeaf(result.tree).id
-    // Update tab identity to match focused pane (e.g., after closing Claude, only Shell remains)
-    reconcileTabIdentity(tab)
-  }
+  applyTabCommandResult(result)
   scheduleSave(worktreePath)
 }
 
@@ -1665,6 +1234,15 @@ export function navigatePaneFocus(
   worktreePath: string,
   direction: 'left' | 'right' | 'up' | 'down',
 ): void {
+  void navigatePaneFocusInMain(worktreePath, direction).catch((err) => {
+    console.error(`[tabs] tabNavigatePaneFocus failed for "${worktreePath}":`, err)
+  })
+}
+
+async function navigatePaneFocusInMain(
+  worktreePath: string,
+  direction: 'left' | 'right' | 'up' | 'down',
+): Promise<void> {
   const tabs = tabsByWorktree[worktreePath]
   if (!tabs) return
 
@@ -1672,35 +1250,63 @@ export function navigatePaneFocus(
   const tab = tabs.find((t) => t.id === tabId)
   if (!tab) return
 
-  const target = navigateFrom(tab.rootSplit, tab.focusedPaneId, direction)
-  if (target) {
-    tab.focusedPaneId = target
+  const result = await window.api.tabNavigatePaneFocus(worktreePath, tab.id, direction)
+  applyTabCommandResult(result)
+  if (
+    result.tabs.some(
+      (candidate) => candidate.id === tab.id && candidate.focusedPaneId !== tab.focusedPaneId,
+    )
+  ) {
+    scheduleSave(worktreePath)
   }
 }
 
-export function focusPane(_worktreePath: string, tabId: string, paneId: string): void {
-  for (const tabs of Object.values(tabsByWorktree)) {
-    const tab = tabs.find((t) => t.id === tabId)
-    if (tab) {
-      tab.focusedPaneId = paneId
-      return
-    }
+export function focusPane(worktreePath: string, tabId: string, paneId: string): void {
+  void focusPaneInMain(worktreePath, tabId, paneId).catch((err) => {
+    console.error(`[tabs] tabFocusPane failed for "${worktreePath}":`, err)
+  })
+}
+
+async function focusPaneInMain(worktreePath: string, tabId: string, paneId: string): Promise<void> {
+  const result = await window.api.tabFocusPane(worktreePath, tabId, paneId)
+  applyTabCommandResult(result)
+  if (result.tabs.some((tab) => tab.id === tabId && tab.focusedPaneId === paneId)) {
+    scheduleSave(worktreePath)
   }
 }
 
 export function updateSplitRatio(
-  _worktreePath: string,
+  worktreePath: string,
   tabId: string,
   splitId: string,
   ratio: number,
 ): void {
-  for (const tabs of Object.values(tabsByWorktree)) {
-    const tab = tabs.find((t) => t.id === tabId)
-    if (tab) {
-      tab.rootSplit = treeUpdateRatio(tab.rootSplit, splitId, ratio)
-      scheduleSave(tab.worktreePath)
-      return
-    }
+  void updateSplitRatioInMain(worktreePath, tabId, splitId, ratio).catch((err) => {
+    console.error(`[tabs] tabUpdateSplitRatio failed for "${worktreePath}":`, err)
+  })
+}
+
+async function updateSplitRatioInMain(
+  worktreePath: string,
+  tabId: string,
+  splitId: string,
+  ratio: number,
+): Promise<void> {
+  const tabs = tabsByWorktree[worktreePath]
+  if (!tabs?.some((tab) => tab.id === tabId)) return
+
+  const result = await window.api.tabUpdateSplitRatio(worktreePath, tabId, splitId, ratio)
+  applyTabCommandResult(result)
+  if (
+    result.tabs.some(
+      (tab) =>
+        tab.id === tabId &&
+        tab.rootSplit.type === 'split' &&
+        tab.rootSplit.id === splitId &&
+        tab.rootSplit.ratio === ratio,
+    )
+  ) {
+    scheduleSave(worktreePath)
   }
 }
 
@@ -1733,30 +1339,19 @@ export async function moveTabToSplit(
   if (targetTab.suspended && !(await resumeTab(targetTab))) return false
 
   const { direction, position } = mapZone(zone)
-  const newTree = graftSubtree(
-    targetTab.rootSplit,
+  const result = await window.api.tabMoveTabToSplit(
+    worktreePath,
+    sourceTabId,
+    targetTabId,
     targetPaneId,
-    direction,
-    sourceTab.rootSplit,
+    direction === 'hsplit' ? 'horizontal' : 'vertical',
     position,
   )
-  if (!newTree) return false
 
-  // Update target tab with grafted tree
-  targetTab.rootSplit = newTree
-  targetTab.focusedPaneId = firstLeaf(sourceTab.rootSplit).id
-
-  // Remove source tab WITHOUT killing sessions — they are relocated, not closed
-  const sourceIdx = tabs.findIndex((t) => t.id === sourceTabId)
-  tabs.splice(sourceIdx, 1)
-
-  // If source was active, switch to target
-  if (activeTabId[worktreePath] === sourceTabId) {
-    activeTabId[worktreePath] = targetTabId
-  }
-
-  scheduleSave(worktreePath)
-  return true
+  const moved = !result.tabs.some((tab) => tab.id === sourceTabId)
+  applyTabCommandResult(result)
+  if (moved) scheduleSave(worktreePath)
+  return moved
 }
 
 // --- Move pane within or across tabs ---
@@ -1768,101 +1363,77 @@ export function movePaneToTarget(
   targetTabId: string,
   targetPaneId: string,
   zone: DropZone,
-): boolean {
+): void {
+  void movePaneToTargetInMain(
+    worktreePath,
+    sourceTabId,
+    sourcePaneId,
+    targetTabId,
+    targetPaneId,
+    zone,
+  ).catch((err) => {
+    console.error(`[tabs] tabMovePaneToTarget failed for "${worktreePath}":`, err)
+  })
+}
+
+async function movePaneToTargetInMain(
+  worktreePath: string,
+  sourceTabId: string,
+  sourcePaneId: string,
+  targetTabId: string,
+  targetPaneId: string,
+  zone: DropZone,
+): Promise<void> {
   const tabs = tabsByWorktree[worktreePath]
-  if (!tabs) return false
+  if (!tabs) return
 
   const sourceTab = tabs.find((t) => t.id === sourceTabId)
   const targetTab = tabs.find((t) => t.id === targetTabId)
-  if (!sourceTab || !targetTab) return false
+  if (!sourceTab || !targetTab) return
 
-  // Extract the source pane from its tree
-  const removeResult = treeRemovePane(sourceTab.rootSplit, sourcePaneId)
-  if (!removeResult) return false
-
-  const leaf = createLeaf(removeResult.removed)
   const { direction, position } = mapZone(zone)
+  const result = await window.api.tabMovePaneToTarget(
+    worktreePath,
+    sourceTabId,
+    sourcePaneId,
+    targetTabId,
+    targetPaneId,
+    direction === 'hsplit' ? 'horizontal' : 'vertical',
+    position,
+  )
 
-  if (sourceTabId === targetTabId) {
-    // Same-tab reorder: removeResult.tree is the tree without the source pane
-    if (!removeResult.tree) return false // was the only pane — should not happen
-    const newTree = graftSubtree(removeResult.tree, targetPaneId, direction, leaf, position)
-    if (!newTree) {
-      return false
-    }
-    sourceTab.rootSplit = newTree
-    sourceTab.focusedPaneId = sourcePaneId
-    reconcileTabIdentity(sourceTab)
-  } else {
-    // Cross-tab move: graft into target tab
-    const newTargetTree = graftSubtree(targetTab.rootSplit, targetPaneId, direction, leaf, position)
-    if (!newTargetTree) {
-      return false
-    }
-
-    targetTab.rootSplit = newTargetTree
-    targetTab.focusedPaneId = sourcePaneId
-    reconcileTabIdentity(targetTab)
-
-    if (!removeResult.tree) {
-      // Source tab had only this pane — remove the tab
-      const sourceIdx = tabs.findIndex((t) => t.id === sourceTabId)
-      tabs.splice(sourceIdx, 1)
-      if (activeTabId[worktreePath] === sourceTabId) {
-        activeTabId[worktreePath] = targetTabId
-      }
-    } else {
-      sourceTab.rootSplit = removeResult.tree
-      sourceTab.focusedPaneId = firstLeaf(removeResult.tree).id
-      reconcileTabIdentity(sourceTab)
-    }
-
-    activeTabId[worktreePath] = targetTabId
-  }
-
-  scheduleSave(worktreePath)
-  return true
+  const moved = result.tabs.some((tab) => tab.focusedPaneId === sourcePaneId)
+  applyTabCommandResult(result)
+  if (moved) scheduleSave(worktreePath)
 }
 
 export function detachPaneToTab(
   worktreePath: string,
   sourceTabId: string,
   sourcePaneId: string,
-): boolean {
+): void {
+  void detachPaneToTabInMain(worktreePath, sourceTabId, sourcePaneId).catch((err) => {
+    console.error(`[tabs] tabDetachPaneToTab failed for "${worktreePath}":`, err)
+  })
+}
+
+async function detachPaneToTabInMain(
+  worktreePath: string,
+  sourceTabId: string,
+  sourcePaneId: string,
+): Promise<void> {
   const tabs = tabsByWorktree[worktreePath]
-  if (!tabs) return false
+  if (!tabs) return
 
   const sourceTab = tabs.find((t) => t.id === sourceTabId)
-  if (!sourceTab) return false
+  if (!sourceTab) return
 
   // Already a standalone tab — nothing to detach
-  if (sourceTab.rootSplit.type === 'leaf') return false
+  if (sourceTab.rootSplit.type === 'leaf') return
 
-  const removeResult = treeRemovePane(sourceTab.rootSplit, sourcePaneId)
-  if (!removeResult || !removeResult.tree) return false
-
-  // Update source tab
-  sourceTab.rootSplit = removeResult.tree
-  sourceTab.focusedPaneId = firstLeaf(removeResult.tree).id
-  reconcileTabIdentity(sourceTab)
-
-  // Create new tab for the detached pane
-  const removed = removeResult.removed
-  const newTab: TabInfo = {
-    id: nextTabId(),
-    toolId: removed.toolId,
-    toolName: removed.toolName,
-    name: computeDisplayName(removed.toolName, worktreePath, removed.toolId),
-    worktreePath,
-    rootSplit: createLeaf(removed),
-    focusedPaneId: removed.id,
-  }
-
-  tabs.push(newTab)
-  activeTabId[worktreePath] = newTab.id
-
-  scheduleSave(worktreePath)
-  return true
+  const result = await window.api.tabDetachPaneToTab(worktreePath, sourceTabId, sourcePaneId)
+  applyTabCommandResult(result)
+  if (result.openedTab) scheduleSave(worktreePath)
 }
 
 // --- Layout persistence ---
@@ -1873,112 +1444,10 @@ function scheduleSave(worktreePath: string): void {
   if (saveTimers[worktreePath]) clearTimeout(saveTimers[worktreePath])
   saveTimers[worktreePath] = setTimeout(() => {
     delete saveTimers[worktreePath]
-    saveLayoutForWorktree(worktreePath)
-  }, 500)
-}
-
-function serializeSplitNode(node: SplitNode): SerializedSplitNode | null {
-  if (node.type === 'leaf') {
-    // Notes and drawing panes are inherently ephemeral — never persist
-    if (node.pane.paneType === 'notes' || node.pane.paneType === 'drawing') {
-      return null
-    }
-    // Skip dead terminal panes — they would respawn as new sessions on restore
-    if (
-      node.pane.paneType !== 'editor' &&
-      node.pane.paneType !== 'browser' &&
-      !node.pane.isRunning &&
-      !node.pane.tmuxSessionName
-    ) {
-      return null
-    }
-    const leaf: SerializedSplitNode = {
-      type: 'leaf',
-      toolId: node.pane.toolId,
-      toolName: node.pane.toolName,
-    }
-    if (agentSessions[node.pane.sessionId]) {
-      const csid = agentSessions[node.pane.sessionId]?.agentSessionId
-      if (csid) leaf.agentSessionId = csid
-      // Backward compat: also write claudeSessionId for claude agents
-      if (node.pane.toolId === 'claude' && csid) leaf.claudeSessionId = csid
-    }
-    if (node.pane.paneType === 'browser') {
-      leaf.browserUrl = node.pane.url ?? ''
-      const bs = browserSessions[node.pane.sessionId]
-      if (bs) leaf.browserDevToolsMode = bs.devToolsMode
-    }
-    if (node.pane.paneType === 'editor') {
-      leaf.filePath = node.pane.filePath
-      const files = node.pane.editorFiles ?? []
-      if (files.length > 0) {
-        leaf.editorFiles = files.map((f) => f.filePath)
-        leaf.editorActiveFile = node.pane.editorActiveFile ?? files[0].filePath
-      } else if (node.pane.filePath) {
-        leaf.editorFiles = [node.pane.filePath]
-        leaf.editorActiveFile = node.pane.filePath
-      }
-    }
-    if (node.pane.tmuxSessionName) {
-      leaf.tmuxSessionName = node.pane.tmuxSessionName
-    }
-    if (node.pane.profileId) {
-      leaf.profileId = node.pane.profileId
-    }
-    return leaf
-  }
-  // Collapse splits when one or both children are dead
-  const first = serializeSplitNode(node.first)
-  const second = serializeSplitNode(node.second)
-  if (!first && !second) return null
-  if (!first) return second
-  if (!second) return first
-  return {
-    type: node.type,
-    first,
-    second,
-    ratio: node.ratio,
-  }
-}
-
-function saveLayoutForWorktree(worktreePath: string): void {
-  const tabs = tabsByWorktree[worktreePath]
-  const wsId = getProjectForWorktree(worktreePath)?.workspace.id
-  if (!tabs || !wsId) return
-
-  const activeId = activeTabId[worktreePath]
-  const activeIndex = tabs.findIndex((t) => t.id === activeId)
-
-  // Filter out tabs where all panes are dead (stopped processes, no tmux session)
-  const serializedTabs: Array<{
-    toolId: string
-    toolName: string
-    rootSplit: SerializedSplitNode
-  }> = []
-  let adjustedActiveIndex = 0
-  for (let i = 0; i < tabs.length; i++) {
-    const tab = tabs[i]
-    const rootSplit = tab.suspended ? tab.suspended : serializeSplitNode(tab.rootSplit)
-    if (!rootSplit) continue
-    if (i === activeIndex) adjustedActiveIndex = serializedTabs.length
-    serializedTabs.push({ toolId: tab.toolId, toolName: tab.toolName, rootSplit })
-  }
-
-  if (serializedTabs.length === 0) {
-    window.api.tabDeleteLayout(worktreePath).catch(() => {
-      // Ignore delete errors silently
+    window.api.tabSaveCurrentLayout(worktreePath).catch(() => {
+      // Ignore save errors silently
     })
-    return
-  }
-
-  const layout: SerializedLayout = {
-    tabs: serializedTabs,
-    activeTabIndex: adjustedActiveIndex,
-  }
-
-  window.api.tabSaveLayout(worktreePath, JSON.stringify(layout)).catch(() => {
-    // Ignore save errors silently
-  })
+  }, 500)
 }
 
 export function saveAllLayouts(): void {
@@ -1987,210 +1456,20 @@ export function saveAllLayouts(): void {
     delete saveTimers[path]
   }
   for (const path of Object.keys(tabsByWorktree)) {
-    saveLayoutForWorktree(path)
-  }
-}
-
-async function restoreSplitNode(
-  node: SerializedSplitNode,
-  worktreePath: string,
-): Promise<SplitNode> {
-  if (node.type === 'leaf') {
-    const paneId = nextPaneId()
-    let pane: PaneSession
-
-    if (node.toolId === 'editor' && (node.filePath || (node.editorFiles?.length ?? 0) > 0)) {
-      const files = node.editorFiles ?? (node.filePath ? [node.filePath] : [])
-      const activeFile = node.editorActiveFile ?? files[0] ?? node.filePath ?? ''
-      pane = {
-        id: paneId,
-        sessionId: '',
-        wsUrl: '',
-        toolId: 'editor',
-        toolName: node.toolName,
-        isRunning: true,
-        exitCode: null,
-        title: null,
-        paneType: 'editor',
-        filePath: activeFile,
-        editorFiles: files.map((filePath) => ({ filePath })),
-        editorActiveFile: activeFile,
-      }
-    } else if (node.toolId === 'browser') {
-      const browserId = crypto.randomUUID()
-      pane = {
-        id: paneId,
-        sessionId: browserId,
-        wsUrl: '',
-        toolId: node.toolId,
-        toolName: node.toolName,
-        isRunning: true,
-        exitCode: null,
-        title: null,
-        paneType: 'browser',
-        url: node.browserUrl,
-      }
-    } else if (
-      node.tmuxSessionName &&
-      (await window.api.tmuxHasSession(node.tmuxSessionName).catch(() => false))
-    ) {
-      // Reattach to an existing tmux session
-      const result = await window.api.tmuxAttach(node.tmuxSessionName)
-      pane = {
-        id: paneId,
-        sessionId: result.sessionId,
-        wsUrl: result.wsUrl,
-        toolId: node.toolId,
-        toolName: node.toolName,
-        isRunning: true,
-        exitCode: null,
-        title: null,
-        tmuxSessionName: node.tmuxSessionName,
-      }
-      if (AI_TOOL_IDS.has(node.toolId)) {
-        initAgentSession(result.sessionId, node.toolId as AgentType)
-      }
-    } else {
-      const options: {
-        workspaceName?: string
-        branch?: string
-        resumeSessionId?: string
-        profileId?: string
-      } = {}
-      if (AI_TOOL_IDS.has(node.toolId)) {
-        const project = getProjectForWorktree(worktreePath)
-        options.workspaceName = project?.workspace.name ?? workspaceState.workspace?.name ?? ''
-        options.branch = workspaceState.branch ?? undefined
-        options.resumeSessionId = node.agentSessionId ?? node.claudeSessionId
-        if (node.profileId) options.profileId = node.profileId
-      }
-      const result = await window.api.tabSpawnPane(node.toolId, worktreePath, options)
-      const restoredProfile = node.profileId ? getProfileById(node.profileId) : undefined
-      pane = {
-        id: paneId,
-        sessionId: result.sessionId,
-        wsUrl: result.wsUrl,
-        toolId: node.toolId,
-        toolName: result.toolName,
-        isRunning: true,
-        exitCode: null,
-        title: null,
-        tmuxSessionName: result.tmuxSessionName,
-        profileId: node.profileId,
-        profileName: restoredProfile?.name,
-      }
-      if (AI_TOOL_IDS.has(node.toolId)) {
-        initAgentSession(result.sessionId, node.toolId as AgentType)
-      }
-    }
-    return createLeaf(pane)
-  }
-
-  const [first, second] = await Promise.all([
-    restoreSplitNode(node.first, worktreePath),
-    restoreSplitNode(node.second, worktreePath),
-  ])
-  return {
-    type: node.type,
-    id: `split-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-    first,
-    second,
-    ratio: node.ratio,
+    window.api.tabSaveCurrentLayout(path).catch(() => {
+      // Ignore save errors silently
+    })
   }
 }
 
 export async function restoreLayout(worktreePath: string, layoutJson: string): Promise<boolean> {
-  let layout: SerializedLayout
-  try {
-    layout = JSON.parse(layoutJson)
-  } catch {
-    return false
-  }
+  const project = getProjectForWorktree(worktreePath)
+  const result = await window.api.tabRestoreLayout(worktreePath, layoutJson, {
+    workspaceName: project?.workspace.name ?? workspaceState.workspace?.name ?? '',
+    branch: workspaceState.branch ?? undefined,
+  })
+  if (!result.restored) return false
 
-  if (!layout.tabs || layout.tabs.length === 0) return false
-
-  const activeIdx = Math.min(Math.max(0, layout.activeTabIndex), layout.tabs.length - 1)
-  const restoredTabs: TabInfo[] = []
-
-  for (let i = 0; i < layout.tabs.length; i++) {
-    const serializedTab = layout.tabs[i]
-
-    if (i === activeIdx) {
-      // Fully restore the active tab
-      try {
-        const rootSplit = await restoreSplitNode(serializedTab.rootSplit, worktreePath)
-        const id = nextTabId()
-        const name = computeDisplayName(serializedTab.toolName, worktreePath, serializedTab.toolId)
-        const firstPane = firstLeaf(rootSplit)
-
-        restoredTabs.push({
-          id,
-          toolId: serializedTab.toolId,
-          toolName: serializedTab.toolName,
-          name,
-          worktreePath,
-          rootSplit,
-          focusedPaneId: firstPane.id,
-        })
-      } catch {
-        // Active tab failed; create as suspended instead
-        const id = nextTabId()
-        const name = computeDisplayName(serializedTab.toolName, worktreePath, serializedTab.toolId)
-        const placeholderPaneId = nextPaneId()
-        restoredTabs.push({
-          id,
-          toolId: serializedTab.toolId,
-          toolName: serializedTab.toolName,
-          name,
-          worktreePath,
-          rootSplit: createLeaf({
-            id: placeholderPaneId,
-            sessionId: '',
-            wsUrl: '',
-            toolId: serializedTab.toolId,
-            toolName: serializedTab.toolName,
-            isRunning: false,
-            exitCode: null,
-            title: null,
-          }),
-          focusedPaneId: placeholderPaneId,
-          suspended: serializedTab.rootSplit,
-        })
-      }
-    } else {
-      // Create suspended tab with placeholder
-      const id = nextTabId()
-      const name = computeDisplayName(serializedTab.toolName, worktreePath, serializedTab.toolId)
-      const placeholderPaneId = nextPaneId()
-      restoredTabs.push({
-        id,
-        toolId: serializedTab.toolId,
-        toolName: serializedTab.toolName,
-        name,
-        worktreePath,
-        rootSplit: createLeaf({
-          id: placeholderPaneId,
-          sessionId: '',
-          wsUrl: '',
-          toolId: serializedTab.toolId,
-          toolName: serializedTab.toolName,
-          isRunning: false,
-          exitCode: null,
-          title: null,
-        }),
-        focusedPaneId: placeholderPaneId,
-        suspended: serializedTab.rootSplit,
-      })
-    }
-  }
-
-  if (restoredTabs.length === 0) return false
-
-  tabsByWorktree[worktreePath] = restoredTabs
-
-  // Prefer a non-suspended tab as active; fall back to first tab
-  const activeTab = restoredTabs.find((t) => !t.suspended) ?? restoredTabs[0]
-  activeTabId[worktreePath] = activeTab.id
-
+  applyTabCommandResult(result)
   return true
 }

--- a/src/renderer/src/lib/stores/taskTracker.svelte.ts
+++ b/src/renderer/src/lib/stores/taskTracker.svelte.ts
@@ -161,8 +161,12 @@ export async function setActiveTask(worktreePath: string, task: ActiveTaskContex
   await setPref(`activeTask.${worktreePath}`, JSON.stringify(task))
 }
 
-export async function loadActiveTask(worktreePath: string): Promise<void> {
+export async function loadActiveTask(
+  worktreePath: string,
+  options: { shouldApply?: () => boolean } = {},
+): Promise<void> {
   const raw = await window.api.getPref(`activeTask.${worktreePath}`)
+  if (options.shouldApply && !options.shouldApply()) return
   if (raw) {
     try {
       activeTask = JSON.parse(raw) as ActiveTaskContext

--- a/src/renderer/src/lib/stores/workspace.svelte.ts
+++ b/src/renderer/src/lib/stores/workspace.svelte.ts
@@ -1,4 +1,10 @@
-import { restoreLayout, closeAllTabsForWorktree, killAllTabs, tabsByWorktree } from './tabs.svelte'
+import {
+  restoreLayout,
+  closeAllTabsForWorktree,
+  killAllTabs,
+  tabsByWorktree,
+  applyTabsSnapshot,
+} from './tabs.svelte'
 import {
   loadRepoConfig,
   getRepoConfig,
@@ -11,6 +17,7 @@ import { clearMru } from './quickOpenMru.svelte'
 import type {
   ProjectSnapshot,
   WorkspaceCommandResult,
+  WorkspaceSnapshot,
   WorkspaceStateSnapshot,
 } from '../../../../main/commands/types'
 
@@ -94,6 +101,9 @@ export const workspaceState: WorkspaceState = $state({ ...initial })
 /** All projects attached to this window */
 export const projects: ProjectState[] = $state([])
 
+let selectWorktreeRequestId = 0
+let pendingSelectedWorktreePath: string | null = null
+
 // --- Multi-project functions ---
 
 // Serialize concurrent attachProject calls to preserve project ordering
@@ -152,6 +162,76 @@ function projectFromSnapshot(project: ProjectSnapshot): ProjectState {
   }
 }
 
+function parseCachedAheadBehind(raw: string | null): { ahead: number; behind: number } | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as { ahead?: unknown }).ahead === 'number' &&
+      typeof (parsed as { behind?: unknown }).behind === 'number'
+    ) {
+      return {
+        ahead: (parsed as { ahead: number }).ahead,
+        behind: (parsed as { behind: number }).behind,
+      }
+    }
+  } catch {
+    // Fall through to the legacy "ahead/behind" cache format.
+  }
+
+  const parts = raw.split('/')
+  if (parts.length !== 2) return null
+  const ahead = parseInt(parts[0], 10)
+  const behind = parseInt(parts[1], 10)
+  if (Number.isNaN(ahead) || Number.isNaN(behind)) return null
+  return { ahead, behind }
+}
+
+function applyLocalWorktreeSelection(path: string): boolean {
+  const project = getProjectForWorktree(path)
+  if (!project) return false
+
+  const previousPath = workspaceState.selectedWorktreePath
+  const previousDirty = workspaceState.isDirty
+  const previousAheadBehind = workspaceState.aheadBehind
+  const selectedWorktree = project.worktrees.find((worktree) => worktree.path === path)
+  const mainWorktreePath =
+    project.worktrees.find((worktree) => worktree.isMain)?.path ??
+    project.repoRoot ??
+    project.workspace.path
+  const isSamePath = previousPath === path
+  const isMainWorktree = path === mainWorktreePath
+
+  workspaceState.workspace = project.workspace
+  workspaceState.isGitRepo = project.isGitRepo
+  workspaceState.repoRoot = project.repoRoot
+  workspaceState.worktrees = project.worktrees
+  workspaceState.selectedWorktreePath = path
+  workspaceState.branch = project.isGitRepo
+    ? (selectedWorktree?.branch ?? project.workspace.cached_branch ?? null)
+    : null
+  workspaceState.isDirty = isSamePath
+    ? previousDirty
+    : isMainWorktree && project.workspace.cached_dirty !== null
+      ? project.workspace.cached_dirty === 1
+      : false
+  workspaceState.aheadBehind = isSamePath
+    ? previousAheadBehind
+    : isMainWorktree
+      ? parseCachedAheadBehind(project.workspace.cached_ahead_behind)
+      : null
+
+  return true
+}
+
+function replaceProjectsFromSnapshot(snapshot: WorkspaceSnapshot): Set<string> {
+  const existingKeys = new Set(projects.map(getProjectKey))
+  projects.splice(0, projects.length, ...snapshot.projects.map(projectFromSnapshot))
+  return existingKeys
+}
+
 function applyWorkspaceStateSnapshot(snapshot: WorkspaceStateSnapshot): void {
   if (!snapshot.project) {
     workspaceState.workspace = null
@@ -178,6 +258,29 @@ function applyWorkspaceStateSnapshot(snapshot: WorkspaceStateSnapshot): void {
   workspaceState.aheadBehind = snapshot.aheadBehind
 }
 
+async function applyWorkspaceSnapshot(
+  snapshot: WorkspaceSnapshot,
+  options: { loadNewProjectConfigs?: boolean; preserveSelectedWorktreePath?: string | null } = {},
+): Promise<void> {
+  const { loadNewProjectConfigs = false } = options
+  const existingKeys = replaceProjectsFromSnapshot(snapshot)
+  if (
+    options.preserveSelectedWorktreePath &&
+    snapshot.workspaceState.selectedWorktreePath !== options.preserveSelectedWorktreePath &&
+    applyLocalWorktreeSelection(options.preserveSelectedWorktreePath)
+  ) {
+    // A slower snapshot for the previous worktree arrived while the user has
+    // already clicked a different one. Keep the optimistic selection visible;
+    // the in-flight command will later apply the authoritative main state.
+  } else {
+    applyWorkspaceStateSnapshot(snapshot.workspaceState)
+  }
+
+  if (loadNewProjectConfigs) {
+    await loadRepoConfigsForNewProjects(existingKeys)
+  }
+}
+
 async function loadRepoConfigsForNewProjects(existingKeys: Set<string>): Promise<void> {
   for (const project of projects) {
     const projectKey = getProjectKey(project)
@@ -199,7 +302,7 @@ async function restoreCommandLayouts(result: WorkspaceCommandResult): Promise<vo
     try {
       await restoreLayout(entry.worktreePath, entry.layoutJson)
     } catch {
-      // Layout restore failed, will fall back to ensureDefaultTab.
+      // Layout restore failed; leave the worktree empty so the user can open a tab manually.
     }
   }
 }
@@ -209,13 +312,11 @@ async function applyWorkspaceCommandResult(
   options: { restoreLayouts?: boolean; loadNewProjectConfigs?: boolean } = {},
 ): Promise<void> {
   const { restoreLayouts = true, loadNewProjectConfigs = true } = options
-  const existingKeys = new Set(projects.map(getProjectKey))
+  const existingKeys = replaceProjectsFromSnapshot(result)
 
   for (const warning of result.warnings) {
     addToast(warning.message)
   }
-
-  projects.splice(0, projects.length, ...result.projects.map(projectFromSnapshot))
 
   if (restoreLayouts) {
     await restoreCommandLayouts(result)
@@ -225,6 +326,39 @@ async function applyWorkspaceCommandResult(
 
   if (loadNewProjectConfigs) {
     await loadRepoConfigsForNewProjects(existingKeys)
+  }
+}
+
+let appStateCleanup: (() => void) | null = null
+
+export function initWorkspaceStateSubscription(): () => void {
+  if (appStateCleanup) return () => {}
+
+  let disposed = false
+  void window.api
+    .getAppState()
+    .then((snapshot) => {
+      if (disposed) return
+      applyTabsSnapshot(snapshot.tabs, { replaceAll: true })
+      return applyWorkspaceSnapshot(snapshot.workspace)
+    })
+    .catch((err) => {
+      console.error('[workspace] getAppState failed:', err)
+    })
+
+  appStateCleanup = window.api.onAppStateChanged((snapshot) => {
+    applyTabsSnapshot(snapshot.tabs, { replaceAll: true })
+    void applyWorkspaceSnapshot(snapshot.workspace, {
+      preserveSelectedWorktreePath: pendingSelectedWorktreePath,
+    }).catch((err) => {
+      console.error('[workspace] apply app state failed:', err)
+    })
+  })
+
+  return () => {
+    disposed = true
+    appStateCleanup?.()
+    appStateCleanup = null
   }
 }
 
@@ -254,7 +388,7 @@ export async function detachProject(path: string): Promise<void> {
     }
   }
   for (const wtPath of ownedPaths) {
-    await closeAllTabsForWorktree(wtPath)
+    if (!(await closeAllTabsForWorktree(wtPath))) return
     clearQuickOpenCache(wtPath)
     clearMru(wtPath)
   }
@@ -342,7 +476,6 @@ export async function updateGitInfoForProject(repoRoot: string, info: GitInfo): 
       }
     }
 
-    // Fetch status for the currently selected worktree
     const selectedPath = workspaceState.selectedWorktreePath
     if (selectedPath) {
       const mainWorktreePath =
@@ -353,10 +486,8 @@ export async function updateGitInfoForProject(repoRoot: string, info: GitInfo): 
         workspaceState.isDirty = info.isDirty
         workspaceState.aheadBehind = info.aheadBehind
       } else {
-        const status = await window.api.gitStatus(selectedPath)
-        workspaceState.branch = status.branch ?? workspaceState.branch
-        workspaceState.isDirty = status.isDirty
-        workspaceState.aheadBehind = status.aheadBehind
+        const selectedWorktree = info.worktrees.find((wt) => wt.path === selectedPath)
+        workspaceState.branch = selectedWorktree?.branch ?? workspaceState.branch
       }
     } else {
       workspaceState.branch = info.branch
@@ -374,16 +505,43 @@ export async function openWorkspace(path: string): Promise<void> {
 }
 
 export async function selectWorktree(path: string): Promise<void> {
-  const commandResult = await window.api.workspaceSelectWorktree(path)
-  await applyWorkspaceCommandResult(commandResult, {
-    restoreLayouts: false,
-    loadNewProjectConfigs: false,
-  })
-  await hydrateSelectedWorktree(path)
+  if (workspaceState.selectedWorktreePath === path) return
+
+  const requestId = ++selectWorktreeRequestId
+  pendingSelectedWorktreePath = path
+  const appliedOptimistically = applyLocalWorktreeSelection(path)
+
+  try {
+    const commandResult = await window.api.workspaceSelectWorktree(path)
+    if (requestId !== selectWorktreeRequestId) return
+
+    await applyWorkspaceCommandResult(commandResult, {
+      restoreLayouts: false,
+      loadNewProjectConfigs: false,
+    })
+    await hydrateSelectedWorktree(path, requestId)
+  } catch (err) {
+    if (requestId !== selectWorktreeRequestId) return
+
+    if (appliedOptimistically) {
+      const snapshot = await window.api.getAppState()
+      applyTabsSnapshot(snapshot.tabs, { replaceAll: true })
+      await applyWorkspaceSnapshot(snapshot.workspace)
+    }
+    throw err
+  } finally {
+    if (requestId === selectWorktreeRequestId) {
+      pendingSelectedWorktreePath = null
+    }
+  }
 }
 
-async function hydrateSelectedWorktree(path: string): Promise<void> {
-  await loadActiveTask(path)
+async function hydrateSelectedWorktree(path: string, requestId?: number): Promise<void> {
+  const shouldApply = (): boolean =>
+    requestId === undefined || requestId === selectWorktreeRequestId
+
+  await loadActiveTask(path, { shouldApply })
+  if (requestId !== undefined && requestId !== selectWorktreeRequestId) return
 
   // Start (or restart) the file tree watcher for the newly active worktree.
   // The main process disposes any previous watcher for this window before
@@ -393,6 +551,7 @@ async function hydrateSelectedWorktree(path: string): Promise<void> {
   } catch (err) {
     console.error(`[workspace] watchFiles failed for "${path}":`, err)
   }
+  if (requestId !== undefined && requestId !== selectWorktreeRequestId) return
 
   const project = getProjectForWorktree(path)
   if (project?.isGitRepo) {
@@ -400,11 +559,6 @@ async function hydrateSelectedWorktree(path: string): Promise<void> {
     if (wt) {
       workspaceState.branch = wt.branch
     }
-
-    // Fetch per-worktree git status
-    const status = await window.api.gitStatus(path)
-    workspaceState.isDirty = status.isDirty
-    workspaceState.aheadBehind = status.aheadBehind
   } else {
     workspaceState.branch = null
     workspaceState.isDirty = false

--- a/src/renderer/src/lib/taskTracker/branchCreation.ts
+++ b/src/renderer/src/lib/taskTracker/branchCreation.ts
@@ -9,14 +9,11 @@ export async function createBranchFromTask(
   const currentBranch = workspaceState.branch
   if (!repoRoot || !currentBranch) return false
 
-  // Resolve branch name from template
-  const branchName = await window.api.taskTrackerResolveBranchName(
+  const { branchName } = await window.api.taskTrackerPrepareBranchFromTask({
     connectionId,
     task,
-    undefined,
-    undefined,
     repoRoot,
-  )
+  })
 
   // Confirm with user
   const confirmed = await confirm({
@@ -27,30 +24,24 @@ export async function createBranchFromTask(
   })
   if (!confirmed) return false
 
-  // Check dirty state
-  if (workspaceState.isDirty) {
+  const stashBeforeCreate = workspaceState.isDirty
+  if (stashBeforeCreate) {
     const stash = await confirm({
       title: 'Uncommitted Changes',
       message: 'You have uncommitted changes. Stash them before switching?',
       confirmLabel: 'Stash & Continue',
     })
     if (!stash) return false
-
-    try {
-      await window.api.gitStash(repoRoot)
-    } catch (e) {
-      await confirm({
-        title: 'Stash Failed',
-        message: e instanceof Error ? e.message : 'Failed to stash changes',
-        confirmLabel: 'OK',
-      })
-      return false
-    }
   }
 
-  // Create and checkout branch
   try {
-    await window.api.gitBranchCreate(repoRoot, branchName, currentBranch)
+    await window.api.taskTrackerCreateBranchFromTask({
+      connectionId,
+      task,
+      repoRoot,
+      baseBranch: currentBranch,
+      stashBeforeCreate,
+    })
   } catch (e) {
     await confirm({
       title: 'Branch Creation Failed',


### PR DESCRIPTION
## What

Moves tab, workspace, and app-state ownership into the Electron main process, with typed preload APIs for renderer interactions. Adds main-process close-all preflight, safer editor file loading/saving, task-tracker IPC validation, and e2e coverage for app-state/session restore flows.

## Why

Renderer state could drift from main-process reality: tabs did not render consistently, interactions stopped reflecting actual state, restore/window grouping regressed, and async editor/session updates could overwrite newer app state.

## How to test

1. npm run typecheck:node
2. npm run svelte-check
3. npx eslint e2e/app-state.spec.ts src/main/commands/tabCommands.ts src/main/commands/types.ts src/main/ipc/handlers.ts src/preload/index.ts src/preload/index.d.ts src/renderer/src/lib/stores/tabs.svelte.ts
4. npm run build
5. npx playwright test e2e/app-state.spec.ts -g "main process exposes and publishes app state snapshots" --reporter=list

## Screenshots / recordings

Not attached; changes are mostly Electron state ownership and process behavior.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly
- [x] Feature docs in `docs/` updated (behavior, config, errors, security — if any changed)
