### PR TITLE
fix(crash): improve crash report diagnostics

### DIFF
--- a/docs/diagnostics/crash-reporting.md
+++ b/docs/diagnostics/crash-reporting.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Canopy records crash information to a local JSON file when the app exits abnormally. On the next launch, if a crash report exists, a dialog appears showing the crash details and offering to open a pre-filled GitHub issue. No crash data is sent to any server automatically.
+Canopy records crash information to a local JSON file when the app exits abnormally. On the next launch, if a crash report exists, a dialog appears showing the crash details and offering to copy a report and open a GitHub issue page. No crash data is sent to any server automatically.
 
 The crash reporter is active only in packaged (production) builds. In development mode, stack traces appear in the terminal and DevTools as usual.
 
@@ -18,7 +18,7 @@ The crash reporter is active only in packaged (production) builds. In developmen
 
 1. On startup, `CrashReporter.init()` checks for a sentinel file `.canopy-running` in the user data directory (`app.getPath('userData')`).
 2. If the sentinel exists but no `crash-report.json` is present, the previous session exited without cleaning up. The reporter writes an `ungracefulShutdown` crash report.
-3. On macOS only, before writing the report the reporter also scans `~/Library/Logs/DiagnosticReports/` (and `…/Retired/`) for a recent `Canopy-*.ips` dump whose mtime is at or after the previous sentinel mtime. If one is found, the reporter parses the header and body JSON, extracts the triggered thread's symbolicated frames from the `.ips`, and attaches them to the report as `stack`, along with structured fields in `nativeCrash` (exception type, codes, termination reason, triggered thread name, incident id, source path). The `errorMessage` becomes e.g. `Native crash: EXC_BREAKPOINT (SIGTRAP) in CrBrowserMain` instead of the generic "did not shut down cleanly" string. If no matching `.ips` is found, the report falls back to the generic message with no stack. Windows and Linux native-dump recovery are not implemented — the same generic fallback applies there.
+3. On macOS only, before writing the report the reporter also scans `~/Library/Logs/DiagnosticReports/` (and `…/Retired/`) for a recent `Canopy-*.ips` dump whose mtime is at or after the previous sentinel mtime. If one is found, the reporter parses the header and body JSON, extracts the triggered thread's symbolicated frames from the `.ips`, and attaches them to the report as `stack`, along with structured fields in `nativeCrash` (exception type, codes, termination reason, triggered thread name, incident id, and native stack). The `.ips` file path is not exposed in the report. The `errorMessage` becomes e.g. `Native crash: EXC_BREAKPOINT (SIGTRAP) in CrBrowserMain` instead of the generic "did not shut down cleanly" string. If no matching `.ips` is found, the report falls back to the generic message with no stack. Windows and Linux native-dump recovery are not implemented — the same generic fallback applies there.
 4. The sentinel file is then (re)written with the current process PID.
 5. On graceful shutdown, `clearSentinel()` removes the sentinel file. It is called from three places, in order of preference:
    - The main `before-quit` handler (synchronous path, line ~1027 in `index.ts`).
@@ -38,6 +38,8 @@ The following process-level events write a crash report immediately:
 
 Each report overwrites any previous `crash-report.json`. Only the most recent crash is preserved.
 
+For renderer crashes on macOS, the reporter also looks for a matching recent `Canopy Helper (Renderer)-*.ips` dump. If the native dump is not yet available when the renderer process exits, `getCrashReport()` attempts the lookup again before sending the report to the renderer.
+
 ### Crash report dialog
 
 1. After the first window finishes loading (the `app:firstWindowReady` post-launch event), the main process reads `crash-report.json` via `getCrashReport()`.
@@ -47,18 +49,20 @@ Each report overwrites any previous `crash-report.json`. Only the most recent cr
 
 ### Dialog actions
 
-The dialog shows: timestamp, crash type, app version, Electron version, OS, error message, and stack trace (if available). The user has two options:
+The dialog shows: timestamp, crash type, app version, Electron version, OS, error message, stack trace (if available), renderer reason/exit code (for renderer crashes), native exception summary (if available), and the exact Markdown report that will be copied. The user has two options:
 
 1. **Dismiss** (Escape or click "Dismiss"): closes the dialog, no further action.
-2. **Create issue** (Enter or click "Create issue"): opens the default browser with a pre-filled GitHub issue URL at `github.com/itsoltech/canopy-desktop/issues/new`. The issue includes labels `bug` and `crash`. Home directory paths in the stack trace are sanitized to `~/` before inclusion in the URL.
+2. **Copy report and open issue** (Enter or click the button): copies the Markdown report to the clipboard, then opens the default browser at `github.com/itsoltech/canopy-desktop/issues/new` with a neutral title, labels `bug` and `crash`, and a placeholder body asking the user to paste the copied report. Diagnostic fields are not placed in the issue URL.
 
-### Stack trace sanitization
+### Diagnostic sanitization
 
-Before the stack trace is included in the GitHub issue URL:
+Before crash data is written to `crash-report.json`, shown in the dialog, copied to the clipboard, or sent over IPC:
 
 - macOS/Linux paths matching `/Users/<username>/` or `/home/<username>/` are replaced with `~/`
 - Windows paths matching `<drive>:\Users\<username>\` (any drive letter A-Z) are replaced with `~/`
-- The stack trace is truncated to 3,000 characters
+- HTTP(S) URLs are replaced with `[redacted]`
+- common secret forms are replaced with `[redacted]`, including bearer tokens, `Authorization: Bearer ...`, `password: ...`, `api_key = ...`, and uppercase environment-style values
+- stack fields are truncated to 4,000 characters
 
 ## Crash report format
 
@@ -72,11 +76,25 @@ The `crash-report.json` file stored in `app.getPath('userData')` contains:
   "stack": "TypeError: Cannot read properties of undefined\n    at ...",
   "appVersion": "0.11.0",
   "electronVersion": "33.2.1",
-  "os": "darwin 24.1.0 arm64"
+  "os": "darwin 24.1.0 arm64",
+  "process": "main"
 }
 ```
 
-The `stack` field is optional. For `ungracefulShutdown` reports it is absent unless a matching macOS `.ips` native dump was recovered, in which case the reporter also populates an optional `nativeCrash` object:
+The `stack` field is optional. Renderer crash reports may include renderer process details:
+
+```json
+{
+  "type": "rendererCrash",
+  "process": "renderer",
+  "renderer": {
+    "reason": "crashed",
+    "exitCode": 5
+  }
+}
+```
+
+For `ungracefulShutdown` and renderer crash reports, native crash details are absent unless a matching macOS `.ips` native dump was recovered, in which case the reporter also populates an optional `nativeCrash` object:
 
 ```json
 {
@@ -86,7 +104,7 @@ The `stack` field is optional. For `ungracefulShutdown` reports it is absent unl
     "terminationReason": "Trace/BPT trap: 5 (by exc handler)",
     "triggeredThread": "CrBrowserMain",
     "incidentId": "A1CE2AD8-CF3F-4E78-A2F1-7AA8328E8857",
-    "sourceFile": "/Users/you/Library/Logs/DiagnosticReports/Canopy-...-ips"
+    "stack": "  0  Canopy                            main + 0"
   }
 }
 ```
@@ -97,20 +115,22 @@ No user-facing configuration. The crash reporter has no preference keys or toggl
 
 ## Error states
 
-| Error                    | User sees                                                                               | Cause                                                                                                                                                                     |
-| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Filesystem write failure | Nothing (silently swallowed)                                                            | `crash-report.json` or sentinel could not be written. Every method in `CrashReporter` wraps its body in `try/catch` to prevent the reporter itself from crashing the app. |
-| Browser open failure     | Toast: "Failed to open browser. Copy the URL from your address bar to report manually." | `window.api.openExternal()` rejected when the user clicked "Create issue".                                                                                                |
+| Error                    | User sees                                                             | Cause                                                                                                                                                                     |
+| ------------------------ | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Filesystem write failure | Nothing (silently swallowed)                                          | `crash-report.json` or sentinel could not be written. Every method in `CrashReporter` wraps its body in `try/catch` to prevent the reporter itself from crashing the app. |
+| Clipboard write failure  | Toast: "Failed to copy crash report to clipboard"                     | `navigator.clipboard.writeText()` rejected when the user clicked "Copy report and open issue"; the browser is not opened.                                                 |
+| Browser open failure     | Toast: "Failed to open browser. Crash report is copied to clipboard." | `window.api.openExternal()` rejected after the report was copied.                                                                                                         |
 
 ## Security and privacy
 
-Crash data never leaves the machine unless the user explicitly clicks "Create issue". The GitHub issue URL is constructed client-side and opened in the user's browser, where they can review and edit it before submitting.
+Crash data never leaves the machine automatically. The user must explicitly click "Copy report and open issue" to place the report on the clipboard. The GitHub issue URL is constructed client-side with only neutral query params: title, placeholder body, and labels. The user decides whether to paste the copied report and submit the issue in the browser.
 
-Home directory paths are stripped from stack traces before they are placed in the URL. The crash report file is stored in the OS-standard user data directory and is readable only by the current user (default OS permissions).
+Home directory paths, URLs, and common secret formats are stripped from diagnostics before they are persisted or displayed. Native `.ips` source paths are not included in the public report. The crash report file is stored in the OS-standard user data directory and is readable only by the current user (default OS permissions).
 
 ## Source files
 
 - Main: `src/main/crash/CrashReporter.ts`
