### PR TITLE
fix: allow worktree repo validation for attached projects

### DIFF
--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -62,6 +62,13 @@ Worktrees are intentionally created OUTSIDE the workspace (default `worktrees.ba
 
 Creation paths additionally walk up to the closest existing ancestor before realpath-normalizing, so a non-existent leaf is OK; the tail is then rechecked to reject escapes via `..`. The same TOCTOU-safe pattern as `validateCreationPath` is used.
 
+Worktree-scoped git operations (`commit`, `push`, `pull`, `fetch`, `stash`, branch
+listing, create, and remove) validate their repository/worktree argument against the main
+process' attached project snapshot. If strict active-window containment fails, the path is
+still allowed only when it exactly matches the attached project's workspace path, repo root,
+or one of its known worktree paths. This lets inactive attached worktrees operate from
+`~/canopy/worktrees` without allowing arbitrary renderer-supplied paths.
+
 ### Post-creation setup
 
 Worktree setup actions are configured per workspace and stored in the preferences database under the key `workspace:<workspaceId>:worktreeSetup` as a JSON array.
@@ -117,6 +124,7 @@ Example configuration (JSON):
 | Path not absolute                    | "Worktree path must be absolute"                         | Renderer passed a relative path to create or remove                                  |
 | No existing ancestor                 | "Access denied: no existing ancestor"                    | Creation path walks up past the filesystem root without finding an existing ancestor |
 | Path outside allowed roots           | "Access denied: worktree path outside home or workspace" | Resolved path is not under `$HOME` or a registered workspace                         |
+| Repo outside attached project        | "Access denied: path outside workspace"                  | Repo/worktree path is not a strict workspace path or exact attached project path      |
 | Path escapes ancestor                | "Access denied: worktree path escapes ancestor"          | Non-existent tail of the creation path escapes its ancestor via `..` or absolute ref |
 | Setup command timeout                | "Command timed out after 5 minutes"                      | A setup action's shell command did not exit within 300 seconds                       |
 | Setup command failure                | "\<label\>: Command exited with code \<N\>"              | A setup action's shell command returned non-zero                                     |

--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -62,13 +62,13 @@ Worktrees are intentionally created OUTSIDE the workspace (default `worktrees.ba
 
 Creation paths additionally walk up to the closest existing ancestor before realpath-normalizing, so a non-existent leaf is OK; the tail is then rechecked to reject escapes via `..`. The same TOCTOU-safe pattern as `validateCreationPath` is used.
 
-Worktree-scoped git operations (`diff`, `stage`, `revert`, `commit`, `push`, `pull`,
-`fetch`, `stash`, branch listing, create, and remove) validate their repository/worktree
-argument against the main process' attached project snapshot. If strict active-window
-containment fails, the path is still allowed only when it exactly matches the attached
-project's workspace path, repo root, or one of its known worktree paths. This lets inactive
-attached worktrees operate from `~/canopy/worktrees` without allowing arbitrary
-renderer-supplied paths.
+Worktree-scoped git operations (`diff`, `stage`, `revert`, `commit`, push preflight,
+`push`, `pull`, `fetch`, `stash`, branch listing, branch create/delete, worktree create,
+and worktree remove) validate their repository/worktree argument against the main process'
+attached project snapshot. If strict active-window containment fails, the path is still
+allowed only when it exactly matches the attached project's workspace path, repo root, or
+one of its known worktree paths. This lets inactive attached worktrees operate from
+`~/canopy/worktrees` without allowing arbitrary renderer-supplied paths.
 
 ### Post-creation setup
 

--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -62,12 +62,13 @@ Worktrees are intentionally created OUTSIDE the workspace (default `worktrees.ba
 
 Creation paths additionally walk up to the closest existing ancestor before realpath-normalizing, so a non-existent leaf is OK; the tail is then rechecked to reject escapes via `..`. The same TOCTOU-safe pattern as `validateCreationPath` is used.
 
-Worktree-scoped git operations (`commit`, `push`, `pull`, `fetch`, `stash`, branch
-listing, create, and remove) validate their repository/worktree argument against the main
-process' attached project snapshot. If strict active-window containment fails, the path is
-still allowed only when it exactly matches the attached project's workspace path, repo root,
-or one of its known worktree paths. This lets inactive attached worktrees operate from
-`~/canopy/worktrees` without allowing arbitrary renderer-supplied paths.
+Worktree-scoped git operations (`diff`, `stage`, `revert`, `commit`, `push`, `pull`,
+`fetch`, `stash`, branch listing, create, and remove) validate their repository/worktree
+argument against the main process' attached project snapshot. If strict active-window
+containment fails, the path is still allowed only when it exactly matches the attached
+project's workspace path, repo root, or one of its known worktree paths. This lets inactive
+attached worktrees operate from `~/canopy/worktrees` without allowing arbitrary
+renderer-supplied paths.
 
 ### Post-creation setup
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -2199,6 +2199,11 @@ export function registerIpcHandlers(
     return target === base || target.startsWith(base + path.sep)
   }
 
+  async function normalizeRealpathOrInput(targetPath: string): Promise<string> {
+    const result = await fromExternalCall(fs.promises.realpath(targetPath), () => null)
+    return path.normalize(result.isOk() ? result.value : targetPath)
+  }
+
   // Realpath-normalize workspace roots too: otherwise a macOS workspace at
   // `/var/...` (which resolves to `/private/var/...`) would never match a
   // target's realpath and all reads get rejected; conversely a symlinked
@@ -2209,15 +2214,7 @@ export function registerIpcHandlers(
   async function validatePathAccess(wcId: number, targetPath: string): Promise<string> {
     const resolved = path.normalize(await fs.promises.realpath(targetPath))
     const allowed = windowManager.getWorkspacePaths(wcId)
-    const resolvedAllowed = await Promise.all(
-      allowed.map(async (wp) => {
-        try {
-          return path.normalize(await fs.promises.realpath(wp))
-        } catch {
-          return path.normalize(wp)
-        }
-      }),
-    )
+    const resolvedAllowed = await Promise.all(allowed.map(normalizeRealpathOrInput))
     const ok = resolvedAllowed.some((normalWp) => sameOrChildPath(resolved, normalWp))
     if (!ok) throw new Error('Access denied: path outside workspace')
     return resolved
@@ -2227,30 +2224,28 @@ export function registerIpcHandlers(
     wcId: number,
     targetPath: string,
   ): Promise<string> {
-    try {
-      return await validatePathAccess(wcId, targetPath)
-    } catch (accessError) {
-      const resolved = path.normalize(await fs.promises.realpath(targetPath))
-      const ownedPaths = workspaceCommandService
-        .getSnapshot(wcId)
-        .projects.flatMap((project) => [
-          project.workspace.path,
-          ...(project.repoRoot ? [project.repoRoot] : []),
-          ...project.worktrees.map((worktree) => worktree.path),
-        ])
-      const resolvedOwnedPaths = await Promise.all(
-        ownedPaths.map(async (ownedPath) => {
-          try {
-            return path.normalize(await fs.promises.realpath(ownedPath))
-          } catch {
-            return path.normalize(ownedPath)
-          }
-        }),
-      )
-      const ok = resolvedOwnedPaths.some((ownedPath) => samePath(resolved, ownedPath))
-      if (!ok) throw accessError
-      return resolved
-    }
+    const strictAccess = await fromExternalCall(validatePathAccess(wcId, targetPath), (e) => e)
+    if (strictAccess.isOk()) return strictAccess.value
+
+    const accessError = strictAccess.error
+    const targetRealpath = await fromExternalCall(
+      fs.promises.realpath(targetPath),
+      () => accessError,
+    )
+    if (targetRealpath.isErr()) throw targetRealpath.error
+
+    const resolved = path.normalize(targetRealpath.value)
+    const ownedPaths = workspaceCommandService
+      .getSnapshot(wcId)
+      .projects.flatMap((project) => [
+        project.workspace.path,
+        ...(project.repoRoot ? [project.repoRoot] : []),
+        ...project.worktrees.map((worktree) => worktree.path),
+      ])
+    const resolvedOwnedPaths = await Promise.all(ownedPaths.map(normalizeRealpathOrInput))
+    const ok = resolvedOwnedPaths.some((ownedPath) => samePath(resolved, ownedPath))
+    if (!ok) throw accessError
+    return resolved
   }
 
   async function readFileTreeDir(
@@ -2530,19 +2525,9 @@ export function registerIpcHandlers(
   // workspace path registered to this window. Windows paths compare
   // case-insensitively to match validatePathAccess.
   async function isUnderHomeOrWorkspace(wcId: number, resolved: string): Promise<boolean> {
-    const homeReal = path.normalize(
-      await fs.promises.realpath(os.homedir()).catch(() => os.homedir()),
-    )
+    const homeReal = await normalizeRealpathOrInput(os.homedir())
     const allowed = windowManager.getWorkspacePaths(wcId)
-    const resolvedAllowed = await Promise.all(
-      allowed.map(async (wp) => {
-        try {
-          return path.normalize(await fs.promises.realpath(wp))
-        } catch {
-          return path.normalize(wp)
-        }
-      }),
-    )
+    const resolvedAllowed = await Promise.all(allowed.map(normalizeRealpathOrInput))
     const bases = [homeReal, ...resolvedAllowed]
     return bases.some((base) => sameOrChildPath(resolved, base))
   }

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1381,14 +1381,14 @@ export function registerIpcHandlers(
         stageAll?: boolean
       },
     ) => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
       const result = await GitRepository.commit(resolvedRepo, payload.message, payload.stageAll)
       return unwrapOrThrow(result, gitErrorMessage)
     },
   )
 
   ipcMain.handle('git:pushWorktree', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
     const result = await GitRepository.push(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })
@@ -1399,14 +1399,14 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('git:pullWithPreferences', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
     const rebase = (preferencesStore.get('gitPullRebase') ?? 'true') !== 'false'
     const result = unwrapOrThrow(await GitRepository.pull(resolvedRepo, rebase), gitErrorMessage)
     return { ...result, rebase }
   })
 
   ipcMain.handle('git:fetchWorktree', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
     const result = await GitRepository.fetch(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })
@@ -1427,7 +1427,7 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('git:stashWorktree', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
     const result = await GitRepository.stash(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })
@@ -1438,7 +1438,7 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('git:stashPopWorktree', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
     const result = await GitRepository.stashPop(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1463,7 +1463,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'git:branchCreateFromHead',
     async (event, payload: { repoRoot: string; branch: string }) => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const result = await GitRepository.createBranch(resolvedRepo, payload.branch, 'HEAD')
       return unwrapOrThrow(result, gitErrorMessage)
     },
@@ -1488,7 +1488,7 @@ export function registerIpcHandlers(
       event,
       payload: GitBranchPrepareDeletePayload,
     ): Promise<GitBranchPrepareDeleteResult> => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const branchMerged = unwrapOrThrow(
         await GitRepository.isBranchMerged(resolvedRepo, payload.branch),
         gitErrorMessage,
@@ -1509,7 +1509,7 @@ export function registerIpcHandlers(
       event,
       payload: GitBranchDeleteWithPreflightPayload,
     ): Promise<GitBranchDeleteWithPreflightResult> => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const branchMerged = unwrapOrThrow(
         await GitRepository.isBranchMerged(resolvedRepo, payload.branch),
         gitErrorMessage,
@@ -1550,7 +1550,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'git:preparePush',
     async (event, payload: { repoRoot: string }): Promise<GitPreparePushResult> => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const info = await GitRepository.getPushInfo(resolvedRepo).unwrapOr(null)
       if (!info) {
         return {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1580,7 +1580,7 @@ export function registerIpcHandlers(
       event,
       payload: { repoRoot: string; path: string; branch: string; baseBranch: string },
     ) => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
       const expanded = payload.path.startsWith('~/')
         ? os.homedir() + payload.path.slice(1)
         : payload.path
@@ -1606,7 +1606,7 @@ export function registerIpcHandlers(
         createLocalTracking: boolean
       },
     ) => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
       const expanded = payload.path.startsWith('~/')
         ? os.homedir() + payload.path.slice(1)
         : payload.path
@@ -1624,7 +1624,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'worktree:create',
     async (event, payload: WorktreeCreatePayload): Promise<WorktreeCreateResult> => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
       const expandedPath = payload.worktreePath.startsWith('~/')
         ? os.homedir() + payload.worktreePath.slice(1)
         : payload.worktreePath
@@ -1655,7 +1655,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'git:worktreeRemove',
     async (event, payload: { repoRoot: string; path: string; force: boolean }) => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
       const resolvedTarget = await validateWorktreeExistingPath(event.sender.id, payload.path)
       const result = await GitRepository.worktreeRemove(resolvedRepo, resolvedTarget, payload.force)
       return unwrapOrThrow(result, gitErrorMessage)
@@ -1665,7 +1665,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'worktree:prepareRemove',
     async (event, payload: WorktreePrepareRemovePayload): Promise<WorktreePrepareRemoveResult> => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
       const resolvedTarget = await validateWorktreeExistingPath(
         event.sender.id,
         payload.worktreePath,
@@ -1712,7 +1712,7 @@ export function registerIpcHandlers(
       event,
       payload: WorktreeGetMergedBranchesPayload,
     ): Promise<WorktreeGetMergedBranchesResult> => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
       const requestedBranches = Array.from(
         new Set(payload.branches.filter((branch) => branch && branch !== '(detached)')),
       )
@@ -1731,12 +1731,12 @@ export function registerIpcHandlers(
   )
 
   ipcMain.handle('worktree:listBranches', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
     return unwrapOrThrow(await GitRepository.listBranches(resolvedRepo), gitErrorMessage)
   })
 
   ipcMain.handle('worktree:refreshBranches', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
     unwrapOrThrow(await GitRepository.fetchAll(resolvedRepo), gitErrorMessage)
     return unwrapOrThrow(await GitRepository.listBranches(resolvedRepo), gitErrorMessage)
   })
@@ -1747,7 +1747,7 @@ export function registerIpcHandlers(
       event,
       payload: WorktreeRemoveWithBranchPayload,
     ): Promise<WorktreeRemoveWithBranchResult> => {
-      const resolvedRepo = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
       const resolvedTarget = await validateWorktreeExistingPath(
         event.sender.id,
         payload.worktreePath,
@@ -2206,6 +2206,38 @@ export function registerIpcHandlers(
     })
     if (!ok) throw new Error('Access denied: path outside workspace')
     return resolved
+  }
+
+  async function validateWorktreeRepoAccess(wcId: number, repoRoot: string): Promise<string> {
+    try {
+      return await validatePathAccess(wcId, repoRoot)
+    } catch (accessError) {
+      const resolved = path.normalize(await fs.promises.realpath(repoRoot))
+      const ownedPaths = workspaceCommandService
+        .getSnapshot(wcId)
+        .projects.flatMap((project) => [
+          project.workspace.path,
+          ...(project.repoRoot ? [project.repoRoot] : []),
+          ...project.worktrees.map((worktree) => worktree.path),
+        ])
+      const resolvedOwnedPaths = await Promise.all(
+        ownedPaths.map(async (ownedPath) => {
+          try {
+            return path.normalize(await fs.promises.realpath(ownedPath))
+          } catch {
+            return path.normalize(ownedPath)
+          }
+        }),
+      )
+      const isWin = process.platform === 'win32'
+      const target = isWin ? resolved.toLowerCase() : resolved
+      const ok = resolvedOwnedPaths.some((ownedPath) => {
+        const base = isWin ? ownedPath.toLowerCase() : ownedPath
+        return target === base
+      })
+      if (!ok) throw accessError
+      return resolved
+    }
   }
 
   async function readFileTreeDir(
@@ -3358,7 +3390,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'taskTracker:createWorktreeFromTask',
     async (event, payload: TaskTrackerCreateWorktreeFromTaskPayload) => {
-      const repoRoot = await validatePathAccess(event.sender.id, payload.repoRoot)
+      const repoRoot = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
       const expandedPath = payload.worktreePath.startsWith('~/')
         ? os.homedir() + payload.worktreePath.slice(1)
         : payload.worktreePath

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1821,7 +1821,7 @@ export function registerIpcHandlers(
   }
 
   ipcMain.handle('changes:getDiff', async (event, payload: { worktreePath: string }) => {
-    const resolvedWorktree = await validatePathAccess(event.sender.id, payload.worktreePath)
+    const resolvedWorktree = await validateWorktreeRepoAccess(event.sender.id, payload.worktreePath)
     const result = await GitRepository.getDiffParsed(resolvedWorktree)
     return result.unwrapOr({ files: [] })
   })
@@ -1829,7 +1829,10 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'changes:stageFile',
     async (event, payload: { worktreePath: string; filePath: string }) => {
-      const resolvedWorktree = await validatePathAccess(event.sender.id, payload.worktreePath)
+      const resolvedWorktree = await validateWorktreeRepoAccess(
+        event.sender.id,
+        payload.worktreePath,
+      )
       validateFilePath(payload.filePath)
       const result = await GitRepository.stageFile(resolvedWorktree, payload.filePath)
       return unwrapOrThrow(result, gitErrorMessage)
@@ -1839,7 +1842,10 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'changes:revertFile',
     async (event, payload: { worktreePath: string; filePath: string }) => {
-      const resolvedWorktree = await validatePathAccess(event.sender.id, payload.worktreePath)
+      const resolvedWorktree = await validateWorktreeRepoAccess(
+        event.sender.id,
+        payload.worktreePath,
+      )
       validateFilePath(payload.filePath)
       const result = await GitRepository.revertFile(resolvedWorktree, payload.filePath)
       return unwrapOrThrow(result, gitErrorMessage)

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1381,14 +1381,14 @@ export function registerIpcHandlers(
         stageAll?: boolean
       },
     ) => {
-      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const result = await GitRepository.commit(resolvedRepo, payload.message, payload.stageAll)
       return unwrapOrThrow(result, gitErrorMessage)
     },
   )
 
   ipcMain.handle('git:pushWorktree', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
     const result = await GitRepository.push(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })
@@ -1399,14 +1399,14 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('git:pullWithPreferences', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
     const rebase = (preferencesStore.get('gitPullRebase') ?? 'true') !== 'false'
     const result = unwrapOrThrow(await GitRepository.pull(resolvedRepo, rebase), gitErrorMessage)
     return { ...result, rebase }
   })
 
   ipcMain.handle('git:fetchWorktree', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
     const result = await GitRepository.fetch(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })
@@ -1427,7 +1427,7 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('git:stashWorktree', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
     const result = await GitRepository.stash(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })
@@ -1438,7 +1438,7 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('git:stashPopWorktree', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
     const result = await GitRepository.stashPop(resolvedRepo)
     return unwrapOrThrow(result, gitErrorMessage)
   })
@@ -1580,7 +1580,7 @@ export function registerIpcHandlers(
       event,
       payload: { repoRoot: string; path: string; branch: string; baseBranch: string },
     ) => {
-      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const expanded = payload.path.startsWith('~/')
         ? os.homedir() + payload.path.slice(1)
         : payload.path
@@ -1606,7 +1606,7 @@ export function registerIpcHandlers(
         createLocalTracking: boolean
       },
     ) => {
-      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const expanded = payload.path.startsWith('~/')
         ? os.homedir() + payload.path.slice(1)
         : payload.path
@@ -1624,7 +1624,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'worktree:create',
     async (event, payload: WorktreeCreatePayload): Promise<WorktreeCreateResult> => {
-      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const expandedPath = payload.worktreePath.startsWith('~/')
         ? os.homedir() + payload.worktreePath.slice(1)
         : payload.worktreePath
@@ -1655,7 +1655,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'git:worktreeRemove',
     async (event, payload: { repoRoot: string; path: string; force: boolean }) => {
-      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const resolvedTarget = await validateWorktreeExistingPath(event.sender.id, payload.path)
       const result = await GitRepository.worktreeRemove(resolvedRepo, resolvedTarget, payload.force)
       return unwrapOrThrow(result, gitErrorMessage)
@@ -1665,7 +1665,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'worktree:prepareRemove',
     async (event, payload: WorktreePrepareRemovePayload): Promise<WorktreePrepareRemoveResult> => {
-      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const resolvedTarget = await validateWorktreeExistingPath(
         event.sender.id,
         payload.worktreePath,
@@ -1712,7 +1712,7 @@ export function registerIpcHandlers(
       event,
       payload: WorktreeGetMergedBranchesPayload,
     ): Promise<WorktreeGetMergedBranchesResult> => {
-      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const requestedBranches = Array.from(
         new Set(payload.branches.filter((branch) => branch && branch !== '(detached)')),
       )
@@ -1731,12 +1731,12 @@ export function registerIpcHandlers(
   )
 
   ipcMain.handle('worktree:listBranches', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
     return unwrapOrThrow(await GitRepository.listBranches(resolvedRepo), gitErrorMessage)
   })
 
   ipcMain.handle('worktree:refreshBranches', async (event, payload: { repoRoot: string }) => {
-    const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+    const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
     unwrapOrThrow(await GitRepository.fetchAll(resolvedRepo), gitErrorMessage)
     return unwrapOrThrow(await GitRepository.listBranches(resolvedRepo), gitErrorMessage)
   })
@@ -1747,7 +1747,7 @@ export function registerIpcHandlers(
       event,
       payload: WorktreeRemoveWithBranchPayload,
     ): Promise<WorktreeRemoveWithBranchResult> => {
-      const resolvedRepo = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+      const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const resolvedTarget = await validateWorktreeExistingPath(
         event.sender.id,
         payload.worktreePath,
@@ -1821,7 +1821,10 @@ export function registerIpcHandlers(
   }
 
   ipcMain.handle('changes:getDiff', async (event, payload: { worktreePath: string }) => {
-    const resolvedWorktree = await validateWorktreeRepoAccess(event.sender.id, payload.worktreePath)
+    const resolvedWorktree = await validateWorktreeScopedPathAccess(
+      event.sender.id,
+      payload.worktreePath,
+    )
     const result = await GitRepository.getDiffParsed(resolvedWorktree)
     return result.unwrapOr({ files: [] })
   })
@@ -1829,7 +1832,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'changes:stageFile',
     async (event, payload: { worktreePath: string; filePath: string }) => {
-      const resolvedWorktree = await validateWorktreeRepoAccess(
+      const resolvedWorktree = await validateWorktreeScopedPathAccess(
         event.sender.id,
         payload.worktreePath,
       )
@@ -1842,7 +1845,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'changes:revertFile',
     async (event, payload: { worktreePath: string; filePath: string }) => {
-      const resolvedWorktree = await validateWorktreeRepoAccess(
+      const resolvedWorktree = await validateWorktreeScopedPathAccess(
         event.sender.id,
         payload.worktreePath,
       )
@@ -2182,6 +2185,20 @@ export function registerIpcHandlers(
     return false
   }
 
+  function comparablePath(value: string): string {
+    return process.platform === 'win32' ? value.toLowerCase() : value
+  }
+
+  function samePath(a: string, b: string): boolean {
+    return comparablePath(a) === comparablePath(b)
+  }
+
+  function sameOrChildPath(targetPath: string, basePath: string): boolean {
+    const target = comparablePath(targetPath)
+    const base = comparablePath(basePath)
+    return target === base || target.startsWith(base + path.sep)
+  }
+
   // Realpath-normalize workspace roots too: otherwise a macOS workspace at
   // `/var/...` (which resolves to `/private/var/...`) would never match a
   // target's realpath and all reads get rejected; conversely a symlinked
@@ -2201,24 +2218,19 @@ export function registerIpcHandlers(
         }
       }),
     )
-    const ok = resolvedAllowed.some((normalWp) => {
-      // Windows paths are case-insensitive
-      if (process.platform === 'win32') {
-        const r = resolved.toLowerCase()
-        const w = normalWp.toLowerCase()
-        return r === w || r.startsWith(w + path.sep)
-      }
-      return resolved === normalWp || resolved.startsWith(normalWp + path.sep)
-    })
+    const ok = resolvedAllowed.some((normalWp) => sameOrChildPath(resolved, normalWp))
     if (!ok) throw new Error('Access denied: path outside workspace')
     return resolved
   }
 
-  async function validateWorktreeRepoAccess(wcId: number, repoRoot: string): Promise<string> {
+  async function validateWorktreeScopedPathAccess(
+    wcId: number,
+    targetPath: string,
+  ): Promise<string> {
     try {
-      return await validatePathAccess(wcId, repoRoot)
+      return await validatePathAccess(wcId, targetPath)
     } catch (accessError) {
-      const resolved = path.normalize(await fs.promises.realpath(repoRoot))
+      const resolved = path.normalize(await fs.promises.realpath(targetPath))
       const ownedPaths = workspaceCommandService
         .getSnapshot(wcId)
         .projects.flatMap((project) => [
@@ -2235,12 +2247,7 @@ export function registerIpcHandlers(
           }
         }),
       )
-      const isWin = process.platform === 'win32'
-      const target = isWin ? resolved.toLowerCase() : resolved
-      const ok = resolvedOwnedPaths.some((ownedPath) => {
-        const base = isWin ? ownedPath.toLowerCase() : ownedPath
-        return target === base
-      })
+      const ok = resolvedOwnedPaths.some((ownedPath) => samePath(resolved, ownedPath))
       if (!ok) throw accessError
       return resolved
     }
@@ -2537,12 +2544,7 @@ export function registerIpcHandlers(
       }),
     )
     const bases = [homeReal, ...resolvedAllowed]
-    const isWin = process.platform === 'win32'
-    return bases.some((base) => {
-      const target = isWin ? resolved.toLowerCase() : resolved
-      const b = isWin ? base.toLowerCase() : base
-      return target === b || target.startsWith(b + path.sep)
-    })
+    return bases.some((base) => sameOrChildPath(resolved, base))
   }
 
   // Worktrees are intentionally created OUTSIDE the workspace by design (the
@@ -3396,7 +3398,7 @@ export function registerIpcHandlers(
   ipcMain.handle(
     'taskTracker:createWorktreeFromTask',
     async (event, payload: TaskTrackerCreateWorktreeFromTaskPayload) => {
-      const repoRoot = await validateWorktreeRepoAccess(event.sender.id, payload.repoRoot)
+      const repoRoot = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const expandedPath = payload.worktreePath.startsWith('~/')
         ? os.homedir() + payload.worktreePath.slice(1)
         : payload.worktreePath

--- a/src/renderer/src/components/palette/CommandPalette.svelte
+++ b/src/renderer/src/components/palette/CommandPalette.svelte
@@ -462,9 +462,10 @@
           action: async () => {
             const wtPath = selectedWt.path
             const branch = selectedWt.branch
+            const operationRoot = workspaceState.worktrees.find((w) => w.isMain)?.path ?? root
             try {
               const preflight = await window.api.worktreePrepareRemove({
-                repoRoot: root,
+                repoRoot: operationRoot,
                 worktreePath: wtPath,
                 branch,
               })
@@ -493,7 +494,7 @@
               }
 
               await window.api.worktreeRemoveWithBranch({
-                repoRoot: root,
+                repoRoot: operationRoot,
                 worktreePath: wtPath,
                 branch,
                 deleteBranch,

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -136,7 +136,8 @@
     project: ProjectState,
     wt: { path: string; branch: string },
   ): Promise<void> {
-    if (!project.repoRoot || removingPaths.has(wt.path)) return
+    const repoRoot = project.worktrees.find((w) => w.isMain)?.path ?? project.repoRoot
+    if (!repoRoot || removingPaths.has(wt.path)) return
     removingPaths.add(wt.path)
 
     try {
@@ -144,13 +145,18 @@
 
       const isDetached = wt.branch === '(detached)'
       await window.api.worktreeRemoveWithBranch({
-        repoRoot: project.repoRoot,
+        repoRoot,
         worktreePath: wt.path,
         branch: wt.branch,
         deleteBranch: !isDetached,
         forceOnFailure: true,
       })
-    } catch {
+    } catch (err) {
+      await confirm({
+        title: 'Git Error',
+        message: err instanceof Error ? err.message : String(err),
+        confirmLabel: 'OK',
+      })
       return
     } finally {
       removingPaths.delete(wt.path)

--- a/src/renderer/src/components/sidebar/WorktreeSection.svelte
+++ b/src/renderer/src/components/sidebar/WorktreeSection.svelte
@@ -67,7 +67,7 @@
     wt: { path: string; branch: string },
   ): Promise<void> {
     e.stopPropagation()
-    const repoRoot = workspaceState.repoRoot
+    const repoRoot = workspaceState.worktrees.find((w) => w.isMain)?.path ?? workspaceState.repoRoot
     if (!repoRoot) return
 
     const isDetached = wt.branch === '(detached)'
@@ -92,8 +92,13 @@
         deleteBranch: !isDetached,
         forceOnFailure: true,
       })
-    } catch {
-      // Ignore — watcher will update the list
+    } catch (err) {
+      await confirm({
+        title: 'Git Error',
+        message: err instanceof Error ? err.message : String(err),
+        confirmLabel: 'OK',
+      })
+      return
     }
 
     if (workspaceState.selectedWorktreePath === wt.path) {

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -188,8 +188,8 @@
         const taskSnapshot = $state.snapshot(fullTask) as typeof fullTask
 
         try {
-          const tab = await openTool(agentId, created.worktreePath)
           await selectWorktree(created.worktreePath)
+          const tab = await openTool(agentId, created.worktreePath)
           const pane = tab.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
           if (pane) {
             const sessionId = pane.sessionId

--- a/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
+++ b/src/renderer/src/components/worktree/CreateWorktreeModal.svelte
@@ -253,11 +253,16 @@
       async () => {
         finishTimer = null
         const targetPath = createdPath || worktreeDirDisplay
-        await openTool(getPref('newWorktree.toolId', 'shell'), targetPath).catch((err) => {
-          console.error('Failed to launch tool after worktree creation:', err)
-        })
-        selectWorktree(targetPath)
-        onClose()
+        try {
+          await selectWorktree(targetPath)
+          await openTool(getPref('newWorktree.toolId', 'shell'), targetPath).catch((err) => {
+            console.error('Failed to launch tool after worktree creation:', err)
+          })
+          onClose()
+        } catch (err) {
+          errorMessage = err instanceof Error ? err.message : String(err)
+          step = 'error'
+        }
       },
       setupErrors.length > 0 ? 2000 : 400,
     )

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -973,7 +973,6 @@ export async function closeAllTabsForWorktree(worktreePath: string): Promise<boo
     delete saveTimers[worktreePath]
   }
   applyTabCommandResult(result)
-  delete closedTabs[worktreePath]
   return true
 }
 
@@ -983,9 +982,6 @@ export async function killAllTabs(): Promise<void> {
   for (const p of allSessions) disposeEphemeralPaneState(p)
   const result = await window.api.tabKillAll()
   applyTabsSnapshot(result, { replaceAll: true })
-  for (const path of Object.keys(closedTabs)) {
-    delete closedTabs[path]
-  }
 }
 
 export function focusSessionByPtyId(ptySessionId: string): void {


### PR DESCRIPTION
## What

Updates worktree-related IPC handlers to validate repository access against attached project/worktree ownership when strict window path validation is too narrow.

## Why

Creating or checking out a worktree could fail with \`Access denied: path outside workspace\` even when the repo belongs to the current project. The worktree flow intentionally works across repo/worktree paths, so it needs ownership-aware repo validation instead of only active-window path containment.

## How to test

1. Open a git project in Canopy.
2. Create a worktree from a new branch using the default worktree directory.
3. Create a worktree from an existing branch.
4. Confirm neither flow fails with \`Access denied: path outside workspace\`.
5. Run \`npm run typecheck:node\`.
6. Run \`npm run lint\`.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [ ] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows \`feature:action\` naming and uses \`invoke\`/\`handle\`
- [x] Renderer code does not import Node.js modules directly
- [ ] Feature docs in \`docs/\` updated (behavior, config, errors, security — if any changed)