### PR TITLE
fix(task-tracker): show task-to-agent failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ perf/results/*.json
 perf/results/*.cpuprofile
 *.tsbuildinfo
 .codex/
+.itsol/plans/
 docs/superpowers/

--- a/.itsol.md
+++ b/.itsol.md
@@ -1,0 +1,143 @@
+# ITSOL Repository Notes
+
+Last reviewed: 2026-06-17
+Maintainers: ITSOL
+Repository type: monorepo
+
+## Monorepo Map
+
+| Path | Type | Stack | TDD mode | Verification |
+| --- | --- | --- | --- | --- |
+| `.` | desktop app | Electron, Svelte 5, TypeScript, electron-vite, npm | limited | lint, typecheck, build, e2e/manual QA |
+| `mobile/` | mobile app | Expo, React 19, React Native, TypeScript, npm, EAS | limited | lint, typecheck, build, doctor, EAS/manual QA |
+
+## Default Policy
+
+If a touched path is not listed:
+
+- inspect local package/project config first
+- do not assume root test commands apply
+- do not add a new test framework without explicit user approval
+- document discovered stable facts by proposing an update to this file
+
+## Project: .
+
+- Owners: ITSOL
+- Stack:
+  - Electron desktop app using the three-process model:
+    - `src/main/` for the Electron main process and Node.js access
+    - `src/preload/` for the context-isolation bridge
+    - `src/renderer/` for Svelte 5 UI and browser APIs
+  - Svelte 5 renderer, TypeScript, electron-vite, npm
+- TDD mode: limited
+- Reason:
+  - Playwright e2e tests exist, but no unit/component test runner is configured.
+  - Some Electron renderer/main/preload flows cross IPC, PTY sessions, OS APIs, and external tools, so RED/GREEN automation may not be practical for every bugfix.
+- Supported automated tests:
+  - `npm run svelte-check`
+  - `npm run typecheck:node`
+  - `npm run typecheck`
+  - `npm run lint`
+  - `npm run build`
+  - `npm run test:e2e`
+- Unsupported automated tests:
+  - Do not introduce Vitest, Jest, or a component test framework during normal work unless the user explicitly approves that setup.
+- Do not spend time on:
+  - scaffolding a new test framework only to satisfy TDD workflow
+  - running full platform release builds unless the task requires packaging validation
+- Required replacement verification:
+  - run the smallest relevant existing check, usually `npm run svelte-check`, `npm run typecheck:node`, `npm run typecheck`, or `npm run lint`
+  - run `npm run build` when behavior touches bundling, Electron process boundaries, preload types, or release-sensitive code
+  - use focused manual QA or a diagnostic reproduction for UI, IPC, PTY, external tool, and task-tracker flows that cannot be covered by existing tests
+  - document the TDD exception and residual risk when no automated RED test is practical
+- Architecture constraints:
+  - Renderer code must never import Node.js modules directly.
+  - All renderer access to Node.js capabilities must go through the preload bridge on `window.api`.
+  - Use `import type` for type-only imports because `verbatimModuleSyntax` is enabled.
+
+## Project: mobile/
+
+- Owners: ITSOL
+- Stack:
+  - Expo, React 19, React Native, TypeScript, npm, EAS
+- TDD mode: limited
+- Reason:
+  - Mobile project has lint/typecheck/build/doctor scripts, but no test runner was detected.
+- Supported automated tests:
+  - `cd mobile && npm run typecheck`
+  - `cd mobile && npm run lint`
+  - `cd mobile && npm run build`
+  - `cd mobile && npm run doctor`
+- Unsupported automated tests:
+  - Do not introduce Jest, Vitest, Detox, or another mobile test framework during normal work unless the user explicitly approves that setup.
+- Do not spend time on:
+  - scaffolding a new test framework only to satisfy TDD workflow
+  - running EAS cloud builds unless the task requires native build validation
+- Required replacement verification:
+  - run `cd mobile && npm run typecheck` and `cd mobile && npm run lint` for code changes
+  - run `cd mobile && npm run build` or `cd mobile && npm run doctor` when dependency, Expo config, or native integration behavior changes
+  - use manual QA on the relevant Expo target when automation does not cover the changed flow
+  - document the TDD exception and residual risk when no automated RED test is practical
+
+## Verification Commands
+
+- Desktop fast check:
+  - `npm run svelte-check`
+  - `npm run typecheck:node`
+- Desktop full typecheck:
+  - `npm run typecheck`
+- Desktop lint:
+  - `npm run lint`
+- Desktop build:
+  - `npm run build`
+- Desktop e2e:
+  - `npm run test:e2e`
+- Mobile fast check:
+  - `cd mobile && npm run typecheck`
+  - `cd mobile && npm run lint`
+- Mobile build/config:
+  - `cd mobile && npm run build`
+  - `cd mobile && npm run doctor`
+- Manual QA:
+  - Required for UI, IPC, PTY, task tracker, external CLI, remote control, and native mobile flows that are not covered by existing automated tests.
+
+## Agent Workflow Notes
+
+- Before implementation:
+  - read this file and apply the most specific project policy for touched paths
+  - inspect local configs before assuming test support
+  - for functional changes and bugfixes, follow the ITSOL planning/approval workflow required by the active instructions
+- During implementation:
+  - keep renderer/main/preload boundaries intact
+  - avoid unrelated refactors and generated or formatting churn
+  - prefer existing app patterns, stores, IPC contracts, and UI tokens
+- Before completion:
+  - run the relevant verification commands for touched projects
+  - state any TDD exception, replacement verification, and residual risk
+  - mention existing unrelated lint/test warnings separately from new failures
+- Use subagents for:
+  - large or multi-surface reviews
+  - independent frontend/backend/security/infra/data review surfaces
+  - current-technology checks when framework, SDK, package, or runtime behavior matters
+- Avoid:
+  - adding new test frameworks without explicit approval
+  - committing `.itsol/plans/`; planning scratch files under `.itsol/plans/` are intentionally gitignored
+  - placing temporary task notes in `.itsol.md`
+
+## Known Constraints
+
+- Constraint: `.itsol/plans/` is ignored by git.
+  - Why it matters: task-specific plans are workflow artifacts and should not be committed.
+  - What agents should do: keep stable repo policy in `.itsol.md`; keep temporary plans under `.itsol/plans/`.
+- Constraint: root CI runs `npm ci`, `npm run lint`, and `npm run build`.
+  - Why it matters: `npm run build` includes typecheck and electron-vite build for release-sensitive validation.
+  - What agents should do: run focused checks locally during development and `npm run build` when the touched area warrants CI-equivalent validation.
+- Constraint: root lint may report existing Prettier warnings outside a touched task.
+  - Why it matters: unrelated warnings should not trigger broad formatting churn.
+  - What agents should do: report unrelated warnings and avoid formatting unrelated files unless asked.
+
+## Update Rules
+
+- Update this file only with stable repo-level facts.
+- Do not add temporary task notes.
+- If a fact is uncertain, mark it as `unknown` and verify first.

--- a/docs/integrations/task-tracker.md
+++ b/docs/integrations/task-tracker.md
@@ -61,7 +61,9 @@ Jira maps `issuetype.subtask = true` to `subtask`, and normalizes type names (`U
 2. Canopy resolves the branch name using the configured `branchTemplate`. The default template is `{branchType}/{taskKey}-{taskTitle}`.
 3. The create form shows the proposed branch name, an optional branch-type select, an optional agent to launch, and a **base branch** picker (grouped local/remote, populated from `gitBranches`). The base defaults to the currently active branch but can be changed to any local or remote branch.
 4. Canopy creates a worktree for the new branch off the selected base via `gitWorktreeAdd`, then runs any configured worktree setup actions and optionally launches the selected agent with the task context.
-5. On failure, an error dialog is shown with the Git error message.
+5. While the flow runs, the form shows inline progress for worktree creation, setup, agent startup, agent readiness, and sending the task context.
+6. If worktree creation fails, an error dialog is shown with the Git error message.
+7. If the worktree is created but the agent cannot be started, does not become ready, or cannot receive the task context, the form keeps the partial-success state visible and offers **Retry Send** without creating another worktree.
 
 ### Branch template system
 
@@ -101,7 +103,9 @@ Default type mapping: `bug` to `fix`, `story`/`task`/`subtask`/`epic` to `feat`.
 2. Canopy fetches three things in parallel: the full task details (to get the description, which list fetches omit for performance), comments, and attachments — each with fallback from config-based API to legacy connection-based API.
 3. A formatted context string is assembled: task header, metadata (status, priority, type), URL, description, comments, and attachment file references (`@/path/to/file`).
 4. The text is wrapped in bracketed-paste markers (`ESC[200~ … ESC[201~`) and written to the agent's PTY as one block, followed by `\r` to submit. The wrapping keeps the CLI's paste detection honest even when the OS (e.g. Windows ConPTY) delivers the write in multiple chunks; without it the tail of a long description can leak in as typed input. Control characters and any stray `ESC[201~` inside the content are sanitised first so they can't hijack the terminal or end the paste early.
-5. Attachment files are cleaned up after 60 seconds via `taskTrackerCleanupAttachments`.
+5. Quick send from the task picker keeps the picker open and shows inline feedback if there is no running agent, the target agent tab cannot be focused, task context cannot be built, or the paste fails.
+6. When sending as part of **Create & Start Agent**, the branch/worktree form shows the same progress and failure states. If the worktree already exists but sending fails, the user can start or focus an agent in that worktree and click **Retry Send**.
+7. Attachment files are cleaned up after 60 seconds via `taskTrackerCleanupAttachments`.
 
 ### Sprints
 
@@ -199,6 +203,11 @@ When a GitHub tracker has an empty `projectKey`, Canopy reads the git remote URL
 | `ConfigParseError`         | "Invalid config in {root}: {reason}"             | JSON parse error or unsupported config version                            |
 | `ConfigWriteError`         | "Failed to write config in {root}: {reason}"     | Filesystem permission error or disk full                                  |
 | `PRCreationFailed`         | "PR creation failed: {reason}"                   | `gh` CLI not installed, Git push failure, or `gh pr create` error         |
+| `NoActiveAgent`            | "No running agent is available..."               | Quick send was triggered after the active agent target disappeared        |
+| `AgentStartFailed`         | "The worktree was created, but..."               | Worktree creation succeeded, but Canopy could not open the selected agent |
+| `AgentNotReady`            | "The agent did not become ready..."              | Started agent ended, errored, or did not become idle before timeout       |
+| `TaskContextBuildFailed`   | "Could not build the task context..."            | Task details/comments/attachments could not be fetched or formatted       |
+| `TaskContextPasteFailed`   | "Could not paste the task into the agent..."     | Target agent session rejected or lost the paste target                    |
 
 ## Security and privacy
 

--- a/docs/integrations/task-tracker.md
+++ b/docs/integrations/task-tracker.md
@@ -206,6 +206,7 @@ When a GitHub tracker has an empty `projectKey`, Canopy reads the git remote URL
 | `NoActiveAgent`            | "No running agent is available..."               | Quick send was triggered after the active agent target disappeared        |
 | `AgentStartFailed`         | "The worktree was created, but..."               | Worktree creation succeeded, but Canopy could not open the selected agent |
 | `AgentNotReady`            | "The agent did not become ready..."              | Started agent ended, errored, or did not become idle before timeout       |
+| `TabFocusFailed`           | "Could not focus the target agent tab..."        | The target agent tab could not be activated before sending                |
 | `TaskContextBuildFailed`   | "Could not build the task context..."            | Task details/comments/attachments could not be fetched or formatted       |
 | `TaskContextPasteFailed`   | "Could not paste the task into the agent..."     | Target agent session rejected or lost the paste target                    |
 

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -7,7 +7,12 @@
   import { addToast } from '../../lib/stores/toast.svelte'
   import { workspaceState, selectWorktree } from '../../lib/stores/workspace.svelte'
   import { getTools, getToolAvailability } from '../../lib/stores/tools.svelte'
-  import { isAiToolId, openTool } from '../../lib/stores/tabs.svelte'
+  import {
+    focusSessionByPtyId,
+    getAiSessions,
+    isAiToolId,
+    openTool,
+  } from '../../lib/stores/tabs.svelte'
   import { agentSessions } from '../../lib/agents/agentState.svelte'
   import { setActiveTask } from '../../lib/stores/taskTracker.svelte'
   import {
@@ -150,7 +155,11 @@
 
   async function confirmBranchCreation(): Promise<void> {
     if (createdWorktreePath && contextSendFailed) {
-      if (!selectedAgentId) return
+      if (!selectedAgentId) {
+        operationStatus = 'Worktree created'
+        operationError = 'Select an agent to retry sending the task.'
+        return
+      }
       creatingWorktree = true
       operationError = ''
       contextSendFailed = false
@@ -160,6 +169,7 @@
         selectedAgentId,
         connectionId,
         taskSnapshot,
+        { reuseExistingAgent: true },
       )
       creatingWorktree = false
       if (sent) closeDialog()
@@ -254,6 +264,7 @@
     agentId: string,
     connId: string,
     taskSnapshot: Task,
+    options: { reuseExistingAgent?: boolean } = {},
   ): Promise<boolean> {
     try {
       await selectWorktree(worktreePath)
@@ -266,20 +277,31 @@
       return false
     }
 
-    operationStatus = 'Starting agent...'
-    let tab: Awaited<ReturnType<typeof openTool>>
-    try {
-      tab = await openTool(agentId, worktreePath)
-    } catch (error) {
-      handleTaskToAgentFailure(agentStartFailedOutcome(error), {
-        taskKey: taskSnapshot.key,
-        connectionId: connId,
-        selectedAgentId: agentId,
-      })
-      return false
+    const existingAgentSession = options.reuseExistingAgent
+      ? getAiSessions(worktreePath).find((session) => session.toolId === agentId)
+      : null
+
+    let sessionId = existingAgentSession?.sessionId
+    if (sessionId) {
+      operationStatus = 'Focusing agent...'
+      focusSessionByPtyId(sessionId)
+    } else {
+      operationStatus = 'Starting agent...'
+      let tab: Awaited<ReturnType<typeof openTool>>
+      try {
+        tab = await openTool(agentId, worktreePath)
+      } catch (error) {
+        handleTaskToAgentFailure(agentStartFailedOutcome(error), {
+          taskKey: taskSnapshot.key,
+          connectionId: connId,
+          selectedAgentId: agentId,
+        })
+        return false
+      }
+      const pane = tab.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+      sessionId = pane?.sessionId
     }
-    const pane = tab.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
-    const sessionId = pane?.sessionId
+
     if (!sessionId) {
       handleTaskToAgentFailure(agentNotReadyOutcome(), {
         taskKey: taskSnapshot.key,
@@ -485,7 +507,7 @@
         {#if creatingWorktree}
           Working...
         {:else if createdWorktreePath && contextSendFailed}
-          Retry Send
+          {selectedAgentId ? 'Retry Send' : 'Select Agent to Retry'}
         {:else if selectedAgentId}
           Create & Start Agent
         {:else}

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -10,6 +10,13 @@
   import { isAiToolId, openTool } from '../../lib/stores/tabs.svelte'
   import { agentSessions } from '../../lib/agents/agentState.svelte'
   import { setActiveTask } from '../../lib/stores/taskTracker.svelte'
+  import {
+    agentNotReadyOutcome,
+    agentStartFailedOutcome,
+    logTaskToAgentFailure,
+    sendTaskToAgentContext,
+    type TaskToAgentOutcome,
+  } from '../../lib/taskTracker/taskToAgent'
   import { safeDirName } from '../../lib/sanitize'
 
   interface Task {
@@ -48,6 +55,10 @@
   let selectedAgentId = $state(getPref('taskTracker.lastAgent', ''))
   let branches = $state<{ local: string[]; remote: string[] }>({ local: [], remote: [] })
   let selectedBaseBranch = $state('')
+  let operationStatus = $state('')
+  let operationError = $state('')
+  let createdWorktreePath = $state('')
+  let contextSendFailed = $state(false)
 
   let baseBranchGroups = $derived(
     [
@@ -138,6 +149,11 @@
   }
 
   async function confirmBranchCreation(): Promise<void> {
+    if (createdWorktreePath && contextSendFailed) {
+      closeDialog()
+      return
+    }
+
     const repoRoot = workspaceState.repoRoot
     const baseBranch = selectedBaseBranch
     if (!repoRoot || !baseBranch || !resolvedBranchName) return
@@ -152,6 +168,10 @@
       : worktreeDir
 
     creatingWorktree = true
+    operationStatus = 'Creating worktree...'
+    operationError = ''
+    contextSendFailed = false
+    createdWorktreePath = ''
     setPref('taskTracker.lastAgent', selectedAgentId)
     try {
       const branchTask = $state.snapshot(task) as Task
@@ -164,6 +184,8 @@
         worktreePath,
         baseBranch,
       })
+      createdWorktreePath = created.worktreePath
+      operationStatus = 'Worktree created'
       await setActiveTask(created.worktreePath, {
         taskKey: fullTask.key,
         summary: fullTask.summary,
@@ -173,6 +195,7 @@
 
       if (hasSetupConfig()) {
         const wsId = workspaceState.workspace!.id
+        operationStatus = 'Running worktree setup...'
         addToast('Running worktree setup...')
         try {
           await window.api.runWorktreeSetup(wsId, repoRoot, created.worktreePath)
@@ -189,34 +212,86 @@
 
         try {
           await selectWorktree(created.worktreePath)
-          const tab = await openTool(agentId, created.worktreePath)
-          const pane = tab.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
-          if (pane) {
-            const sessionId = pane.sessionId
-            const ready = await waitForAgentIdle(sessionId)
-            if (ready) {
-              const context = await window.api.taskTrackerBuildTaskContext({
-                connectionId: connId,
-                task: taskSnapshot,
-                repoRoot: workspaceState.repoRoot ?? undefined,
-              })
-              await window.api.agentSendTaskContext({
-                text: context,
-                worktreePath: created.worktreePath,
-                sessionId,
-              })
-            }
-          }
-        } catch {
-          addToast('Failed to send task context to agent')
+        } catch (error) {
+          handleTaskToAgentFailure(agentStartFailedOutcome(error), {
+            taskKey: taskSnapshot.key,
+            connectionId: connId,
+            selectedAgentId: agentId,
+          })
+          creatingWorktree = false
+          return
         }
+
+        operationStatus = 'Starting agent...'
+        let tab: Awaited<ReturnType<typeof openTool>>
+        try {
+          tab = await openTool(agentId, created.worktreePath)
+        } catch (error) {
+          handleTaskToAgentFailure(agentStartFailedOutcome(error), {
+            taskKey: taskSnapshot.key,
+            connectionId: connId,
+            selectedAgentId: agentId,
+          })
+          creatingWorktree = false
+          return
+        }
+        const pane = tab.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+        const sessionId = pane?.sessionId
+        if (!sessionId) {
+          handleTaskToAgentFailure(agentNotReadyOutcome(), {
+            taskKey: taskSnapshot.key,
+            connectionId: connId,
+            selectedAgentId: agentId,
+          })
+          creatingWorktree = false
+          return
+        }
+
+        operationStatus = 'Waiting for agent...'
+        const ready = await waitForAgentIdle(sessionId)
+        if (!ready) {
+          handleTaskToAgentFailure(agentNotReadyOutcome(sessionId), {
+            taskKey: taskSnapshot.key,
+            connectionId: connId,
+            selectedAgentId: agentId,
+            sessionId,
+          })
+          creatingWorktree = false
+          return
+        }
+
+        operationStatus = 'Sending task to agent...'
+        const outcome = await sendTaskToAgentContext({
+          connectionId: connId,
+          task: taskSnapshot,
+          repoRoot: workspaceState.repoRoot ?? undefined,
+          target: {
+            worktreePath: created.worktreePath,
+            sessionId,
+          },
+        })
+        if (outcome.status !== 'sent') {
+          handleTaskToAgentFailure(outcome, {
+            taskKey: taskSnapshot.key,
+            connectionId: connId,
+            selectedAgentId: agentId,
+            sessionId,
+          })
+          creatingWorktree = false
+          return
+        }
+        operationStatus = 'Task sent to agent'
+        addToast('Task sent to agent')
       } else {
+        operationStatus = 'Opening worktree...'
         await selectWorktree(created.worktreePath)
       }
 
       closeDialog()
     } catch (e) {
       creatingWorktree = false
+      operationStatus = ''
+      operationError = ''
       closeDialog()
       await new Promise((r) => setTimeout(r, 0))
       await confirm({
@@ -225,6 +300,21 @@
         confirmLabel: 'OK',
       })
     }
+  }
+
+  function handleTaskToAgentFailure(
+    outcome: Exclude<TaskToAgentOutcome, { status: 'sent' }>,
+    metadata: {
+      taskKey: string
+      connectionId: string
+      selectedAgentId?: string
+      sessionId?: string
+    },
+  ): void {
+    contextSendFailed = true
+    operationStatus = 'Worktree created'
+    operationError = outcome.message
+    logTaskToAgentFailure(outcome, metadata)
   }
 
   async function waitForAgentIdle(sessionId: string, timeoutMs = 30000): Promise<boolean> {
@@ -318,6 +408,31 @@
         >{resolvedBranchName}</code
       >
     </div>
+    {#if operationStatus || operationError}
+      <div
+        class="rounded-lg border px-3 py-2 text-xs leading-snug"
+        role={operationError ? 'alert' : 'status'}
+        aria-live={operationError ? 'assertive' : 'polite'}
+        class:border-danger={operationError}
+        class:border-border={!operationError}
+        class:bg-danger-bg={operationError}
+        class:bg-bg-input={!operationError}
+        class:text-danger-text={operationError}
+        class:text-text-muted={!operationError}
+      >
+        {#if operationError}
+          <p class="m-0 font-medium">{operationError}</p>
+          {#if createdWorktreePath}
+            <p class="mt-1 mb-0">
+              The worktree was created. Open it from the worktree list if needed, start or focus an
+              agent there, then send the task again from the picker.
+            </p>
+          {/if}
+        {:else}
+          {operationStatus}
+        {/if}
+      </div>
+    {/if}
     {#if availableAgents.length > 0}
       <div class="flex items-center gap-2.5">
         <span class="text-sm text-text-muted w-[50px] flex-shrink-0">Agent</span>
@@ -344,8 +459,15 @@
         onclick={confirmBranchCreation}
         disabled={creatingWorktree || !resolvedBranchName || !selectedBaseBranch}
       >
-        {#if creatingWorktree}Creating...{:else if selectedAgentId}Create & Start Agent{:else}Create
-          & Switch{/if}
+        {#if creatingWorktree}
+          Working...
+        {:else if createdWorktreePath && contextSendFailed}
+          Close
+        {:else if selectedAgentId}
+          Create & Start Agent
+        {:else}
+          Create & Switch
+        {/if}
       </button>
     </div>
   </div>

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -150,7 +150,19 @@
 
   async function confirmBranchCreation(): Promise<void> {
     if (createdWorktreePath && contextSendFailed) {
-      closeDialog()
+      if (!selectedAgentId) return
+      creatingWorktree = true
+      operationError = ''
+      contextSendFailed = false
+      const taskSnapshot = $state.snapshot(fullTask) as typeof fullTask
+      const sent = await sendTaskContextToSelectedAgent(
+        createdWorktreePath,
+        selectedAgentId,
+        connectionId,
+        taskSnapshot,
+      )
+      creatingWorktree = false
+      if (sent) closeDialog()
       return
     }
 
@@ -206,82 +218,17 @@
       }
 
       if (selectedAgentId) {
-        const agentId = selectedAgentId
-        const connId = connectionId
         const taskSnapshot = $state.snapshot(fullTask) as typeof fullTask
-
-        try {
-          await selectWorktree(created.worktreePath)
-        } catch (error) {
-          handleTaskToAgentFailure(agentStartFailedOutcome(error), {
-            taskKey: taskSnapshot.key,
-            connectionId: connId,
-            selectedAgentId: agentId,
-          })
+        const sent = await sendTaskContextToSelectedAgent(
+          created.worktreePath,
+          selectedAgentId,
+          connectionId,
+          taskSnapshot,
+        )
+        if (!sent) {
           creatingWorktree = false
           return
         }
-
-        operationStatus = 'Starting agent...'
-        let tab: Awaited<ReturnType<typeof openTool>>
-        try {
-          tab = await openTool(agentId, created.worktreePath)
-        } catch (error) {
-          handleTaskToAgentFailure(agentStartFailedOutcome(error), {
-            taskKey: taskSnapshot.key,
-            connectionId: connId,
-            selectedAgentId: agentId,
-          })
-          creatingWorktree = false
-          return
-        }
-        const pane = tab.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
-        const sessionId = pane?.sessionId
-        if (!sessionId) {
-          handleTaskToAgentFailure(agentNotReadyOutcome(), {
-            taskKey: taskSnapshot.key,
-            connectionId: connId,
-            selectedAgentId: agentId,
-          })
-          creatingWorktree = false
-          return
-        }
-
-        operationStatus = 'Waiting for agent...'
-        const ready = await waitForAgentIdle(sessionId)
-        if (!ready) {
-          handleTaskToAgentFailure(agentNotReadyOutcome(sessionId), {
-            taskKey: taskSnapshot.key,
-            connectionId: connId,
-            selectedAgentId: agentId,
-            sessionId,
-          })
-          creatingWorktree = false
-          return
-        }
-
-        operationStatus = 'Sending task to agent...'
-        const outcome = await sendTaskToAgentContext({
-          connectionId: connId,
-          task: taskSnapshot,
-          repoRoot: workspaceState.repoRoot ?? undefined,
-          target: {
-            worktreePath: created.worktreePath,
-            sessionId,
-          },
-        })
-        if (outcome.status !== 'sent') {
-          handleTaskToAgentFailure(outcome, {
-            taskKey: taskSnapshot.key,
-            connectionId: connId,
-            selectedAgentId: agentId,
-            sessionId,
-          })
-          creatingWorktree = false
-          return
-        }
-        operationStatus = 'Task sent to agent'
-        addToast('Task sent to agent')
       } else {
         operationStatus = 'Opening worktree...'
         await selectWorktree(created.worktreePath)
@@ -300,6 +247,83 @@
         confirmLabel: 'OK',
       })
     }
+  }
+
+  async function sendTaskContextToSelectedAgent(
+    worktreePath: string,
+    agentId: string,
+    connId: string,
+    taskSnapshot: Task,
+  ): Promise<boolean> {
+    try {
+      await selectWorktree(worktreePath)
+    } catch (error) {
+      handleTaskToAgentFailure(agentStartFailedOutcome(error), {
+        taskKey: taskSnapshot.key,
+        connectionId: connId,
+        selectedAgentId: agentId,
+      })
+      return false
+    }
+
+    operationStatus = 'Starting agent...'
+    let tab: Awaited<ReturnType<typeof openTool>>
+    try {
+      tab = await openTool(agentId, worktreePath)
+    } catch (error) {
+      handleTaskToAgentFailure(agentStartFailedOutcome(error), {
+        taskKey: taskSnapshot.key,
+        connectionId: connId,
+        selectedAgentId: agentId,
+      })
+      return false
+    }
+    const pane = tab.rootSplit.type === 'leaf' ? tab.rootSplit.pane : null
+    const sessionId = pane?.sessionId
+    if (!sessionId) {
+      handleTaskToAgentFailure(agentNotReadyOutcome(), {
+        taskKey: taskSnapshot.key,
+        connectionId: connId,
+        selectedAgentId: agentId,
+      })
+      return false
+    }
+
+    operationStatus = 'Waiting for agent...'
+    const ready = await waitForAgentIdle(sessionId)
+    if (!ready) {
+      handleTaskToAgentFailure(agentNotReadyOutcome(sessionId), {
+        taskKey: taskSnapshot.key,
+        connectionId: connId,
+        selectedAgentId: agentId,
+        sessionId,
+      })
+      return false
+    }
+
+    operationStatus = 'Sending task to agent...'
+    const outcome = await sendTaskToAgentContext({
+      connectionId: connId,
+      task: taskSnapshot,
+      repoRoot: workspaceState.repoRoot ?? undefined,
+      target: {
+        worktreePath,
+        sessionId,
+      },
+    })
+    if (outcome.status !== 'sent') {
+      handleTaskToAgentFailure(outcome, {
+        taskKey: taskSnapshot.key,
+        connectionId: connId,
+        selectedAgentId: agentId,
+        sessionId,
+      })
+      return false
+    }
+
+    operationStatus = 'Task sent to agent'
+    addToast('Task sent to agent')
+    return true
   }
 
   function handleTaskToAgentFailure(
@@ -408,11 +432,11 @@
         >{resolvedBranchName}</code
       >
     </div>
+    <span class="sr-only" role="status" aria-live="polite">{operationError || operationStatus}</span
+    >
     {#if operationStatus || operationError}
       <div
         class="rounded-lg border px-3 py-2 text-xs leading-snug"
-        role={operationError ? 'alert' : 'status'}
-        aria-live={operationError ? 'assertive' : 'polite'}
         class:border-danger={operationError}
         class:border-border={!operationError}
         class:bg-danger-bg={operationError}
@@ -424,8 +448,7 @@
           <p class="m-0 font-medium">{operationError}</p>
           {#if createdWorktreePath}
             <p class="mt-1 mb-0">
-              The worktree was created. Open it from the worktree list if needed, start or focus an
-              agent there, then send the task again from the picker.
+              The worktree was created. Start or focus an agent there, then use Retry Send.
             </p>
           {/if}
         {:else}
@@ -462,7 +485,7 @@
         {#if creatingWorktree}
           Working...
         {:else if createdWorktreePath && contextSendFailed}
-          Close
+          Retry Send
         {:else if selectedAgentId}
           Create & Start Agent
         {:else}

--- a/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
@@ -11,6 +11,7 @@
     logTaskToAgentFailure,
     noActiveAgentOutcome,
     sendTaskToAgentContext,
+    tabFocusFailedOutcome,
   } from '../../lib/taskTracker/taskToAgent'
   import BranchCreateForm from './BranchCreateForm.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
@@ -168,6 +169,7 @@
   }
 
   async function onBoardChange(): Promise<void> {
+    clearTaskSendFeedback()
     setPref(`taskTracker.lastBoard.${connectionId}`, selectedBoardId)
     restoreSavedFilters()
     await fetchTasks()
@@ -244,6 +246,7 @@
 
   function selectTask(task: Task): void {
     if (!workspaceState.repoRoot || !workspaceState.branch) return
+    clearTaskSendFeedback()
     selectedTask = $state.snapshot(task) as Task
   }
 
@@ -266,6 +269,12 @@
 
   let hasActiveAgent = $derived(!!getActiveAgentPane())
 
+  function clearTaskSendFeedback(): void {
+    if (sendingTaskKey) return
+    sendStatus = ''
+    sendError = ''
+  }
+
   async function sendTaskToAgent(task: Task, e: MouseEvent): Promise<void> {
     e.stopPropagation()
     if (sendingTaskKey) return
@@ -287,16 +296,14 @@
     try {
       await switchTab(result.tabId)
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
+      const outcome = tabFocusFailedOutcome(error, result.pane.sessionId)
       sendStatus = ''
-      sendError = 'Could not focus the target agent tab. The task was not sent.'
+      sendError = outcome.message
       sendingTaskKey = ''
-      console.error('Task to agent failed', {
-        outcome: 'tab-focus-failed',
-        errorMessage,
+      logTaskToAgentFailure(outcome, {
         taskKey: task.key,
         connectionId,
-        hasSessionId: Boolean(result.pane.sessionId),
+        sessionId: result.pane.sessionId,
       })
       return
     }
@@ -432,21 +439,32 @@
           bind:this={searchInputEl}
           bind:value={searchQuery}
           placeholder="Search by key or title..."
-          oninput={() => (selectedIndex = 0)}
+          oninput={() => {
+            selectedIndex = 0
+            clearTaskSendFeedback()
+          }}
         />
       </div>
 
+      <span class="sr-only" role="status" aria-live="polite">{sendError || sendStatus}</span>
       {#if sendStatus || sendError}
         <div
-          class="px-4 py-2 border-b border-border-subtle text-xs leading-snug"
-          role={sendError ? 'alert' : 'status'}
-          aria-live={sendError ? 'assertive' : 'polite'}
+          class="flex items-start gap-2 px-4 py-2 border-b border-border-subtle text-xs leading-snug"
           class:bg-danger-bg={sendError}
           class:text-danger-text={sendError}
           class:bg-bg-input={!sendError}
           class:text-text-muted={!sendError}
         >
-          {sendError || sendStatus}
+          <span class="flex-1">{sendError || sendStatus}</span>
+          {#if sendError}
+            <button
+              class="flex items-center justify-center w-5 h-5 -mr-1 border-0 rounded bg-transparent text-current cursor-pointer opacity-70 hover:opacity-100 hover:bg-hover"
+              onclick={clearTaskSendFeedback}
+              aria-label="Dismiss task send error"
+            >
+              <X size={12} />
+            </button>
+          {/if}
         </div>
       {/if}
 

--- a/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
@@ -7,6 +7,11 @@
   import { addToast } from '../../lib/stores/toast.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import { getActiveAgentPane, switchTab } from '../../lib/stores/tabs.svelte'
+  import {
+    logTaskToAgentFailure,
+    noActiveAgentOutcome,
+    sendTaskToAgentContext,
+  } from '../../lib/taskTracker/taskToAgent'
   import BranchCreateForm from './BranchCreateForm.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
   import CustomCheckbox from '../shared/CustomCheckbox.svelte'
@@ -118,6 +123,9 @@
   let selectedTask: Task | null = $state(null)
 
   let searchInputEl: HTMLInputElement | null = $state(null)
+  let sendingTaskKey = $state('')
+  let sendStatus = $state('')
+  let sendError = $state('')
 
   onMount(async () => {
     searchInputEl?.focus()
@@ -260,19 +268,60 @@
 
   async function sendTaskToAgent(task: Task, e: MouseEvent): Promise<void> {
     e.stopPropagation()
+    if (sendingTaskKey) return
+
+    sendingTaskKey = task.key
+    sendStatus = `Sending ${task.key} to agent...`
+    sendError = ''
+
     const result = getActiveAgentPane()
-    if (!result) return
-    const context = await window.api.taskTrackerBuildTaskContext({
+    if (!result) {
+      const outcome = noActiveAgentOutcome()
+      sendStatus = ''
+      sendError = outcome.message
+      sendingTaskKey = ''
+      logTaskToAgentFailure(outcome, { taskKey: task.key, connectionId })
+      return
+    }
+
+    try {
+      await switchTab(result.tabId)
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      sendStatus = ''
+      sendError = 'Could not focus the target agent tab. The task was not sent.'
+      sendingTaskKey = ''
+      console.error('Task to agent failed', {
+        outcome: 'tab-focus-failed',
+        errorMessage,
+        taskKey: task.key,
+        connectionId,
+        hasSessionId: Boolean(result.pane.sessionId),
+      })
+      return
+    }
+
+    const outcome = await sendTaskToAgentContext({
       connectionId,
       task,
       repoRoot: workspaceState.repoRoot ?? undefined,
+      target: {
+        worktreePath: workspaceState.selectedWorktreePath ?? undefined,
+        sessionId: result.pane.sessionId,
+      },
     })
-    await switchTab(result.tabId)
-    await window.api.agentSendTaskContext({
-      text: context,
-      worktreePath: workspaceState.selectedWorktreePath ?? undefined,
-      sessionId: result.pane.sessionId,
-    })
+    sendingTaskKey = ''
+    sendStatus = ''
+    if (outcome.status !== 'sent') {
+      sendError = outcome.message
+      logTaskToAgentFailure(outcome, {
+        taskKey: task.key,
+        connectionId,
+        sessionId: result.pane.sessionId,
+      })
+      return
+    }
+
     addToast('Task sent to agent')
     closeDialog()
   }
@@ -387,6 +436,20 @@
         />
       </div>
 
+      {#if sendStatus || sendError}
+        <div
+          class="px-4 py-2 border-b border-border-subtle text-xs leading-snug"
+          role={sendError ? 'alert' : 'status'}
+          aria-live={sendError ? 'assertive' : 'polite'}
+          class:bg-danger-bg={sendError}
+          class:text-danger-text={sendError}
+          class:bg-bg-input={!sendError}
+          class:text-text-muted={!sendError}
+        >
+          {sendError || sendStatus}
+        </div>
+      {/if}
+
       <div class="flex-1 overflow-y-auto py-1">
         {#if loading}
           <div class="flex items-center justify-center gap-2 px-4 py-6 text-md text-text-muted">
@@ -441,10 +504,15 @@
                 <button
                   class="flex items-center justify-center w-6 h-6 border-0 rounded-md bg-transparent text-text-faint cursor-pointer flex-shrink-0 opacity-0 transition-opacity duration-fast group-hover/task:opacity-100 hover:bg-hover-strong hover:text-generate"
                   onclick={(e) => sendTaskToAgent(task, e)}
+                  disabled={Boolean(sendingTaskKey)}
                   title="Send to agent"
                   aria-label="Send to agent"
                 >
-                  <Send size={12} />
+                  {#if sendingTaskKey === task.key}
+                    <Loader2 size={12} class="animate-spin" />
+                  {:else}
+                    <Send size={12} />
+                  {/if}
                 </button>
               {/if}
               <button

--- a/src/renderer/src/lib/taskTracker/taskToAgent.ts
+++ b/src/renderer/src/lib/taskTracker/taskToAgent.ts
@@ -1,0 +1,122 @@
+export interface TaskToAgentTask {
+  key: string
+  summary: string
+  description?: string
+  status?: string
+  priority?: string
+  type?: string
+  parentKey?: string
+  sprintName?: string
+  sprintNumber?: number
+  assignee?: string
+  url?: string
+}
+
+export interface TaskToAgentTarget {
+  sessionId: string
+  worktreePath?: string
+}
+
+export type TaskToAgentOutcome =
+  | { status: 'sent'; sessionId: string }
+  | { status: 'no-active-agent'; message: string }
+  | { status: 'agent-not-ready'; message: string; sessionId?: string }
+  | { status: 'agent-start-failed'; message: string; errorMessage: string }
+  | { status: 'context-build-failed'; message: string; errorMessage: string }
+  | { status: 'paste-failed'; message: string; errorMessage: string; sessionId: string }
+
+export interface SendTaskToAgentInput {
+  connectionId: string
+  task: TaskToAgentTask
+  repoRoot?: string
+  target: TaskToAgentTarget | null
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function noActiveAgentOutcome(): TaskToAgentOutcome {
+  return {
+    status: 'no-active-agent',
+    message: 'No running agent is available. Start an agent and try again.',
+  }
+}
+
+export function agentNotReadyOutcome(sessionId?: string): TaskToAgentOutcome {
+  return {
+    status: 'agent-not-ready',
+    sessionId,
+    message: 'The agent did not become ready. The worktree was created, but the task was not sent.',
+  }
+}
+
+export function agentStartFailedOutcome(error: unknown): TaskToAgentOutcome {
+  return {
+    status: 'agent-start-failed',
+    errorMessage: errorMessage(error),
+    message: 'The worktree was created, but the selected agent could not be started.',
+  }
+}
+
+export async function sendTaskToAgentContext(
+  input: SendTaskToAgentInput,
+): Promise<TaskToAgentOutcome> {
+  if (!input.target) return noActiveAgentOutcome()
+
+  let context = ''
+  try {
+    context = await window.api.taskTrackerBuildTaskContext({
+      connectionId: input.connectionId,
+      task: input.task,
+      repoRoot: input.repoRoot,
+    })
+  } catch (error) {
+    return {
+      status: 'context-build-failed',
+      errorMessage: errorMessage(error),
+      message: 'Could not build the task context. The task was not sent to the agent.',
+    }
+  }
+
+  try {
+    const result = await window.api.agentSendTaskContext({
+      text: context,
+      worktreePath: input.target.worktreePath,
+      sessionId: input.target.sessionId,
+    })
+    return { status: 'sent', sessionId: result.sessionId }
+  } catch (error) {
+    return {
+      status: 'paste-failed',
+      sessionId: input.target.sessionId,
+      errorMessage: errorMessage(error),
+      message: 'Could not paste the task into the agent. The worktree is still available.',
+    }
+  }
+}
+
+export function logTaskToAgentFailure(
+  outcome: Exclude<TaskToAgentOutcome, { status: 'sent' }>,
+  metadata: {
+    taskKey: string
+    connectionId: string
+    selectedAgentId?: string
+    sessionId?: string
+  },
+): void {
+  console.error('Task to agent failed', {
+    outcome: outcome.status,
+    message: outcome.message,
+    errorMessage:
+      outcome.status === 'agent-start-failed' ||
+      outcome.status === 'context-build-failed' ||
+      outcome.status === 'paste-failed'
+        ? outcome.errorMessage
+        : undefined,
+    taskKey: metadata.taskKey,
+    connectionId: metadata.connectionId,
+    selectedAgentId: metadata.selectedAgentId,
+    hasSessionId: Boolean(metadata.sessionId),
+  })
+}

--- a/src/renderer/src/lib/taskTracker/taskToAgent.ts
+++ b/src/renderer/src/lib/taskTracker/taskToAgent.ts
@@ -22,6 +22,7 @@ export type TaskToAgentOutcome =
   | { status: 'no-active-agent'; message: string }
   | { status: 'agent-not-ready'; message: string; sessionId?: string }
   | { status: 'agent-start-failed'; message: string; errorMessage: string }
+  | { status: 'tab-focus-failed'; message: string; errorMessage: string; sessionId?: string }
   | { status: 'context-build-failed'; message: string; errorMessage: string }
   | { status: 'paste-failed'; message: string; errorMessage: string; sessionId: string }
 
@@ -56,6 +57,15 @@ export function agentStartFailedOutcome(error: unknown): TaskToAgentOutcome {
     status: 'agent-start-failed',
     errorMessage: errorMessage(error),
     message: 'The worktree was created, but the selected agent could not be started.',
+  }
+}
+
+export function tabFocusFailedOutcome(error: unknown, sessionId?: string): TaskToAgentOutcome {
+  return {
+    status: 'tab-focus-failed',
+    sessionId,
+    errorMessage: errorMessage(error),
+    message: 'Could not focus the target agent tab. The task was not sent.',
   }
 }
 
@@ -110,6 +120,7 @@ export function logTaskToAgentFailure(
     message: outcome.message,
     errorMessage:
       outcome.status === 'agent-start-failed' ||
+      outcome.status === 'tab-focus-failed' ||
       outcome.status === 'context-build-failed' ||
       outcome.status === 'paste-failed'
         ? outcome.errorMessage


### PR DESCRIPTION
## What

Adds a shared renderer-side task-to-agent helper and wires it into both task tracker entry points: `Create & Start Agent` and the quick send action.

The task flow now shows persistent inline status/error feedback for agent startup, readiness, context build, and paste failures instead of silently doing nothing.

## Why

Users selecting tasks from Jira could click the run/paste/send-to-agent flow and see no visible result when the target agent was missing, not ready, or when context build/paste failed.

This makes partial success explicit: if a worktree is created but the task cannot be sent to the agent, the UI tells the user what happened and how to recover.

## How to test

- Run `npm run svelte-check`
- Run `npm run typecheck:node`
- Run `npm run lint`
  - Note: lint exits successfully, with existing Prettier warnings in unrelated files.
- With a configured tracker, select a task and use `Create & Start Agent`.
- Confirm the modal shows progress through worktree creation, agent startup, waiting, and sending.
- Force or observe an agent startup/readiness/send failure and confirm a persistent inline error appears.
- With an active running agent, use the quick send icon and confirm the task context is pasted into the intended agent.
- Double-click a send action and confirm only one send is attempted.

## Screenshots / recordings

Not included. This is a state/feedback change in an existing modal flow.

## Checklist

- [x] Conventional commit title
- [x] Rebased on `next`
- [x] Relevant repo policy checked in `.itsol.md`
- [x] No task plans committed; `.itsol/plans/` remains ignored
- [x] Renderer code uses `window.api` and does not import Node modules directly
- [x] Manual QA steps documented
- [x] Automated checks documented
- [ ] Screenshots/recordings included