+- Crash diagnostic sanitizer: `src/main/crash/sanitizeCrashDiagnostic.ts`
 - Native dump reader (macOS `.ips`): `src/main/crash/NativeCrashReader.ts`
 - IPC wiring: `src/main/index.ts` (crash handler registration near line 381, push to renderer near line 810)
 - Preload: `src/preload/index.ts` (`onCrashReport` listener)

--- a/e2e/crash-diagnostics.spec.ts
+++ b/e2e/crash-diagnostics.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+import { matchesNativeCrashProcessName } from '../src/main/crash/NativeCrashReader'
+import { sanitizeDiagnosticText } from '../src/main/crash/sanitizeCrashDiagnostic'
+import { formatCrashReportMarkdown } from '../src/renderer/src/lib/crashReportMarkdown'
+
+test('crash diagnostics keep useful stack symbols while redacting common secret formats', () => {
+  const sanitized = sanitizeDiagnosticText(`
+    at tokenize (/Users/alice/project/tokenize.ts:12:3)
+    at secretStore (/Users/alice/project/secretStore.ts:5:7)
+    Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
+    eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.sflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+    AKIAIOSFODNN7EXAMPLE
+    ghp_abcdefghijklmnopqrstuvwxyz123456
+    -----BEGIN PRIVATE KEY-----
+    secret-key-material
+    -----END PRIVATE KEY-----
+    session=abc123secret
+  `)
+
+  expect(sanitized).toContain('tokenize')
+  expect(sanitized).toContain('secretStore')
+  expect(sanitized).not.toContain('QWxhZGRpbjpvcGVuIHNlc2FtZQ==')
+  expect(sanitized).not.toContain('eyJhbGciOiJIUzI1NiJ9')
+  expect(sanitized).not.toContain('AKIAIOSFODNN7EXAMPLE')
+  expect(sanitized).not.toContain('ghp_abcdefghijklmnopqrstuvwxyz123456')
+  expect(sanitized).not.toContain('secret-key-material')
+  expect(sanitized).not.toContain('abc123secret')
+})
+
+test('renderer native crash matching accepts Electron helper process variants', () => {
+  expect(matchesNativeCrashProcessName('Canopy Helper (Renderer)', 'Canopy Helper')).toBe(true)
+  expect(
+    matchesNativeCrashProcessName('Canopy Helper (Renderer)', 'Canopy Helper (Renderer)'),
+  ).toBe(true)
+  expect(matchesNativeCrashProcessName('Canopy', 'Canopy Helper (Renderer)')).toBe(false)
+})
+
+test('crash report markdown renders renderer and native crash details with safe fences', () => {
+  const markdown = formatCrashReportMarkdown({
+    timestamp: '2026-06-18T06:00:00.000Z',
+    type: 'rendererCrash',
+    process: 'renderer',
+    errorMessage: 'Renderer crashed with ``` in message',
+    appVersion: '0.13.0',
+    electronVersion: '41.0.0',
+    os: 'darwin 25 arm64',
+    renderer: {
+      reason: 'crashed',
+      exitCode: 139,
+    },
+    nativeCrash: {
+      exceptionType: 'EXC_BAD_ACCESS',
+      triggeredThread: 'CrRendererMain',
+      stack: '0 Canopy Helper tokenize + 4',
+    },
+  })
+
+  expect(markdown).toContain('- **Process:** renderer')
+  expect(markdown).toContain('- **Renderer reason:** crashed')
+  expect(markdown).toContain('- **Renderer exit code:** 139')
+  expect(markdown).toContain('### Native crash')
+  expect(markdown).toContain('#### Native stack')
+  expect(markdown).toContain('````\nRenderer crashed with ``` in message\n````')
+})

--- a/src/main/crash/CrashReporter.ts
+++ b/src/main/crash/CrashReporter.ts
@@ -3,36 +3,9 @@ import os from 'os'
 import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { match, P } from 'ts-pattern'
+import type { CrashReport } from '../../renderer-shared/crashReport'
 import { findRecentNativeCrash, type NativeCrashInfo } from './NativeCrashReader'
 import { sanitizeDiagnosticText, sanitizeStack } from './sanitizeCrashDiagnostic'
-
-export interface CrashReport {
-  timestamp: string
-  type:
-    | 'uncaughtException'
-    | 'unhandledRejection'
-    | 'rendererCrash'
-    | 'childProcessGone'
-    | 'ungracefulShutdown'
-  errorMessage: string
-  stack?: string
-  appVersion: string
-  electronVersion: string
-  os: string
-  process?: 'main' | 'renderer' | 'child' | 'unknown'
-  renderer?: {
-    reason?: string
-    exitCode?: number
-  }
-  nativeCrash?: {
-    exceptionType?: string
-    exceptionCodes?: string
-    terminationReason?: string
-    triggeredThread?: string
-    incidentId?: string
-    stack?: string
-  }
-}
 
 const NATIVE_CRASH_PROCESS_NAME = 'Canopy'
 const RENDERER_CRASH_PROCESS_NAME = 'Canopy Helper (Renderer)'

--- a/src/main/crash/CrashReporter.ts
+++ b/src/main/crash/CrashReporter.ts
@@ -2,7 +2,9 @@ import { app, type RenderProcessGoneDetails } from 'electron'
 import os from 'os'
 import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs'
 import { join } from 'path'
+import { match, P } from 'ts-pattern'
 import { findRecentNativeCrash, type NativeCrashInfo } from './NativeCrashReader'
