### PR TITLE
fix(renderer): preserve agent status across snapshots

### DIFF
--- a/docs/integrations/agents.md
+++ b/docs/integrations/agents.md
@@ -75,6 +75,11 @@ The renderer maintains per-session state in `agentSessions[ptySessionId]`:
 - `compactCount` / `toolCallCount`: Counters incremented on relevant events.
 - `extra`: Agent-specific data (Claude rate limits, Codex `cwd`/`transcriptPath`/`turnId`, OpenCode pending questions).
 
+Runtime session state is not reset when tab snapshots are reapplied. `initAgentSession()` is
+idempotent for an existing PTY session and `paneFromSnapshot()` rekeys the renderer state when a
+running agent pane receives a new `sessionId`, preserving status, badges, model/context data, tasks,
+notifications, and counters across tab/layout updates.
+
 ### Busy/idle tracking
 
 Each adapter declares `busyEvents` and `idleEvents` sets. The `AgentSessionManager` tracks busy state per session so the notch overlay and other UI elements can reflect whether the agent is actively working.

--- a/src/renderer/src/lib/agents/agentState.svelte.ts
+++ b/src/renderer/src/lib/agents/agentState.svelte.ts
@@ -69,7 +69,11 @@ export const agentBadges: Record<string, BadgeType> = $state({})
 export const worktreeBadges: Record<string, BadgeType> = $state({})
 
 export function initAgentSession(ptySessionId: string, agentType: AgentType): void {
-  if (agentSessions[ptySessionId]) return
+  const existing = agentSessions[ptySessionId]
+  if (existing) {
+    if (existing.agentType === agentType) return
+    removeAgentSession(ptySessionId)
+  }
 
   agentSessions[ptySessionId] = {
     agentType,
@@ -105,8 +109,11 @@ export function rekeyAgentSession(
   if (previousPtySessionId === nextPtySessionId) return
 
   const session = agentSessions[previousPtySessionId]
-  if (!session || agentSessions[nextPtySessionId]) return
-  if (session.agentType !== agentType) return
+  if (!session) return
+  if (agentSessions[nextPtySessionId] || session.agentType !== agentType) {
+    removeAgentSession(previousPtySessionId)
+    return
+  }
 
   agentSessions[nextPtySessionId] = session
   delete agentSessions[previousPtySessionId]

--- a/src/renderer/src/lib/agents/agentState.svelte.ts
+++ b/src/renderer/src/lib/agents/agentState.svelte.ts
@@ -69,6 +69,8 @@ export const agentBadges: Record<string, BadgeType> = $state({})
 export const worktreeBadges: Record<string, BadgeType> = $state({})
 
 export function initAgentSession(ptySessionId: string, agentType: AgentType): void {
+  if (agentSessions[ptySessionId]) return
+
   agentSessions[ptySessionId] = {
     agentType,
     status: { type: 'inactive' },
@@ -92,6 +94,28 @@ export function initAgentSession(ptySessionId: string, agentType: AgentType): vo
     extra: {},
   }
   agentBadges[ptySessionId] = 'none'
+}
+
+export function rekeyAgentSession(
+  previousPtySessionId: string,
+  nextPtySessionId: string,
+  agentType: AgentType,
+): void {
+  if (!previousPtySessionId || !nextPtySessionId) return
+  if (previousPtySessionId === nextPtySessionId) return
+
+  const session = agentSessions[previousPtySessionId]
+  if (!session || agentSessions[nextPtySessionId]) return
+  if (session.agentType !== agentType) return
+
+  agentSessions[nextPtySessionId] = session
+  delete agentSessions[previousPtySessionId]
+
+  const badge = agentBadges[previousPtySessionId]
+  if (badge) {
+    agentBadges[nextPtySessionId] = badge
+    delete agentBadges[previousPtySessionId]
+  }
 }
 
 export function removeAgentSession(ptySessionId: string): void {

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -12,6 +12,7 @@ import { recordFileOpen } from './quickOpenMru.svelte'
 import { workspaceState, getProjectForWorktree, selectWorktree } from './workspace.svelte'
 import {
   initAgentSession,
+  rekeyAgentSession,
   removeAgentSession,
   agentSessions,
   type AgentType,
@@ -106,6 +107,15 @@ function editorFilesFromSnapshot(
 }
 
 function paneFromSnapshot(snapshot: PaneSnapshot, previous?: PaneSession): PaneSession {
+  if (
+    previous &&
+    previous.sessionId !== snapshot.sessionId &&
+    isAiToolId(snapshot.toolId) &&
+    snapshot.isRunning
+  ) {
+    rekeyAgentSession(previous.sessionId, snapshot.sessionId, snapshot.toolId as AgentType)
+  }
+
   return {
     ...previous,
     id: snapshot.id,


### PR DESCRIPTION
## What

Preserve renderer agent session state when tab snapshots are reapplied or when an agent pane's session ID changes during runtime.

The change makes agent session initialization idempotent and rekeys existing renderer state and badges instead of creating a fresh inactive session.

## Why

Users reported that the agent status in the bottom status bar and right-side Agent Inspector could become stale or reset after recent updates, while the notch still showed the correct status.

The renderer state was being recreated from tab snapshots, which could reset active agent status data to \`inactive\`.

## How to test

1. Start an agent session and wait until it reports an active status such as thinking, tool calling, or idle.
2. Switch to another tab in the same worktree and back to the agent tab.
3. Confirm the bottom status bar and Agent Inspector keep the current agent status instead of resetting to inactive.
4. Confirm the notch status remains consistent.
5. Run \`npm run svelte-check\`.

Diagnostic checks used during implementation:

- repeated init with the same session ID preserved \`thinking\`
- changed session ID rekey preserved \`thinking:unread\` and removed the old key
- \`npm run svelte-check\` passed with 0 errors and 0 warnings

## Screenshots / recordings

Not included. This is a renderer state preservation fix with no visual UI changes.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [ ] Keyboard accessible (all interactive elements reachable via keyboard)
- [ ] IPC follows \`feature:action\` naming and uses \`invoke\`/\`handle\`
- [x] Renderer code does not import Node.js modules directly
- [ ] Feature docs in \`docs/\` updated (behavior, config, errors, security — if any changed)