+import { sanitizeDiagnosticText, sanitizeStack } from './sanitizeCrashDiagnostic'
 
 export interface CrashReport {
   timestamp: string
@@ -34,13 +36,6 @@ export interface CrashReport {
 
 const NATIVE_CRASH_PROCESS_NAME = 'Canopy'
 const RENDERER_CRASH_PROCESS_NAME = 'Canopy Helper (Renderer)'
-const REDACTED = '[redacted]'
-const MAX_STACK_CHARS = 4000
-const USER_PATH_PATTERN = /(?:[A-Z]:\\Users\\[^\\\s]+\\|\/(?:Users|home)\/[^/\s]+\/)/gi
-const URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi
-const TOKEN_LIKE_PATTERN =
-  /\b(?:token|secret|password|passwd|apikey|api_key|authorization|bearer)[A-Za-z0-9_\-:=./+]{3,}/gi
-const ENV_VALUE_PATTERN = /\b[A-Z][A-Z0-9_]{2,}=([^\s]+)/g
 
 export class CrashReporter {
   private readonly sentinelPath: string
@@ -229,18 +224,14 @@ export class CrashReporter {
   }
 
   private processForType(type: CrashReport['type']): NonNullable<CrashReport['process']> {
-    switch (type) {
-      case 'rendererCrash':
-        return 'renderer'
-      case 'childProcessGone':
-        return 'child'
-      case 'uncaughtException':
-      case 'unhandledRejection':
-      case 'ungracefulShutdown':
-        return 'main'
-      default:
-        return 'unknown'
-    }
+    return match(type)
+      .with('rendererCrash', () => 'renderer' as const)
+      .with('childProcessGone', () => 'child' as const)
+      .with(
+        P.union('uncaughtException', 'unhandledRejection', 'ungracefulShutdown'),
+        () => 'main' as const,
+      )
+      .exhaustive()
   }
 
   private writeCrashReport(report: CrashReport): void {
@@ -248,25 +239,6 @@ export class CrashReporter {
   }
 }
 
-function sanitizeStack(value: string | undefined): string | undefined {
-  const sanitized = sanitizeDiagnosticText(value)
-  if (!sanitized) return sanitized
-  if (sanitized.length <= MAX_STACK_CHARS) return sanitized
-  return `${sanitized.slice(0, MAX_STACK_CHARS - 20)}\n... (truncated)`
-}
-
 function sanitizeRequired(value: string): string {
   return sanitizeDiagnosticText(value) ?? ''
-}
-
-function sanitizeDiagnosticText(value: string | undefined): string | undefined {
-  if (!value) return value
-  return value
-    .replace(USER_PATH_PATTERN, '~/')
-    .replace(URL_PATTERN, REDACTED)
-    .replace(TOKEN_LIKE_PATTERN, REDACTED)
-    .replace(ENV_VALUE_PATTERN, (match) => {
-      const idx = match.indexOf('=')
-      return idx >= 0 ? `${match.slice(0, idx + 1)}${REDACTED}` : REDACTED
-    })
 }

--- a/src/main/crash/CrashReporter.ts
+++ b/src/main/crash/CrashReporter.ts
@@ -1,4 +1,4 @@
-import { app } from 'electron'
+import { app, type RenderProcessGoneDetails } from 'electron'
 import os from 'os'
 import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs'
 import { join } from 'path'
@@ -17,17 +17,30 @@ export interface CrashReport {
   appVersion: string
   electronVersion: string
   os: string
+  process?: 'main' | 'renderer' | 'child' | 'unknown'
+  renderer?: {
+    reason?: string
+    exitCode?: number
+  }
   nativeCrash?: {
     exceptionType?: string
     exceptionCodes?: string
     terminationReason?: string
     triggeredThread?: string
     incidentId?: string
-    sourceFile?: string
+    stack?: string
   }
 }
 
 const NATIVE_CRASH_PROCESS_NAME = 'Canopy'
+const RENDERER_CRASH_PROCESS_NAME = 'Canopy Helper (Renderer)'
+const REDACTED = '[redacted]'
+const MAX_STACK_CHARS = 4000
+const USER_PATH_PATTERN = /(?:[A-Z]:\\Users\\[^\\\s]+\\|\/(?:Users|home)\/[^/\s]+\/)/gi
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi
+const TOKEN_LIKE_PATTERN =
+  /\b(?:token|secret|password|passwd|apikey|api_key|authorization|bearer)[A-Za-z0-9_\-:=./+]{3,}/gi
+const ENV_VALUE_PATTERN = /\b[A-Z][A-Z0-9_]{2,}=([^\s]+)/g
 
 export class CrashReporter {
   private readonly sentinelPath: string
@@ -57,11 +70,37 @@ export class CrashReporter {
       this.writeCrashReport({
         timestamp: new Date().toISOString(),
         type,
-        errorMessage: error.message,
-        stack: error.stack,
+        errorMessage: sanitizeRequired(error.message),
+        stack: sanitizeStack(error.stack),
         appVersion: app.getVersion(),
         electronVersion: process.versions.electron,
         os: `${os.platform()} ${os.release()} ${os.arch()}`,
+        process: this.processForType(type),
+      })
+    } catch {
+      // Crash reporter must never throw
+    }
+  }
+
+  recordRendererCrash(details: RenderProcessGoneDetails): void {
+    try {
+      const timestamp = new Date().toISOString()
+      const crashMs = Date.parse(timestamp)
+      const native = findRecentNativeCrash(RENDERER_CRASH_PROCESS_NAME, crashMs)
+      this.writeCrashReport({
+        timestamp,
+        type: 'rendererCrash',
+        errorMessage: sanitizeRequired(`Renderer crashed: ${details.reason}`),
+        stack: sanitizeStack(new Error(`Renderer crashed: ${details.reason}`).stack),
+        appVersion: app.getVersion(),
+        electronVersion: process.versions.electron,
+        os: `${os.platform()} ${os.release()} ${os.arch()}`,
+        process: 'renderer',
+        renderer: {
+          reason: sanitizeDiagnosticText(details.reason),
+          exitCode: details.exitCode,
+        },
+        nativeCrash: this.toPublicNativeCrash(native),
       })
     } catch {
       // Crash reporter must never throw
@@ -72,7 +111,8 @@ export class CrashReporter {
     try {
       if (!existsSync(this.reportPath)) return null
       const raw = readFileSync(this.reportPath, 'utf-8')
-      return JSON.parse(raw) as CrashReport
+      const report = JSON.parse(raw) as CrashReport
+      return this.toPublicCrashReport(this.enrichRendererCrashReport(report))
     } catch {
       return null
     }
@@ -108,13 +148,14 @@ export class CrashReporter {
       appVersion: app.getVersion(),
       electronVersion: process.versions.electron,
       os: `${os.platform()} ${os.release()} ${os.arch()}`,
+      process: 'main' as const,
     }
 
     if (!native) {
       return {
         ...base,
         timestamp: new Date().toISOString(),
-        errorMessage: 'The app did not shut down cleanly',
+        errorMessage: sanitizeRequired('The app did not shut down cleanly'),
       }
     }
 
@@ -123,20 +164,109 @@ export class CrashReporter {
     return {
       ...base,
       timestamp: native.timestamp || new Date().toISOString(),
-      errorMessage: `Native crash: ${what}${where}`,
-      stack: native.stack,
-      nativeCrash: {
-        exceptionType: native.exceptionType,
-        exceptionCodes: native.exceptionCodes,
-        terminationReason: native.terminationReason,
-        triggeredThread: native.triggeredThread,
-        incidentId: native.incidentId,
-        sourceFile: native.sourceFile,
-      },
+      errorMessage: sanitizeRequired(`Native crash: ${what}${where}`),
+      stack: sanitizeStack(native.stack),
+      nativeCrash: this.toPublicNativeCrash(native),
+    }
+  }
+
+  private enrichRendererCrashReport(report: CrashReport): CrashReport {
+    if (report.type !== 'rendererCrash' || report.nativeCrash?.stack) return report
+
+    const crashMs = Date.parse(report.timestamp)
+    if (Number.isNaN(crashMs)) return report
+
+    const native = findRecentNativeCrash(RENDERER_CRASH_PROCESS_NAME, crashMs)
+    const nativeCrash = this.toPublicNativeCrash(native)
+    if (!nativeCrash) return report
+
+    return {
+      ...report,
+      process: 'renderer',
+      nativeCrash,
+    }
+  }
+
+  private toPublicCrashReport(report: CrashReport): CrashReport {
+    return {
+      timestamp: sanitizeRequired(report.timestamp),
+      type: report.type,
+      errorMessage: sanitizeRequired(report.errorMessage),
+      stack: sanitizeStack(report.stack),
+      appVersion: sanitizeRequired(report.appVersion),
+      electronVersion: sanitizeRequired(report.electronVersion),
+      os: sanitizeRequired(report.os),
+      process: report.process ?? this.processForType(report.type),
+      renderer: report.renderer
+        ? {
+            reason: sanitizeDiagnosticText(report.renderer.reason),
+            exitCode: report.renderer.exitCode,
+          }
+        : undefined,
+      nativeCrash: report.nativeCrash
+        ? {
+            exceptionType: sanitizeDiagnosticText(report.nativeCrash.exceptionType),
+            exceptionCodes: sanitizeDiagnosticText(report.nativeCrash.exceptionCodes),
+            terminationReason: sanitizeDiagnosticText(report.nativeCrash.terminationReason),
+            triggeredThread: sanitizeDiagnosticText(report.nativeCrash.triggeredThread),
+            incidentId: sanitizeDiagnosticText(report.nativeCrash.incidentId),
+            stack: sanitizeStack(report.nativeCrash.stack),
+          }
+        : undefined,
+    }
+  }
+
+  private toPublicNativeCrash(native: NativeCrashInfo | null): CrashReport['nativeCrash'] {
+    if (!native) return undefined
+    return {
+      exceptionType: sanitizeDiagnosticText(native.exceptionType),
+      exceptionCodes: sanitizeDiagnosticText(native.exceptionCodes),
+      terminationReason: sanitizeDiagnosticText(native.terminationReason),
+      triggeredThread: sanitizeDiagnosticText(native.triggeredThread),
+      incidentId: sanitizeDiagnosticText(native.incidentId),
+      stack: sanitizeStack(native.stack),
+    }
+  }
+
+  private processForType(type: CrashReport['type']): NonNullable<CrashReport['process']> {
+    switch (type) {
+      case 'rendererCrash':
+        return 'renderer'
+      case 'childProcessGone':
+        return 'child'
+      case 'uncaughtException':
+      case 'unhandledRejection':
+      case 'ungracefulShutdown':
+        return 'main'
+      default:
+        return 'unknown'
     }
   }
 
   private writeCrashReport(report: CrashReport): void {
-    writeFileSync(this.reportPath, JSON.stringify(report, null, 2))
+    writeFileSync(this.reportPath, JSON.stringify(this.toPublicCrashReport(report), null, 2))
   }
+}
+
+function sanitizeStack(value: string | undefined): string | undefined {
+  const sanitized = sanitizeDiagnosticText(value)
+  if (!sanitized) return sanitized
+  if (sanitized.length <= MAX_STACK_CHARS) return sanitized
+  return `${sanitized.slice(0, MAX_STACK_CHARS - 20)}\n... (truncated)`
+}
+
+function sanitizeRequired(value: string): string {
+  return sanitizeDiagnosticText(value) ?? ''
+}
+
+function sanitizeDiagnosticText(value: string | undefined): string | undefined {
+  if (!value) return value
+  return value
+    .replace(USER_PATH_PATTERN, '~/')
+    .replace(URL_PATTERN, REDACTED)
+    .replace(TOKEN_LIKE_PATTERN, REDACTED)
+    .replace(ENV_VALUE_PATTERN, (match) => {
+      const idx = match.indexOf('=')
+      return idx >= 0 ? `${match.slice(0, idx + 1)}${REDACTED}` : REDACTED
+    })
 }

--- a/src/main/crash/NativeCrashReader.ts
+++ b/src/main/crash/NativeCrashReader.ts
@@ -113,7 +113,7 @@ function findCandidate(
 
       const info = parseIpsFile(fullPath)
       if (!info) continue
-      if (info.processName !== processName) continue
+      if (!matchesNativeCrashProcessName(processName, info.processName)) continue
 
       const crashMs = Date.parse(info.timestamp)
       if (Number.isNaN(crashMs)) continue
@@ -126,6 +126,22 @@ function findCandidate(
   }
 
   return best?.info ?? null
+}
+
+export function matchesNativeCrashProcessName(
+  expectedProcessName: string,
+  actualProcessName: string | undefined,
+): boolean {
+  if (!actualProcessName) return false
+  if (actualProcessName === expectedProcessName) return true
+
+  const suffixIndex = expectedProcessName.indexOf(' (')
+  if (suffixIndex < 0) return false
+
+  const expectedBaseName = expectedProcessName.slice(0, suffixIndex)
+  return (
+    actualProcessName === expectedBaseName || actualProcessName.startsWith(`${expectedBaseName} (`)
+  )
 }
 
 function parseIpsFile(filePath: string): NativeCrashInfo | null {

--- a/src/main/crash/NativeCrashReader.ts
+++ b/src/main/crash/NativeCrashReader.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync, statSync } from 'fs'
 import os from 'os'
 import { join } from 'path'
+import { sanitizeDiagnosticText, sanitizeStack } from './sanitizeCrashDiagnostic'
 
 export interface NativeCrashInfo {
   timestamp: string
@@ -56,12 +57,6 @@ interface IpsBody {
 const MAX_FRAMES = 40
 const MAX_STACK_CHARS = 4000
 const CLOCK_SKEW_MS = 60_000
-const REDACTED = '[redacted]'
-const URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi
-const USER_PATH_PATTERN = /(?:[A-Z]:\\Users\\[^\\\s]+\\|\/(?:Users|home)\/[^/\s]+\/)/gi
-const TOKEN_LIKE_PATTERN =
-  /\b(?:token|secret|password|passwd|apikey|api_key|authorization|bearer)[A-Za-z0-9_\-:=./+]{3,}/gi
-const ENV_VALUE_PATTERN = /\b[A-Z][A-Z0-9_]{2,}=([^\s]+)/g
 
 export function findRecentNativeCrash(
   processName: string,
@@ -209,24 +204,11 @@ function formatFrames(frames: IpsFrame[], images: IpsImage[]): string {
   }
 
   const joined = lines.join('\n')
-  if (joined.length <= MAX_STACK_CHARS) return joined
-  return `${joined.slice(0, MAX_STACK_CHARS - 20)}\n... (truncated)`
+  return sanitizeStack(joined, MAX_STACK_CHARS) ?? ''
 }
 
 function sanitizeFramePart(value: string): string {
   const sanitized = sanitizeDiagnosticText(value) ?? '???'
   if (sanitized.length <= 160) return sanitized
   return `${sanitized.slice(0, 157)}...`
-}
-
-function sanitizeDiagnosticText(value: string | undefined): string | undefined {
-  if (!value) return value
-  return value
-    .replace(USER_PATH_PATTERN, '~/')
-    .replace(URL_PATTERN, REDACTED)
-    .replace(TOKEN_LIKE_PATTERN, REDACTED)
-    .replace(ENV_VALUE_PATTERN, (match) => {
-      const idx = match.indexOf('=')
-      return idx >= 0 ? `${match.slice(0, idx + 1)}${REDACTED}` : REDACTED
-    })
 }

--- a/src/main/crash/NativeCrashReader.ts
+++ b/src/main/crash/NativeCrashReader.ts
@@ -4,13 +4,13 @@ import { join } from 'path'
 
 export interface NativeCrashInfo {
   timestamp: string
+  processName?: string
   exceptionType?: string
   exceptionCodes?: string
   terminationReason?: string
   triggeredThread?: string
   stack: string
   incidentId?: string
-  sourceFile: string
 }
 
 interface IpsFrame {
@@ -38,6 +38,8 @@ interface IpsHeader {
 }
 
 interface IpsBody {
+  captureTime?: string
+  procName?: string
   exception?: {
     type?: string
     signal?: string
@@ -54,6 +56,12 @@ interface IpsBody {
 const MAX_FRAMES = 40
 const MAX_STACK_CHARS = 4000
 const CLOCK_SKEW_MS = 60_000
+const REDACTED = '[redacted]'
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi
+const USER_PATH_PATTERN = /(?:[A-Z]:\\Users\\[^\\\s]+\\|\/(?:Users|home)\/[^/\s]+\/)/gi
+const TOKEN_LIKE_PATTERN =
+  /\b(?:token|secret|password|passwd|apikey|api_key|authorization|bearer)[A-Za-z0-9_\-:=./+]{3,}/gi
+const ENV_VALUE_PATTERN = /\b[A-Z][A-Z0-9_]{2,}=([^\s]+)/g
 
 export function findRecentNativeCrash(
   processName: string,
@@ -63,19 +71,17 @@ export function findRecentNativeCrash(
   if (process.platform !== 'darwin') return null
 
   try {
-    const candidate = findCandidateFile(processName, sinceEpochMs, nowEpochMs)
-    if (!candidate) return null
-    return parseIpsFile(candidate)
+    return findCandidate(processName, sinceEpochMs, nowEpochMs)
   } catch {
     return null
   }
 }
 
-function findCandidateFile(
+function findCandidate(
   processName: string,
   sinceEpochMs: number,
   nowEpochMs: number,
-): string | null {
+): NativeCrashInfo | null {
   const home = os.homedir()
   const dirs = [
     join(home, 'Library', 'Logs', 'DiagnosticReports'),
@@ -86,7 +92,7 @@ function findCandidateFile(
   const upperBound = nowEpochMs + CLOCK_SKEW_MS
   const prefix = `${processName}-`
 
-  let best: { path: string; mtimeMs: number } | null = null
+  let best: { info: NativeCrashInfo; crashMs: number; mtimeMs: number } | null = null
 
   for (const dir of dirs) {
     let entries: string[]
@@ -108,15 +114,23 @@ function findCandidateFile(
         continue
       }
 
-      if (mtimeMs < lowerBound || mtimeMs > upperBound) continue
+      if (mtimeMs < lowerBound) continue
 
-      if (!best || mtimeMs > best.mtimeMs) {
-        best = { path: fullPath, mtimeMs }
+      const info = parseIpsFile(fullPath)
+      if (!info) continue
+      if (info.processName !== processName) continue
+
+      const crashMs = Date.parse(info.timestamp)
+      if (Number.isNaN(crashMs)) continue
+      if (crashMs < lowerBound || crashMs > upperBound) continue
+
+      if (!best || crashMs > best.crashMs || (crashMs === best.crashMs && mtimeMs > best.mtimeMs)) {
+        best = { info, crashMs, mtimeMs }
       }
     }
   }
 
-  return best ? best.path : null
+  return best?.info ?? null
 }
 
 function parseIpsFile(filePath: string): NativeCrashInfo | null {
@@ -146,14 +160,14 @@ function parseIpsFile(filePath: string): NativeCrashInfo | null {
   const terminationReason = formatTermination(body.termination)
 
   return {
-    timestamp: toIsoTimestamp(header.timestamp),
+    timestamp: toIsoTimestamp(body.captureTime ?? header.timestamp),
+    processName: body.procName ?? header.app_name,
     exceptionType,
-    exceptionCodes: body.exception?.codes,
+    exceptionCodes: sanitizeDiagnosticText(body.exception?.codes),
     terminationReason,
-    triggeredThread: triggered?.name ?? triggered?.queue,
+    triggeredThread: sanitizeDiagnosticText(triggered?.name ?? triggered?.queue),
     stack,
-    incidentId: header.incident_id,
-    sourceFile: filePath,
+    incidentId: sanitizeDiagnosticText(header.incident_id),
   }
 }
 
@@ -168,15 +182,15 @@ function toIsoTimestamp(raw: string | undefined): string {
 function formatException(exception: IpsBody['exception']): string | undefined {
   if (!exception) return undefined
   const { type, signal } = exception
-  if (type && signal) return `${type} (${signal})`
-  return type ?? signal
+  if (type && signal) return sanitizeDiagnosticText(`${type} (${signal})`)
+  return sanitizeDiagnosticText(type ?? signal)
 }
 
 function formatTermination(termination: IpsBody['termination']): string | undefined {
   if (!termination) return undefined
   const { indicator, byProc } = termination
-  if (indicator && byProc) return `${indicator} (by ${byProc})`
-  return indicator ?? byProc
+  if (indicator && byProc) return sanitizeDiagnosticText(`${indicator} (by ${byProc})`)
+  return sanitizeDiagnosticText(indicator ?? byProc)
 }
 
 function formatFrames(frames: IpsFrame[], images: IpsImage[]): string {
@@ -184,9 +198,10 @@ function formatFrames(frames: IpsFrame[], images: IpsImage[]): string {
 
   for (let i = 0; i < frames.length && i < MAX_FRAMES; i++) {
     const frame = frames[i]
-    const imageName =
-      frame.imageIndex !== undefined ? (images[frame.imageIndex]?.name ?? '???') : '???'
-    const symbol = frame.symbol ?? '???'
+    const imageName = sanitizeFramePart(
+      frame.imageIndex !== undefined ? (images[frame.imageIndex]?.name ?? '???') : '???',
+    )
+    const symbol = sanitizeFramePart(frame.symbol ?? '???')
     const offset = frame.symbolLocation ?? 0
     const idx = String(i).padStart(3, ' ')
     const img = imageName.padEnd(32, ' ')
@@ -195,5 +210,23 @@ function formatFrames(frames: IpsFrame[], images: IpsImage[]): string {
 
   const joined = lines.join('\n')
   if (joined.length <= MAX_STACK_CHARS) return joined
-  return `${joined.slice(0, MAX_STACK_CHARS - 20)}\n… (truncated)`
+  return `${joined.slice(0, MAX_STACK_CHARS - 20)}\n... (truncated)`
+}
+
+function sanitizeFramePart(value: string): string {
+  const sanitized = sanitizeDiagnosticText(value) ?? '???'
+  if (sanitized.length <= 160) return sanitized
+  return `${sanitized.slice(0, 157)}...`
+}
+
+function sanitizeDiagnosticText(value: string | undefined): string | undefined {
+  if (!value) return value
+  return value
+    .replace(USER_PATH_PATTERN, '~/')
+    .replace(URL_PATTERN, REDACTED)
+    .replace(TOKEN_LIKE_PATTERN, REDACTED)
+    .replace(ENV_VALUE_PATTERN, (match) => {
+      const idx = match.indexOf('=')
+      return idx >= 0 ? `${match.slice(0, idx + 1)}${REDACTED}` : REDACTED
+    })
 }

--- a/src/main/crash/sanitizeCrashDiagnostic.ts
+++ b/src/main/crash/sanitizeCrashDiagnostic.ts
@@ -3,12 +3,18 @@ const DEFAULT_MAX_CHARS = 4000
 const USER_PATH_PATTERN = /(?:[A-Z]:\\Users\\[^\\\s]+\\|\/(?:Users|home)\/[^/\s]+\/)/gi
 const URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi
 const SECRET_KEY_VALUE_PATTERN =
-  /(["'`]?)(\b(?:x-api-key|api[-_]?key|apikey|access[-_]?token|refresh[-_]?token|client[-_]?secret|token|secret|password|passwd)\b)\1(\s*[:=]\s*)(["'`]?)([^\s,;'"`<>)\]}]+)\4/gi
+  /(["'`]?)(\b(?:x-api-key|api[-_]?key|apikey|access[-_]?token|refresh[-_]?token|client[-_]?secret|session[-_]?id|session|cookie|token|secret|password|passwd)\b)\1(\s*[:=]\s*)(["'`]?)([^\s,;'"`<>)\]}]+)\4/gi
 const AUTHORIZATION_SECRET_PATTERN =
   /(["'`]?)(\bauthorization\b)\1(\s*[:=]\s*)(["'`]?)([^\n\r,;<>)}\]]+)\4/gi
 const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]{6,}/gi
+const BASIC_TOKEN_PATTERN = /\bBasic\s+[A-Za-z0-9+/=_-]{6,}/gi
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g
+const AWS_KEY_PATTERN = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g
+const GH_TOKEN_PATTERN = /\b(?:gh[posru]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/g
+const PEM_PRIVATE_KEY_PATTERN =
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g
 const TOKEN_LIKE_PATTERN =
-  /\b(?:token|secret|password|passwd|apikey|api_key|authorization|bearer)[A-Za-z0-9_\-:=./+]{3,}/gi
+  /\b(?:token|secret|password|passwd|apikey|api_key|authorization|bearer)\s*[:=]\s*[A-Za-z0-9_\-./+]{3,}/gi
 const ENV_VALUE_PATTERN = /\b[A-Z][A-Z0-9_]{2,}=([^\s]+)/g
 
 export function sanitizeDiagnosticText(value: string | undefined): string | undefined {
@@ -29,6 +35,11 @@ export function sanitizeDiagnosticText(value: string | undefined): string | unde
       },
     )
     .replace(BEARER_TOKEN_PATTERN, `Bearer ${REDACTED}`)
+    .replace(BASIC_TOKEN_PATTERN, `Basic ${REDACTED}`)
+    .replace(JWT_PATTERN, REDACTED)
+    .replace(AWS_KEY_PATTERN, REDACTED)
+    .replace(GH_TOKEN_PATTERN, REDACTED)
+    .replace(PEM_PRIVATE_KEY_PATTERN, REDACTED)
     .replace(TOKEN_LIKE_PATTERN, REDACTED)
     .replace(ENV_VALUE_PATTERN, (match) => {
       const idx = match.indexOf('=')

--- a/src/main/crash/sanitizeCrashDiagnostic.ts
+++ b/src/main/crash/sanitizeCrashDiagnostic.ts
@@ -2,8 +2,10 @@ const REDACTED = '[redacted]'
 const DEFAULT_MAX_CHARS = 4000
 const USER_PATH_PATTERN = /(?:[A-Z]:\\Users\\[^\\\s]+\\|\/(?:Users|home)\/[^/\s]+\/)/gi
 const URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi
-const KEY_VALUE_SECRET_PATTERN =
-  /\b(token|secret|password|passwd|apikey|api_key|authorization)\b(\s*[:=]\s*)(?:Bearer\s+)?[^\s,;'"`<>)]+/gi
+const SECRET_KEY_VALUE_PATTERN =
+  /(["'`]?)(\b(?:x-api-key|api[-_]?key|apikey|access[-_]?token|refresh[-_]?token|client[-_]?secret|token|secret|password|passwd)\b)\1(\s*[:=]\s*)(["'`]?)([^\s,;'"`<>)\]}]+)\4/gi
+const AUTHORIZATION_SECRET_PATTERN =
+  /(["'`]?)(\bauthorization\b)\1(\s*[:=]\s*)(["'`]?)([^\n\r,;<>)}\]]+)\4/gi
 const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]{6,}/gi
 const TOKEN_LIKE_PATTERN =
   /\b(?:token|secret|password|passwd|apikey|api_key|authorization|bearer)[A-Za-z0-9_\-:=./+]{3,}/gi
@@ -14,9 +16,18 @@ export function sanitizeDiagnosticText(value: string | undefined): string | unde
   return value
     .replace(USER_PATH_PATTERN, '~/')
     .replace(URL_PATTERN, REDACTED)
-    .replace(KEY_VALUE_SECRET_PATTERN, (_match, key: string, separator: string) => {
-      return `${key}${separator}${REDACTED}`
-    })
+    .replace(
+      AUTHORIZATION_SECRET_PATTERN,
+      (_match, keyQuote: string, key: string, separator: string, valueQuote: string) => {
+        return `${keyQuote}${key}${keyQuote}${separator}${valueQuote}${REDACTED}${valueQuote}`
+      },
+    )
+    .replace(
+      SECRET_KEY_VALUE_PATTERN,
+      (_match, keyQuote: string, key: string, separator: string, valueQuote: string) => {
+        return `${keyQuote}${key}${keyQuote}${separator}${valueQuote}${REDACTED}${valueQuote}`
+      },
+    )
     .replace(BEARER_TOKEN_PATTERN, `Bearer ${REDACTED}`)
     .replace(TOKEN_LIKE_PATTERN, REDACTED)
     .replace(ENV_VALUE_PATTERN, (match) => {

--- a/src/main/crash/sanitizeCrashDiagnostic.ts
+++ b/src/main/crash/sanitizeCrashDiagnostic.ts
@@ -1,0 +1,36 @@
+const REDACTED = '[redacted]'
+const DEFAULT_MAX_CHARS = 4000
+const USER_PATH_PATTERN = /(?:[A-Z]:\\Users\\[^\\\s]+\\|\/(?:Users|home)\/[^/\s]+\/)/gi
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi
+const KEY_VALUE_SECRET_PATTERN =
+  /\b(token|secret|password|passwd|apikey|api_key|authorization)\b(\s*[:=]\s*)(?:Bearer\s+)?[^\s,;'"`<>)]+/gi
+const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]{6,}/gi
+const TOKEN_LIKE_PATTERN =
+  /\b(?:token|secret|password|passwd|apikey|api_key|authorization|bearer)[A-Za-z0-9_\-:=./+]{3,}/gi
+const ENV_VALUE_PATTERN = /\b[A-Z][A-Z0-9_]{2,}=([^\s]+)/g
+
+export function sanitizeDiagnosticText(value: string | undefined): string | undefined {
+  if (!value) return value
+  return value
+    .replace(USER_PATH_PATTERN, '~/')
+    .replace(URL_PATTERN, REDACTED)
+    .replace(KEY_VALUE_SECRET_PATTERN, (_match, key: string, separator: string) => {
+      return `${key}${separator}${REDACTED}`
+    })
+    .replace(BEARER_TOKEN_PATTERN, `Bearer ${REDACTED}`)
+    .replace(TOKEN_LIKE_PATTERN, REDACTED)
+    .replace(ENV_VALUE_PATTERN, (match) => {
+      const idx = match.indexOf('=')
+      return idx >= 0 ? `${match.slice(0, idx + 1)}${REDACTED}` : REDACTED
+    })
+}
+
+export function sanitizeStack(
+  value: string | undefined,
+  maxChars = DEFAULT_MAX_CHARS,
+): string | undefined {
+  const sanitized = sanitizeDiagnosticText(value)
+  if (!sanitized) return sanitized
+  if (sanitized.length <= maxChars) return sanitized
+  return `${sanitized.slice(0, maxChars - 20)}\n... (truncated)`
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -544,10 +544,7 @@ app.whenReady().then(async () => {
 
       window.webContents.on('render-process-gone', (_event, details) => {
         if (details.reason !== 'clean-exit') {
-          crashReporter?.recordCrash(
-            'rendererCrash',
-            new Error(`Renderer crashed: ${details.reason}`),
-          )
+          crashReporter?.recordRendererCrash(details)
         }
       })
     }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -14,6 +14,7 @@ import type {
   TabStateSnapshot,
   WorkspaceCommandResult,
 } from '../main/commands/types'
+import type { CrashReportData } from '../renderer-shared/crashReport'
 
 interface PtyExitData {
   sessionId: string
@@ -257,36 +258,6 @@ interface ChangelogEntry {
   version: string
   date: string
   body: string
-}
-
-type CrashReportType =
-  | 'uncaughtException'
-  | 'unhandledRejection'
-  | 'rendererCrash'
-  | 'childProcessGone'
-  | 'ungracefulShutdown'
-
-interface CrashReportData {
-  timestamp: string
-  type: CrashReportType
-  errorMessage: string
-  stack?: string
-  appVersion: string
-  electronVersion: string
-  os: string
-  process?: 'main' | 'renderer' | 'child' | 'unknown'
-  renderer?: {
-    reason?: string
-    exitCode?: number
-  }
-  nativeCrash?: {
-    exceptionType?: string
-    exceptionCodes?: string
-    terminationReason?: string
-    triggeredThread?: string
-    incidentId?: string
-    stack?: string
-  }
 }
 
 interface UpdateInfo {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -259,6 +259,36 @@ interface ChangelogEntry {
   body: string
 }
 
+type CrashReportType =
+  | 'uncaughtException'
+  | 'unhandledRejection'
+  | 'rendererCrash'
+  | 'childProcessGone'
+  | 'ungracefulShutdown'
+
+interface CrashReportData {
+  timestamp: string
+  type: CrashReportType
+  errorMessage: string
+  stack?: string
+  appVersion: string
+  electronVersion: string
+  os: string
+  process?: 'main' | 'renderer' | 'child' | 'unknown'
+  renderer?: {
+    reason?: string
+    exitCode?: number
+  }
+  nativeCrash?: {
+    exceptionType?: string
+    exceptionCodes?: string
+    terminationReason?: string
+    triggeredThread?: string
+    incidentId?: string
+    stack?: string
+  }
+}
+
 interface UpdateInfo {
   version: string
   releaseNotes?: string
@@ -338,17 +368,7 @@ interface CanopyAPI {
   onShowChangelog: (callback: (data: { fromVersion: string }) => void) => () => void
 
   // Crash reports
-  onCrashReport: (
-    callback: (data: {
-      timestamp: string
-      type: string
-      errorMessage: string
-      stack?: string
-      appVersion: string
-      electronVersion: string
-      os: string
-    }) => void,
-  ) => () => void
+  onCrashReport: (callback: (data: CrashReportData) => void) => () => void
 
   // PTY
   resizePty: (sessionId: string, cols: number, rows: number) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,6 +17,34 @@ import type {
   TabClosePreflightResult,
 } from '../main/commands/types'
 
+type CrashReportData = {
+  timestamp: string
+  type:
+    | 'uncaughtException'
+    | 'unhandledRejection'
+    | 'rendererCrash'
+    | 'childProcessGone'
+    | 'ungracefulShutdown'
+  errorMessage: string
+  stack?: string
+  appVersion: string
+  electronVersion: string
+  os: string
+  process?: 'main' | 'renderer' | 'child' | 'unknown'
+  renderer?: {
+    reason?: string
+    exitCode?: number
+  }
+  nativeCrash?: {
+    exceptionType?: string
+    exceptionCodes?: string
+    terminationReason?: string
+    triggeredThread?: string
+    incidentId?: string
+    stack?: string
+  }
+}
+
 const api = {
   // PTY
   resizePty: (sessionId: string, cols: number, rows: number) =>
@@ -615,17 +643,7 @@ const api = {
   },
 
   // Crash reports
-  onCrashReport: (
-    callback: (data: {
-      timestamp: string
-      type: string
-      errorMessage: string
-      stack?: string
-      appVersion: string
-      electronVersion: string
-      os: string
-    }) => void,
-  ) => {
+  onCrashReport: (callback: (data: CrashReportData) => void) => {
     const handler = (_event: IpcRendererEvent, data: Parameters<typeof callback>[0]): void =>
       callback(data)
     ipcRenderer.on('app:crashReport', handler)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,7 @@ import type { CanopySkill } from '../main/skills/types'
 import type { RemoteSessionStatus } from '../main/remote/types'
 import type { AgentProfileMasked, ProfileInput } from '../main/profiles/types'
 import type { AgentType } from '../main/agents/types'
+import type { CrashReportData } from '../renderer-shared/crashReport'
 import type {
   AppStateSnapshot,
   CloseWarningResult,
@@ -16,34 +17,6 @@ import type {
   TabCloseAllPreflightResult,
   TabClosePreflightResult,
 } from '../main/commands/types'
-
-type CrashReportData = {
-  timestamp: string
-  type:
-    | 'uncaughtException'
-    | 'unhandledRejection'
-    | 'rendererCrash'
-    | 'childProcessGone'
-    | 'ungracefulShutdown'
-  errorMessage: string
-  stack?: string
-  appVersion: string
-  electronVersion: string
-  os: string
-  process?: 'main' | 'renderer' | 'child' | 'unknown'
-  renderer?: {
-    reason?: string
-    exitCode?: number
-  }
-  nativeCrash?: {
-    exceptionType?: string
-    exceptionCodes?: string
-    terminationReason?: string
-    triggeredThread?: string
-    incidentId?: string
-    stack?: string
-  }
-}
 
 const api = {
   // PTY

--- a/src/renderer-shared/crashReport.ts
+++ b/src/renderer-shared/crashReport.ts
@@ -1,0 +1,33 @@
+export type CrashReportType =
+  | 'uncaughtException'
+  | 'unhandledRejection'
+  | 'rendererCrash'
+  | 'childProcessGone'
+  | 'ungracefulShutdown'
+
+export type CrashReportProcess = 'main' | 'renderer' | 'child' | 'unknown'
+
+export interface CrashReportData {
+  timestamp: string
+  type: CrashReportType
+  errorMessage: string
+  stack?: string
+  appVersion: string
+  electronVersion: string
+  os: string
+  process?: CrashReportProcess
+  renderer?: {
+    reason?: string
+    exitCode?: number
+  }
+  nativeCrash?: {
+    exceptionType?: string
+    exceptionCodes?: string
+    terminationReason?: string
+    triggeredThread?: string
+    incidentId?: string
+    stack?: string
+  }
+}
+
+export type CrashReport = CrashReportData

--- a/src/renderer/src/components/dialogs/CrashReportDialog.svelte
+++ b/src/renderer/src/components/dialogs/CrashReportDialog.svelte
@@ -16,9 +16,12 @@
   } = $props()
 
   let dismissBtn: HTMLButtonElement | undefined = $state()
+  let containerEl: HTMLDivElement | undefined = $state()
 
   onMount(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null
     dismissBtn?.focus()
+    return () => previouslyFocused?.focus?.()
   })
 
   function handleKeydown(e: KeyboardEvent): void {
@@ -26,7 +29,27 @@
       e.preventDefault()
       e.stopPropagation()
       onDismiss()
+      return
     }
+
+    if (e.key === 'Tab' && containerEl) {
+      const focusable = containerEl.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )
+      if (focusable.length === 0) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const active = document.activeElement as HTMLElement | null
+      if (e.shiftKey && (active === first || !containerEl.contains(active))) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
+      return
+    }
+
     if (e.key === 'Enter') {
       e.preventDefault()
       e.stopPropagation()
@@ -54,6 +77,7 @@
 >
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
+    bind:this={containerEl}
     class="w-[480px] max-w-full max-h-[calc(100vh-48px)] sm:max-h-[calc(100vh-144px)] overflow-y-auto bg-bg-overlay border border-border rounded-[10px] shadow-modal p-5"
     role="dialog"
     aria-modal="true"

--- a/src/renderer/src/components/dialogs/CrashReportDialog.svelte
+++ b/src/renderer/src/components/dialogs/CrashReportDialog.svelte
@@ -5,10 +5,12 @@
 
   let {
     data,
+    reportMarkdown,
     onCreateIssue,
     onDismiss,
   }: {
     data: CrashReportData
+    reportMarkdown: string
     onCreateIssue: () => void
     onDismiss: () => void
   } = $props()
@@ -56,6 +58,7 @@
     role="dialog"
     aria-modal="true"
     aria-labelledby="crash-dialog-title"
+    tabindex="-1"
     onmousedown={(e) => e.stopPropagation()}
   >
     <h3
@@ -66,7 +69,7 @@
       Canopy crashed
     </h3>
     <p class="m-0 mb-3 text-md text-text-secondary leading-normal">
-      The app did not shut down cleanly last time. You can report this to help us fix it.
+      The app did not shut down cleanly last time. Review the report before sharing it.
     </p>
 
     <div class="flex flex-col gap-1 mb-3 text-sm text-text-muted">
@@ -90,6 +93,24 @@
         <span class="min-w-16 text-text-faint">OS</span>
         <span>{data.os}</span>
       </div>
+      {#if data.renderer?.reason}
+        <div class="flex gap-2">
+          <span class="min-w-16 text-text-faint">Reason</span>
+          <span>{data.renderer.reason}</span>
+        </div>
+      {/if}
+      {#if data.renderer?.exitCode !== undefined}
+        <div class="flex gap-2">
+          <span class="min-w-16 text-text-faint">Exit</span>
+          <span>{data.renderer.exitCode}</span>
+        </div>
+      {/if}
+      {#if data.nativeCrash?.exceptionType}
+        <div class="flex gap-2">
+          <span class="min-w-16 text-text-faint">Native</span>
+          <span>{data.nativeCrash.exceptionType}</span>
+        </div>
+      {/if}
     </div>
 
     {#if data.errorMessage || data.stack}
@@ -97,6 +118,12 @@
         class="m-0 mb-3 p-2 bg-bg border border-border rounded-lg font-mono text-xs leading-snug text-text-muted max-h-[200px] overflow-y-auto whitespace-pre-wrap break-all">{data.errorMessage}{#if data.stack}
           {data.stack}{/if}</pre>
     {/if}
+
+    <div class="mb-3">
+      <div class="mb-1 text-sm text-text-faint">Report to copy</div>
+      <pre
+        class="m-0 p-2 bg-bg border border-border rounded-lg font-mono text-xs leading-snug text-text-muted max-h-[240px] overflow-y-auto whitespace-pre-wrap break-all">{reportMarkdown}</pre>
+    </div>
 
     <div class="flex justify-end gap-2 mt-4">
       <button
@@ -106,7 +133,7 @@
       >
       <button
         class="px-3.5 py-1.5 rounded-lg text-md font-inherit cursor-pointer border-0 outline-none bg-accent-bg text-accent-text transition-colors duration-fast hover:bg-accent-muted focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-1"
-        onclick={onCreateIssue}>Create issue</button
+        onclick={onCreateIssue}>Copy report and open issue</button
       >
     </div>
   </div>

--- a/src/renderer/src/components/dialogs/CrashReportDialog.svelte
+++ b/src/renderer/src/components/dialogs/CrashReportDialog.svelte
@@ -48,13 +48,13 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  class="fixed inset-0 z-[1001] flex justify-center items-start pt-[120px] bg-scrim"
+  class="fixed inset-0 z-[1001] flex justify-center items-start p-4 pt-6 sm:pt-[120px] overflow-y-auto bg-scrim"
   onkeydown={handleKeydown}
   onmousedown={onDismiss}
 >
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
-    class="w-[480px] bg-bg-overlay border border-border rounded-[10px] shadow-modal p-5"
+    class="w-[480px] max-w-full max-h-[calc(100vh-48px)] sm:max-h-[calc(100vh-144px)] overflow-y-auto bg-bg-overlay border border-border rounded-[10px] shadow-modal p-5"
     role="dialog"
     aria-modal="true"
     aria-labelledby="crash-dialog-title"

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -26,6 +26,7 @@
   import RightPanel from './RightPanel.svelte'
   import Toast from '../shared/Toast.svelte'
   import { Loader2 } from '@lucide/svelte'
+  import { formatCrashReportMarkdown } from '../../lib/crashReportMarkdown'
   import { getPref, setPref } from '../../lib/stores/preferences.svelte'
   import { addToast } from '../../lib/stores/toast.svelte'
   import {
@@ -79,64 +80,6 @@
     clearWorktreeBadge,
   } from '../../lib/agents/agentState.svelte'
   import { findWorktreeForSession } from '../../lib/stores/tabs.svelte'
-
-  function formatCrashReportMarkdown(d: CrashReportData): string {
-    const lines = [
-      '## Crash report',
-      '',
-      `- **Timestamp:** ${d.timestamp}`,
-      `- **Type:** ${d.type}`,
-      `- **Process:** ${d.process ?? 'unknown'}`,
-      `- **App version:** ${d.appVersion}`,
-      `- **Electron:** ${d.electronVersion}`,
-      `- **OS:** ${d.os}`,
-    ]
-
-    if (d.renderer?.reason) lines.push(`- **Renderer reason:** ${d.renderer.reason}`)
-    if (d.renderer?.exitCode !== undefined)
-      lines.push(`- **Renderer exit code:** ${d.renderer.exitCode}`)
-
-    appendFencedSection(lines, '### Error', d.errorMessage)
-
-    if (d.stack) {
-      appendFencedSection(lines, '### Stack trace', d.stack)
-    }
-
-    if (d.nativeCrash) {
-      lines.push('', '### Native crash')
-      if (d.nativeCrash.exceptionType) {
-        lines.push(`- **Exception:** ${d.nativeCrash.exceptionType}`)
-      }
-      if (d.nativeCrash.exceptionCodes) {
-        lines.push(`- **Exception codes:** ${d.nativeCrash.exceptionCodes}`)
-      }
-      if (d.nativeCrash.terminationReason) {
-        lines.push(`- **Termination:** ${d.nativeCrash.terminationReason}`)
-      }
-      if (d.nativeCrash.triggeredThread) {
-        lines.push(`- **Triggered thread:** ${d.nativeCrash.triggeredThread}`)
-      }
-      if (d.nativeCrash.incidentId) {
-        lines.push(`- **Incident ID:** ${d.nativeCrash.incidentId}`)
-      }
-      if (d.nativeCrash.stack) {
-        appendFencedSection(lines, '#### Native stack', d.nativeCrash.stack)
-      }
-    }
-
-    return lines.join('\n')
-  }
-
-  function appendFencedSection(lines: string[], heading: string, value: string): void {
-    const fence = markdownFenceFor(value)
-    lines.push('', heading, fence, value, fence)
-  }
-
-  function markdownFenceFor(value: string): string {
-    const backtickRuns = value.match(/`+/g) ?? []
-    const longestRun = backtickRuns.reduce((max, run) => Math.max(max, run.length), 0)
-    return '`'.repeat(Math.max(3, longestRun + 1))
-  }
 
   function crashIssueUrl(d: CrashReportData): string {
     const process = d.process ?? 'unknown'
@@ -194,6 +137,11 @@
           title: 'Starting Canopy',
           description: 'Checking for a previous session...',
         },
+  )
+  let crashReportMarkdown = $derived(
+    dialogState.current.type === 'crashReport'
+      ? formatCrashReportMarkdown(dialogState.current.data)
+      : '',
   )
 
   // Sidebar resize state
@@ -652,13 +600,12 @@
 {:else if dialogState.current.type === 'crashReport'}
   <CrashReportDialog
     data={dialogState.current.data}
-    reportMarkdown={formatCrashReportMarkdown(dialogState.current.data)}
+    reportMarkdown={crashReportMarkdown}
     onCreateIssue={async () => {
       if (dialogState.current.type !== 'crashReport') return
       const d = dialogState.current.data
-      const report = formatCrashReportMarkdown(d)
       try {
-        await navigator.clipboard.writeText(report)
+        await navigator.clipboard.writeText(crashReportMarkdown)
         addToast('Crash report copied to clipboard')
       } catch {
         addToast('Failed to copy crash report to clipboard')

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -37,6 +37,7 @@
     showOnboardingWizard,
     showFeatureOnboarding,
     showCrashReport,
+    type CrashReportData,
   } from '../../lib/stores/dialogs.svelte'
   import {
     workspaceState,
@@ -78,6 +79,61 @@
     clearWorktreeBadge,
   } from '../../lib/agents/agentState.svelte'
   import { findWorktreeForSession } from '../../lib/stores/tabs.svelte'
+
+  function formatCrashReportMarkdown(d: CrashReportData): string {
+    const lines = [
+      '## Crash report',
+      '',
+      `- **Timestamp:** ${d.timestamp}`,
+      `- **Type:** ${d.type}`,
+      `- **Process:** ${d.process ?? 'unknown'}`,
+      `- **App version:** ${d.appVersion}`,
+      `- **Electron:** ${d.electronVersion}`,
+      `- **OS:** ${d.os}`,
+    ]
+
+    if (d.renderer?.reason) lines.push(`- **Renderer reason:** ${d.renderer.reason}`)
+    if (d.renderer?.exitCode !== undefined)
+      lines.push(`- **Renderer exit code:** ${d.renderer.exitCode}`)
+
+    lines.push('', '### Error', '```', d.errorMessage, '```')
+
+    if (d.stack) {
+      lines.push('', '### Stack trace', '```', d.stack, '```')
+    }
+
+    if (d.nativeCrash) {
+      lines.push('', '### Native crash')
+      if (d.nativeCrash.exceptionType) {
+        lines.push(`- **Exception:** ${d.nativeCrash.exceptionType}`)
+      }
+      if (d.nativeCrash.exceptionCodes) {
+        lines.push(`- **Exception codes:** ${d.nativeCrash.exceptionCodes}`)
+      }
+      if (d.nativeCrash.terminationReason) {
+        lines.push(`- **Termination:** ${d.nativeCrash.terminationReason}`)
+      }
+      if (d.nativeCrash.triggeredThread) {
+        lines.push(`- **Triggered thread:** ${d.nativeCrash.triggeredThread}`)
+      }
+      if (d.nativeCrash.incidentId) {
+        lines.push(`- **Incident ID:** ${d.nativeCrash.incidentId}`)
+      }
+      if (d.nativeCrash.stack) {
+        lines.push('', '#### Native stack', '```', d.nativeCrash.stack, '```')
+      }
+    }
+
+    return lines.join('\n')
+  }
+
+  function crashIssueUrl(d: CrashReportData): string {
+    const title = encodeURIComponent(`Crash: ${d.errorMessage.slice(0, 80)}`)
+    const body = encodeURIComponent(
+      'Crash report copied from Canopy. Paste it here before submitting.',
+    )
+    return `https://github.com/itsoltech/canopy-desktop/issues/new?title=${title}&body=${body}&labels=bug,crash`
+  }
   import { initToolStore, destroyToolStore } from '../../lib/stores/tools.svelte'
   import { initSkillStore, destroySkillStore } from '../../lib/stores/skills.svelte'
   import { initProfileStore, destroyProfileStore } from '../../lib/stores/profiles.svelte'
@@ -584,28 +640,22 @@
 {:else if dialogState.current.type === 'crashReport'}
   <CrashReportDialog
     data={dialogState.current.data}
-    onCreateIssue={() => {
+    reportMarkdown={formatCrashReportMarkdown(dialogState.current.data)}
+    onCreateIssue={async () => {
       if (dialogState.current.type !== 'crashReport') return
       const d = dialogState.current.data
-      // Strip home directory paths from stack traces to avoid leaking local paths
-      const homeDir = d.os.startsWith('win32')
-        ? /[A-Z]:\\Users\\[^\\]+\\/gi
-        : /\/(?:Users|home)\/[^/]+\//g
-      const sanitize = (s: string): string => s.replace(homeDir, '~/')
-      const title = encodeURIComponent(`Crash: ${sanitize(d.errorMessage).slice(0, 80)}`)
-      const body = encodeURIComponent(
-        `## Crash report\n\n` +
-          `- **Timestamp:** ${d.timestamp}\n` +
-          `- **Type:** ${d.type}\n` +
-          `- **App version:** ${d.appVersion}\n` +
-          `- **Electron:** ${d.electronVersion}\n` +
-          `- **OS:** ${d.os}\n\n` +
-          `### Error\n\`\`\`\n${sanitize(d.errorMessage)}\n\`\`\`\n\n` +
-          (d.stack ? `### Stack trace\n\`\`\`\n${sanitize(d.stack).slice(0, 3000)}\n\`\`\`\n` : ''),
-      )
-      const url = `https://github.com/itsoltech/canopy-desktop/issues/new?title=${title}&body=${body}&labels=bug,crash`
+      const report = formatCrashReportMarkdown(d)
+      try {
+        await navigator.clipboard.writeText(report)
+        addToast('Crash report copied to clipboard')
+      } catch {
+        addToast('Failed to copy crash report to clipboard')
+        return
+      }
+
+      const url = crashIssueUrl(d)
       window.api.openExternal(url).catch(() => {
-        addToast('Failed to open browser. Copy the URL from your address bar to report manually.')
+        addToast('Failed to open browser. Crash report is copied to clipboard.')
       })
       closeDialog()
     }}

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -96,10 +96,10 @@
     if (d.renderer?.exitCode !== undefined)
       lines.push(`- **Renderer exit code:** ${d.renderer.exitCode}`)
 
-    lines.push('', '### Error', '```', d.errorMessage, '```')
+    appendFencedSection(lines, '### Error', d.errorMessage)
 
     if (d.stack) {
-      lines.push('', '### Stack trace', '```', d.stack, '```')
+      appendFencedSection(lines, '### Stack trace', d.stack)
     }
 
     if (d.nativeCrash) {
@@ -120,15 +120,27 @@
         lines.push(`- **Incident ID:** ${d.nativeCrash.incidentId}`)
       }
       if (d.nativeCrash.stack) {
-        lines.push('', '#### Native stack', '```', d.nativeCrash.stack, '```')
+        appendFencedSection(lines, '#### Native stack', d.nativeCrash.stack)
       }
     }
 
     return lines.join('\n')
   }
 
+  function appendFencedSection(lines: string[], heading: string, value: string): void {
+    const fence = markdownFenceFor(value)
+    lines.push('', heading, fence, value, fence)
+  }
+
+  function markdownFenceFor(value: string): string {
+    const backtickRuns = value.match(/`+/g) ?? []
+    const longestRun = backtickRuns.reduce((max, run) => Math.max(max, run.length), 0)
+    return '`'.repeat(Math.max(3, longestRun + 1))
+  }
+
   function crashIssueUrl(d: CrashReportData): string {
-    const title = encodeURIComponent(`Crash: ${d.errorMessage.slice(0, 80)}`)
+    const process = d.process ?? 'unknown'
+    const title = encodeURIComponent(`Canopy crash report: ${d.type} (${process})`)
     const body = encodeURIComponent(
       'Crash report copied from Canopy. Paste it here before submitting.',
     )

--- a/src/renderer/src/lib/crashReportMarkdown.ts
+++ b/src/renderer/src/lib/crashReportMarkdown.ts
@@ -1,0 +1,59 @@
+import type { CrashReportData } from '../../../renderer-shared/crashReport'
+
+export function formatCrashReportMarkdown(d: CrashReportData): string {
+  const lines = [
+    '## Crash report',
+    '',
+    `- **Timestamp:** ${d.timestamp}`,
+    `- **Type:** ${d.type}`,
+    `- **Process:** ${d.process ?? 'unknown'}`,
+    `- **App version:** ${d.appVersion}`,
+    `- **Electron:** ${d.electronVersion}`,
+    `- **OS:** ${d.os}`,
+  ]
+
+  if (d.renderer?.reason) lines.push(`- **Renderer reason:** ${d.renderer.reason}`)
+  if (d.renderer?.exitCode !== undefined)
+    lines.push(`- **Renderer exit code:** ${d.renderer.exitCode}`)
+
+  appendFencedSection(lines, '### Error', d.errorMessage)
+
+  if (d.stack) {
+    appendFencedSection(lines, '### Stack trace', d.stack)
+  }
+
+  if (d.nativeCrash) {
+    lines.push('', '### Native crash')
+    if (d.nativeCrash.exceptionType) {
+      lines.push(`- **Exception:** ${d.nativeCrash.exceptionType}`)
+    }
+    if (d.nativeCrash.exceptionCodes) {
+      lines.push(`- **Exception codes:** ${d.nativeCrash.exceptionCodes}`)
+    }
+    if (d.nativeCrash.terminationReason) {
+      lines.push(`- **Termination:** ${d.nativeCrash.terminationReason}`)
+    }
+    if (d.nativeCrash.triggeredThread) {
+      lines.push(`- **Triggered thread:** ${d.nativeCrash.triggeredThread}`)
+    }
+    if (d.nativeCrash.incidentId) {
+      lines.push(`- **Incident ID:** ${d.nativeCrash.incidentId}`)
+    }
+    if (d.nativeCrash.stack) {
+      appendFencedSection(lines, '#### Native stack', d.nativeCrash.stack)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function appendFencedSection(lines: string[], heading: string, value: string): void {
+  const fence = markdownFenceFor(value)
+  lines.push('', heading, fence, value, fence)
+}
+
+function markdownFenceFor(value: string): string {
+  const backtickRuns = value.match(/`+/g) ?? []
+  const longestRun = backtickRuns.reduce((max, run) => Math.max(max, run.length), 0)
+  return '`'.repeat(Math.max(3, longestRun + 1))
+}

--- a/src/renderer/src/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/src/lib/stores/dialogs.svelte.ts
@@ -1,3 +1,5 @@
+export type { CrashReportData } from '../../../../renderer-shared/crashReport'
+
 export interface ConfirmOptions {
   title: string
   message: string
@@ -97,34 +99,6 @@ interface RunConfigManagerState {
   type: 'runConfigManager'
   selectConfigDir?: string
   selectConfigName?: string
-}
-
-export interface CrashReportData {
-  timestamp: string
-  type:
-    | 'uncaughtException'
-    | 'unhandledRejection'
-    | 'rendererCrash'
-    | 'childProcessGone'
-    | 'ungracefulShutdown'
-  errorMessage: string
-  stack?: string
-  appVersion: string
-  electronVersion: string
-  os: string
-  process?: 'main' | 'renderer' | 'child' | 'unknown'
-  renderer?: {
-    reason?: string
-    exitCode?: number
-  }
-  nativeCrash?: {
-    exceptionType?: string
-    exceptionCodes?: string
-    terminationReason?: string
-    triggeredThread?: string
-    incidentId?: string
-    stack?: string
-  }
 }
 
 interface CrashReportState {

--- a/src/renderer/src/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/src/lib/stores/dialogs.svelte.ts
@@ -101,12 +101,30 @@ interface RunConfigManagerState {
 
 export interface CrashReportData {
   timestamp: string
-  type: string
+  type:
+    | 'uncaughtException'
+    | 'unhandledRejection'
+    | 'rendererCrash'
+    | 'childProcessGone'
+    | 'ungracefulShutdown'
   errorMessage: string
   stack?: string
   appVersion: string
   electronVersion: string
   os: string
+  process?: 'main' | 'renderer' | 'child' | 'unknown'
+  renderer?: {
+    reason?: string
+    exitCode?: number
+  }
+  nativeCrash?: {
+    exceptionType?: string
+    exceptionCodes?: string
+    terminationReason?: string
+    triggeredThread?: string
+    incidentId?: string
+    stack?: string
+  }
 }
 
 interface CrashReportState {


### PR DESCRIPTION
## What

Improves Canopy crash reporting by capturing renderer crash details, enriching macOS native crash diagnostics, and making copied crash reports safer to share.

The crash report flow now keeps diagnostic data out of GitHub issue URLs, strengthens redaction for paths, URLs, tokens, and common secret formats, and improves the crash dialog keyboard/focus behavior.

## Why

Renderer crashes previously produced too little actionable context, while richer diagnostics needed stricter privacy handling before users copied reports into GitHub issues.

Fixes crash diagnostics work related to #257.

## How to test

1. Trigger or simulate a crash report payload and verify the crash dialog shows the report preview.
2. Click "Copy report and open issue" and verify the GitHub issue URL contains only neutral title/body/labels, not stack traces or error details.
3. Verify copied crash Markdown includes renderer/native crash details where present.
4. Verify sanitizer redacts samples like `Authorization: Basic ...`, `x-api-key: ...`, `clientSecret: ...`, local home paths, and URLs.
5. Verify keyboard behavior in the crash dialog: initial focus is inside the dialog, Tab/Shift+Tab stay inside, Escape/Dismiss closes it.
6. Run:
   - `npm run typecheck:node`
   - `npm run svelte-check`
   - `npm run typecheck`
   - `npm run lint`
   - `npm run build`

## Screenshots / recordings

Not attached. UI change is limited to the crash report dialog content/keyboard behavior.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [x] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly
- [x] Feature docs in `docs/` updated (behavior, config, errors, security — if any changed)
