### PR TITLE
fix(terminal): pause streams during screen lock

### DIFF
--- a/docs/core/terminal.md
+++ b/docs/core/terminal.md
@@ -37,9 +37,34 @@ Tmux integration (dev builds only) allows creating new tmux sessions or attachin
 3. On reconnect, the client passes `?offset=<receivedChars>` so the bridge replays only missed history.
 4. After 30 consecutive failed attempts, the status changes to `disconnected` and reconnection stops.
 
+### Screen lock and wake handling
+
+Canopy keeps PTY processes alive while the OS session is locked or suspended, but pauses terminal
+stream reconnects so the renderer does not try to catch up while Chromium is throttled. Screen-lock
+pause uses Electron `lock-screen`/`unlock-screen` events where supported (macOS and Windows);
+Linux builds rely on `suspend`/`resume` for this lifecycle handling.
+
+1. Main process tracks terminal stream pause reasons from Electron `powerMonitor` events.
+   `lock-screen` adds a screen-lock pause reason and `suspend` adds a system-suspend pause reason.
+2. `unlock-screen` clears only the screen-lock reason. `resume` clears only the system-suspend
+   reason. If both reasons are active, terminal streams resume only after both have cleared.
+3. On the first transition into paused state, main broadcasts `terminal-stream:state` and closes
+   current terminal WebSocket clients. PTY processes keep running.
+4. While paused, `TerminalInstance` cancels pending reconnect timers and does not create a new
+   WebSocket. It also clears transient reconnect status so the UI does not remain stuck on a stale
+   reconnecting state.
+5. When the effective pause state clears, visible terminal panes reconnect and request missed
+   history through their existing offset.
+6. If Electron emits `resume` without a prior tracked `suspend`, Canopy still force-closes terminal
+   WebSocket clients to preserve the defensive wake behavior for stale connections.
+
 ### Scrollback and history
 
 The WsBridge maintains a circular buffer of up to 1 MB of PTY output per session. When a new WebSocket client connects (or reconnects), it receives history from the requested offset. xterm.js maintains a separate scrollback buffer of 5000 lines.
+
+Replayed or bursty output is flushed to xterm in bounded chunks on animation frames instead of
+writing an entire backlog in one frame. This keeps the renderer responsive after long lock/unlock
+or wake intervals where terminal output accumulated in the bridge history.
 
 ### Terminal resize
 
@@ -150,11 +175,13 @@ Every PTY session inherits the user's login environment (resolved via `getLoginE
 | -------------------------- | --------------------------------------- | ------------------------------------------- |
 | WebSocket disconnected     | "reconnecting" overlay on terminal      | WebSocket server or PTY process crashed     |
 | WebSocket permanently lost | "disconnected" overlay                  | 30 consecutive reconnect attempts failed    |
+| Terminal stream paused     | No error state; reconnect status clears | Screen is locked or system is suspended     |
 | WebGL context loss         | Transparent fallback to canvas renderer | GPU driver issue or resource pressure       |
 | PTY spawn failure          | Tab fails to open                       | Shell binary not found or permission denied |
 
 ## Source files
 
+- Power lifecycle handling: `src/main/index.ts`
 - PTY manager: `src/main/pty/PtyManager.ts`
 - Tmux manager: `src/main/pty/TmuxManager.ts`
 - WebSocket bridge: `src/main/pty/WsBridge.ts`
@@ -162,4 +189,17 @@ Every PTY session inherits the user's login environment (resolved via `getLoginE
 - Connection state: `src/renderer/src/lib/terminal/connectionState.svelte.ts`
 - Themes: `src/renderer/src/lib/terminal/themes.ts`
 - Tab management: `src/renderer/src/lib/stores/tabs.svelte.ts`
-- Preload (PTY/Tmux API): `src/preload/index.ts`
+- Preload (PTY/Tmux API and terminal stream state): `src/preload/index.ts`
+
+## IPC channels
+
+| Channel | Direction | Purpose |
+| --- | --- | --- |
+| `pty:resize` | Renderer invoke | Resize a PTY after xterm fit changes. |
+| `pty:kill` | Renderer invoke | Terminate a PTY session, optionally killing the tmux session. |
+| `pty:write` | Renderer invoke | Write user input to the PTY. |
+| `pty:getDimensions` | Renderer invoke | Read the current PTY cols/rows. |
+| `pty:exit` | Main event | Notify renderer that a PTY exited. |
+| `pty:resized` | Main event | Broadcast PTY size changes to renderers and remote-control forwarding. |
+| `terminal-stream:getState` | Renderer invoke | Read whether terminal stream reconnects are currently paused. |
+| `terminal-stream:state` | Main event | Notify terminal panes when lock/suspend pauses or resumes stream reconnects. |

--- a/docs/core/terminal.md
+++ b/docs/core/terminal.md
@@ -58,6 +58,10 @@ Linux builds rely on `suspend`/`resume` for this lifecycle handling.
    history through their existing offset.
 6. If Electron emits `resume` without a prior tracked `suspend`, Canopy still force-closes terminal
    WebSocket clients to preserve the defensive wake behavior for stale connections.
+7. If a wake clears `suspend` but only `lock-screen` remains, main starts a 30 second watchdog.
+   A normal `unlock-screen` cancels it and resumes streams immediately; if the OS never delivers
+   `unlock-screen`, the watchdog clears the stale screen-lock pause so terminal streaming can
+   recover without restarting Canopy.
 
 ### Scrollback and history
 
@@ -201,13 +205,13 @@ Every PTY session inherits the user's login environment (resolved via `getLoginE
 
 ## IPC channels
 
-| Channel | Direction | Purpose |
-| --- | --- | --- |
-| `pty:resize` | Renderer invoke | Resize a PTY after xterm fit changes. |
-| `pty:kill` | Renderer invoke | Terminate a PTY session, optionally killing the tmux session. |
-| `pty:write` | Renderer invoke | Write user input to the PTY. |
-| `pty:getDimensions` | Renderer invoke | Read the current PTY cols/rows. |
-| `pty:exit` | Main event | Notify renderer that a PTY exited. |
-| `pty:resized` | Main event | Broadcast PTY size changes to renderers and remote-control forwarding. |
-| `terminal-stream:getState` | Renderer invoke | Read whether terminal stream reconnects are currently paused. |
-| `terminal-stream:state` | Main event | Notify terminal panes when lock/suspend pauses or resumes stream reconnects. |
+| Channel                    | Direction       | Purpose                                                                      |
+| -------------------------- | --------------- | ---------------------------------------------------------------------------- |
+| `pty:resize`               | Renderer invoke | Resize a PTY after xterm fit changes.                                        |
+| `pty:kill`                 | Renderer invoke | Terminate a PTY session, optionally killing the tmux session.                |
+| `pty:write`                | Renderer invoke | Write user input to the PTY.                                                 |
+| `pty:getDimensions`        | Renderer invoke | Read the current PTY cols/rows.                                              |
+| `pty:exit`                 | Main event      | Notify renderer that a PTY exited.                                           |
+| `pty:resized`              | Main event      | Broadcast PTY size changes to renderers and remote-control forwarding.       |
+| `terminal-stream:getState` | Renderer invoke | Read whether terminal stream reconnects are currently paused.                |
+| `terminal-stream:state`    | Main event      | Notify terminal panes when lock/suspend pauses or resumes stream reconnects. |

--- a/docs/diagnostics/perf-hud.md
+++ b/docs/diagnostics/perf-hud.md
@@ -60,12 +60,14 @@ A separate developer-only diagnostics mode is available behind the `CANOPY_PERF=
 
 ### Developer diagnostics (CANOPY_PERF=1)
 
-Launching with `CANOPY_PERF=1` enables two additional IPC endpoints exposed through the preload bridge:
+Launching with `CANOPY_PERF=1` enables additional IPC endpoints exposed through the preload bridge:
 
-| Endpoint           | Returns                                                                                                                                                                       |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `perf:diagnostics` | Object with `ptySessionCount`, `wsBridgeCount`, `agentSessionCount`, `gitWatcherCount`, `windowCount`, `uptime`, `heapUsed`, `rss`, and `marks` (performance timeline marks). |
-| `perf:ipcLog`      | Array of `{ channel, size, ts, dir }` entries logged since the last call. The log is drained on read.                                                                         |
+| Endpoint                         | Returns / effect                                                                                                                                                             |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `perf:diagnostics`               | Object with `ptySessionCount`, `wsBridgeCount`, `agentSessionCount`, `gitWatcherCount`, `windowCount`, `uptime`, `heapUsed`, `rss`, and `marks` (performance timeline marks). |
+| `perf:ipcLog`                    | Array of `{ channel, size, ts, dir }` entries logged since the last call. The log is drained on read.                                                                         |
+| `perf:disconnectTerminalClients` | Closes active terminal WebSocket clients so perf tests can measure reconnect history replay without killing PTY processes. Returns the number of clients disconnected.          |
+| `perf:openProject`               | Grants and opens an existing project path under the user's home directory for perf fixtures.                                                                                  |
 
 These endpoints are gated at the preload level: when `CANOPY_PERF` is not `'1'`, the properties are not added to the `window.api` object. The main-process IPC interceptor that records traffic is also only installed when `CANOPY_PERF=1`.
 
@@ -76,8 +78,8 @@ No user-visible errors. `app.getAppMetrics()` is a synchronous Electron API that
 ## Source files
 
 - Main: `src/main/perf/PerfHudService.ts`
-- IPC handlers: `src/main/index.ts` (`perf:hud:start`, `perf:hud:stop` near line 694; `perf:diagnostics`, `perf:ipcLog` near line 672)
-- Preload: `src/preload/index.ts` (`perfHud` object and conditional `perfDiagnostics`/`perfIpcLog`)
+- IPC handlers: `src/main/index.ts` (`perf:hud:start`, `perf:hud:stop`, `perf:diagnostics`, `perf:ipcLog`, `perf:disconnectTerminalClients`, `perf:openProject`)
+- Preload: `src/preload/index.ts` (`perfHud` object and conditional `perfDiagnostics`, `perfIpcLog`, `perfDisconnectTerminalClients`, `perfOpenProject`)
 - Store: `src/renderer/src/lib/stores/perfHud.svelte.ts`
 - Status bar: `src/renderer/src/components/layout/StatusBar.svelte`
 - Settings toggle: `src/renderer/src/components/preferences/GeneralPrefs.svelte`

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "perf:memory": "CANOPY_PERF=1 npx playwright test perf/memory-leak.ts --config perf/playwright.perf.config.ts",
     "perf:ipc": "CANOPY_PERF=1 npx playwright test perf/ipc-monitor.ts --config perf/playwright.perf.config.ts",
     "perf:renderer": "CANOPY_PERF=1 npx playwright test perf/renderer-perf.ts --config perf/playwright.perf.config.ts",
+    "perf:terminal-replay": "CANOPY_PERF=1 npx playwright test perf/terminal-replay.ts --config perf/playwright.perf.config.ts",
     "perf:cpu": "CANOPY_PERF=1 npx playwright test perf/cpu-profile.ts --config perf/playwright.perf.config.ts",
-    "perf:all": "npm run perf:startup && npm run perf:memory && npm run perf:ipc && npm run perf:renderer",
+    "perf:all": "npm run perf:startup && npm run perf:memory && npm run perf:ipc && npm run perf:renderer && npm run perf:terminal-replay",
     "_perf:note": "perf:* scripts use Unix env var syntax (macOS/Linux only)"
   },
   "dependencies": {

--- a/perf/fixtures.ts
+++ b/perf/fixtures.ts
@@ -147,6 +147,10 @@ export interface CpuProfile {
   samples: number[]
 }
 
+type SplitSnapshot =
+  | { type: 'leaf'; pane: { id: string; sessionId: string; paneType?: string; toolId: string } }
+  | { type: 'split'; first: SplitSnapshot; second: SplitSnapshot }
+
 export async function stopCPUProfile(cdp: CDPSession): Promise<CpuProfile> {
   const { profile } = await cdp.send('Profiler.stop')
   await cdp.send('Profiler.disable')
@@ -172,10 +176,26 @@ export async function takeHeapSnapshot(cdp: CDPSession): Promise<string> {
  */
 export interface BrowserApi {
   api: {
+    platform: NodeJS.Platform
     getPref: (k: string) => Promise<string | null>
+    getAppState: () => Promise<{
+      tabs: {
+        tabsByWorktree: Record<
+          string,
+          Array<{
+            id: string
+            rootSplit: SplitSnapshot
+            focusedPaneId: string
+          }>
+        >
+        activeTabIdByWorktree: Record<string, string | null>
+      }
+    }>
     perfDiagnostics: () => Promise<PerfDiagnostics | null>
     perfIpcLog: () => Promise<Array<{ channel: string; size: number; ts: number; dir: string }>>
+    perfDisconnectTerminalClients?: () => Promise<number>
     perfOpenProject?: (path: string) => Promise<void>
+    workspaceAttachProject: (path: string) => Promise<unknown>
     tabSpawnPane: (toolId: string, worktreePath: string) => Promise<{ sessionId: string }>
     writePty: (sid: string, data: string) => Promise<void>
     killPty: (sid: string) => Promise<void>

--- a/perf/terminal-replay.ts
+++ b/perf/terminal-replay.ts
@@ -1,0 +1,187 @@
+/**
+ * Terminal replay responsiveness diagnostic.
+ *
+ * Exercises a near-WsBridge-cap burst of terminal output and checks that the
+ * renderer stays responsive while xterm catches up.
+ */
+
+import { test, expect, formatMs } from './fixtures'
+import type { BrowserApi } from './fixtures'
+
+interface LongTaskEntry {
+  duration: number
+  startTime: number
+}
+
+interface ProbeStats {
+  maxLatencyMs: number
+  samples: number
+}
+
+type SplitSnapshot =
+  | { type: 'leaf'; pane: { id: string; sessionId: string; paneType?: string; toolId: string } }
+  | { type: 'split'; first: SplitSnapshot; second: SplitSnapshot }
+
+async function installLongTaskObserver(page: import('@playwright/test').Page): Promise<void> {
+  await page.evaluate(() => {
+    const w = window as unknown as {
+      __terminalReplayLongTasks?: LongTaskEntry[]
+      __terminalReplayLongTaskObserver?: PerformanceObserver
+    }
+    w.__terminalReplayLongTasks = []
+    w.__terminalReplayLongTaskObserver?.disconnect()
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        w.__terminalReplayLongTasks?.push({
+          duration: entry.duration,
+          startTime: entry.startTime,
+        })
+      }
+    })
+    observer.observe({ type: 'longtask', buffered: true })
+    w.__terminalReplayLongTaskObserver = observer
+  })
+}
+
+async function readLongTasks(page: import('@playwright/test').Page): Promise<LongTaskEntry[]> {
+  return page.evaluate(() => {
+    const w = window as unknown as { __terminalReplayLongTasks?: LongTaskEntry[] }
+    return w.__terminalReplayLongTasks ?? []
+  })
+}
+
+async function stopLongTaskObserver(page: import('@playwright/test').Page): Promise<void> {
+  await page.evaluate(() => {
+    const w = window as unknown as {
+      __terminalReplayLongTaskObserver?: PerformanceObserver
+    }
+    w.__terminalReplayLongTaskObserver?.disconnect()
+  })
+}
+
+test('near-cap terminal output replay keeps renderer responsive', async ({ page }) => {
+  const OUTPUT_BYTES = 1024 * 1024
+  const PROBE_DURATION_MS = 4_000
+  const MAX_LONG_TASK_MS = 250
+  const MAX_TOTAL_BLOCKED_MS = 2_000
+  const MAX_IPC_PROBE_MS = 500
+  const DONE_MARKER = 'CANOPY_REPLAY_DONE'
+  const worktreePath = process.cwd()
+
+  await page
+    .getByRole('button', { name: 'Skip setup' })
+    .click({ timeout: 5_000 })
+    .catch(() => {})
+  await page.waitForFunction(
+    () =>
+      !!(window as unknown as BrowserApi).api &&
+      typeof (window as unknown as BrowserApi).api.perfOpenProject === 'function',
+  )
+  await page.evaluate(
+    (path) => (window as unknown as BrowserApi).api.perfOpenProject?.(path),
+    worktreePath,
+  )
+  await page.evaluate(
+    (path) => (window as unknown as BrowserApi).api.workspaceAttachProject(path),
+    worktreePath,
+  )
+  await page.waitForTimeout(2_000)
+
+  const platform = await page.evaluate(() => (window as unknown as BrowserApi).api.platform)
+  await page.keyboard.press(platform === 'darwin' ? 'Meta+T' : 'Control+T')
+
+  const terminal = page.locator('.terminal-container .xterm').first()
+  await terminal.waitFor({ state: 'visible' })
+  const sessionId = await page.evaluate(async (worktreePath) => {
+    function findFocusedPane(
+      split: SplitSnapshot,
+      focusedPaneId: string,
+    ): { sessionId: string; paneType?: string; toolId: string } | null {
+      if (split.type === 'leaf') {
+        return split.pane.id === focusedPaneId ? split.pane : null
+      }
+      return (
+        findFocusedPane(split.first, focusedPaneId) ?? findFocusedPane(split.second, focusedPaneId)
+      )
+    }
+
+    const state = await (window as unknown as BrowserApi).api.getAppState()
+    const tabs = state.tabs.tabsByWorktree[worktreePath] ?? []
+    const activeTab =
+      tabs.find((tab) => tab.id === state.tabs.activeTabIdByWorktree[worktreePath]) ??
+      tabs[tabs.length - 1]
+    if (!activeTab) return null
+    const focusedPane = findFocusedPane(activeTab.rootSplit, activeTab.focusedPaneId)
+    return focusedPane?.sessionId ?? null
+  }, worktreePath)
+  expect(sessionId).toBeTruthy()
+
+  await page.waitForTimeout(500)
+  await installLongTaskObserver(page)
+
+  const disconnectedClients = await page.evaluate(() => {
+    const disconnect = (window as unknown as BrowserApi).api.perfDisconnectTerminalClients
+    if (!disconnect) throw new Error('CANOPY_PERF helper perfDisconnectTerminalClients is missing')
+    return disconnect()
+  })
+  expect(disconnectedClients).toBeGreaterThan(0)
+  await page.waitForTimeout(50)
+
+  const probePromise = page.evaluate(async (durationMs) => {
+    const api = (window as unknown as BrowserApi).api
+    const started = performance.now()
+    let maxLatencyMs = 0
+    let samples = 0
+    while (performance.now() - started < durationMs) {
+      const before = performance.now()
+      await api.perfDiagnostics()
+      maxLatencyMs = Math.max(maxLatencyMs, performance.now() - before)
+      samples++
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+    return { maxLatencyMs, samples } satisfies ProbeStats
+  }, PROBE_DURATION_MS)
+
+  await page.evaluate(
+    ({ sessionId, bytes, marker }) => {
+      const markerChars = marker
+        .split('')
+        .map((char) => char.charCodeAt(0))
+        .join(',')
+      const command = `node -e "process.stdout.write('x'.repeat(${bytes}) + String.fromCharCode(${markerChars}))"\n`
+      return (window as unknown as BrowserApi).api.writePty(sessionId, command)
+    },
+    { sessionId, bytes: OUTPUT_BYTES, marker: DONE_MARKER },
+  )
+
+  await page.waitForFunction(
+    ({ sessionId, marker }) =>
+      !!(window as unknown as { __canopyTerminalMarkers?: Record<string, Record<string, true>> })
+        .__canopyTerminalMarkers?.[sessionId]?.[marker],
+    { sessionId: sessionId!, marker: DONE_MARKER },
+    { timeout: PROBE_DURATION_MS },
+  )
+
+  const probeStats = await probePromise
+  const longTasks = await readLongTasks(page)
+  await stopLongTaskObserver(page)
+
+  const maxLongTask = longTasks.reduce((max, task) => Math.max(max, task.duration), 0)
+  const totalBlocked = longTasks.reduce((sum, task) => sum + task.duration, 0)
+
+  console.log('\n--- Terminal Replay Responsiveness ---')
+  console.log(`Output: ${(OUTPUT_BYTES / 1024).toFixed(0)} KiB`)
+  console.log(`Long tasks: ${longTasks.length}`)
+  console.log(`Max long task: ${formatMs(maxLongTask)}`)
+  console.log(`Total blocked: ${formatMs(totalBlocked)}`)
+  console.log(`Max IPC probe: ${formatMs(probeStats.maxLatencyMs)} (${probeStats.samples} samples)`)
+
+  expect(maxLongTask).toBeLessThanOrEqual(MAX_LONG_TASK_MS)
+  expect(totalBlocked).toBeLessThanOrEqual(MAX_TOTAL_BLOCKED_MS)
+  expect(probeStats.maxLatencyMs).toBeLessThanOrEqual(MAX_IPC_PROBE_MS)
+
+  await page.evaluate(
+    (sessionId) => (window as unknown as BrowserApi).api.killPty(sessionId),
+    sessionId,
+  )
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -874,7 +874,15 @@ app.whenReady().then(async () => {
   type TerminalStreamPauseReason = 'lock-screen' | 'suspend'
   type TerminalStreamEventReason = TerminalStreamPauseReason | 'unlock-screen' | 'resume'
 
+  const LOCK_SCREEN_RESUME_WATCHDOG_MS = 30_000
   const terminalStreamPauseReasons = new Set<TerminalStreamPauseReason>()
+  let lockScreenResumeWatchdog: ReturnType<typeof setTimeout> | null = null
+
+  const clearLockScreenResumeWatchdog = (): void => {
+    if (lockScreenResumeWatchdog === null) return
+    clearTimeout(lockScreenResumeWatchdog)
+    lockScreenResumeWatchdog = null
+  }
 
   const broadcastTerminalStreamState = (
     state: 'paused' | 'resumed',
@@ -891,6 +899,7 @@ app.whenReady().then(async () => {
   }
 
   const pauseTerminalStreams = (reason: TerminalStreamPauseReason): void => {
+    clearLockScreenResumeWatchdog()
     const wasPaused = terminalStreamPauseReasons.size > 0
     terminalStreamPauseReasons.add(reason)
     if (wasPaused) return
@@ -910,9 +919,24 @@ app.whenReady().then(async () => {
     broadcastTerminalStreamState('resumed', eventReason)
   }
 
+  const scheduleLockScreenResumeWatchdog = (): void => {
+    if (lockScreenResumeWatchdog !== null) return
+    if (terminalStreamPauseReasons.size !== 1 || !terminalStreamPauseReasons.has('lock-screen')) {
+      return
+    }
+
+    lockScreenResumeWatchdog = setTimeout(() => {
+      lockScreenResumeWatchdog = null
+      if (terminalStreamPauseReasons.size === 1 && terminalStreamPauseReasons.has('lock-screen')) {
+        resumeTerminalStreams('lock-screen', 'resume')
+      }
+    }, LOCK_SCREEN_RESUME_WATCHDOG_MS)
+  }
+
   const handlePowerResume = (): void => {
     const wasPaused = terminalStreamPauseReasons.size > 0
     resumeTerminalStreams('suspend', 'resume')
+    scheduleLockScreenResumeWatchdog()
     if (!wasPaused) {
       wsBridge.disconnectAllClients()
     }
@@ -925,7 +949,10 @@ app.whenReady().then(async () => {
 
   powerMonitor.on('lock-screen', () => pauseTerminalStreams('lock-screen'))
   powerMonitor.on('suspend', () => pauseTerminalStreams('suspend'))
-  powerMonitor.on('unlock-screen', () => resumeTerminalStreams('lock-screen', 'unlock-screen'))
+  powerMonitor.on('unlock-screen', () => {
+    clearLockScreenResumeWatchdog()
+    resumeTerminalStreams('lock-screen', 'unlock-screen')
+  })
   powerMonitor.on('resume', handlePowerResume)
 
   // Restore windows from last session

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -810,6 +810,8 @@ app.whenReady().then(async () => {
       return snapshot
     })
 
+    ipcMain.handle('perf:disconnectTerminalClients', () => wsBridge.disconnectAllClients())
+
     ipcMain.handle('perf:openProject', (event, payload: { path: string }) => {
       let resolved: string
       let home: string
@@ -869,10 +871,62 @@ app.whenReady().then(async () => {
     },
   )
 
-  // Force-close stale WebSocket clients on system wake so renderer reconnects
-  powerMonitor.on('resume', () => {
+  type TerminalStreamPauseReason = 'lock-screen' | 'suspend'
+  type TerminalStreamEventReason = TerminalStreamPauseReason | 'unlock-screen' | 'resume'
+
+  const terminalStreamPauseReasons = new Set<TerminalStreamPauseReason>()
+
+  const broadcastTerminalStreamState = (
+    state: 'paused' | 'resumed',
+    reason: TerminalStreamEventReason,
+  ): void => {
+    const payload = {
+      state,
+      reason,
+      pauseReasons: [...terminalStreamPauseReasons],
+    }
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send('terminal-stream:state', payload)
+    }
+  }
+
+  const pauseTerminalStreams = (reason: TerminalStreamPauseReason): void => {
+    const wasPaused = terminalStreamPauseReasons.size > 0
+    terminalStreamPauseReasons.add(reason)
+    if (wasPaused) return
+
+    broadcastTerminalStreamState('paused', reason)
     wsBridge.disconnectAllClients()
-  })
+  }
+
+  const resumeTerminalStreams = (
+    clearReason: TerminalStreamPauseReason,
+    eventReason: Extract<TerminalStreamEventReason, 'unlock-screen' | 'resume'>,
+  ): void => {
+    const wasPaused = terminalStreamPauseReasons.size > 0
+    terminalStreamPauseReasons.delete(clearReason)
+    if (!wasPaused || terminalStreamPauseReasons.size > 0) return
+
+    broadcastTerminalStreamState('resumed', eventReason)
+  }
+
+  const handlePowerResume = (): void => {
+    const wasPaused = terminalStreamPauseReasons.size > 0
+    resumeTerminalStreams('suspend', 'resume')
+    if (!wasPaused) {
+      wsBridge.disconnectAllClients()
+    }
+  }
+
+  ipcMain.handle('terminal-stream:getState', () => ({
+    state: terminalStreamPauseReasons.size > 0 ? ('paused' as const) : ('resumed' as const),
+    pauseReasons: [...terminalStreamPauseReasons],
+  }))
+
+  powerMonitor.on('lock-screen', () => pauseTerminalStreams('lock-screen'))
+  powerMonitor.on('suspend', () => pauseTerminalStreams('suspend'))
+  powerMonitor.on('unlock-screen', () => resumeTerminalStreams('lock-screen', 'unlock-screen'))
+  powerMonitor.on('resume', handlePowerResume)
 
   // Restore windows from last session
   const reopenPref = preferencesStore.get('reopenLastWorkspace')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -954,6 +954,7 @@ app.whenReady().then(async () => {
     resumeTerminalStreams('lock-screen', 'unlock-screen')
   })
   powerMonitor.on('resume', handlePowerResume)
+  app.on('will-quit', clearLockScreenResumeWatchdog)
 
   // Restore windows from last session
   const reopenPref = preferencesStore.get('reopenLastWorkspace')

--- a/src/main/pty/WsBridge.ts
+++ b/src/main/pty/WsBridge.ts
@@ -87,12 +87,15 @@ export class WsBridge {
   }
 
   /** Terminate all WS clients across all bridges (triggers renderer reconnection) */
-  disconnectAllClients(): void {
+  disconnectAllClients(): number {
+    let disconnected = 0
     for (const bridge of this.bridges.values()) {
       for (const client of bridge.clients) {
+        disconnected++
         client.terminate()
       }
     }
+    return disconnected
   }
 
   destroy(sessionId: string): void {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -23,6 +23,14 @@ interface PtyExitData {
   tmuxSessionName?: string
 }
 
+interface TerminalStreamStateChange {
+  state: 'paused' | 'resumed'
+  reason: 'lock-screen' | 'unlock-screen' | 'suspend' | 'resume'
+  pauseReasons: Array<'lock-screen' | 'suspend'>
+}
+
+type TerminalStreamState = Omit<TerminalStreamStateChange, 'reason'>
+
 interface TmuxSessionInfo {
   name: string
   created: number
@@ -346,6 +354,8 @@ interface CanopyAPI {
   killPty: (sessionId: string, killTmux?: boolean) => Promise<void>
   writePty: (sessionId: string, data: string) => Promise<void>
   getPtyDimensions: (sessionId: string) => Promise<{ cols: number; rows: number } | null>
+  getTerminalStreamState: () => Promise<TerminalStreamState>
+  onTerminalStreamStateChanged: (callback: (data: TerminalStreamStateChange) => void) => () => void
 
   // Tmux
   tmuxIsAvailable: () => Promise<boolean>
@@ -1107,6 +1117,7 @@ interface CanopyAPI {
     ts: number
     dir: string
   }> | null>
+  perfDisconnectTerminalClients?: () => Promise<number>
   perfOpenProject?: (path: string) => Promise<void>
 
   // Status-bar perf HUD (always present)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,6 +18,14 @@ import type {
   TabClosePreflightResult,
 } from '../main/commands/types'
 
+type TerminalStreamStateChange = {
+  state: 'paused' | 'resumed'
+  reason: 'lock-screen' | 'unlock-screen' | 'suspend' | 'resume'
+  pauseReasons: Array<'lock-screen' | 'suspend'>
+}
+
+type TerminalStreamState = Omit<TerminalStreamStateChange, 'reason'>
+
 const api = {
   // PTY
   resizePty: (sessionId: string, cols: number, rows: number) =>
@@ -31,6 +39,16 @@ const api = {
       cols: number
       rows: number
     } | null>,
+  getTerminalStreamState: () =>
+    ipcRenderer.invoke('terminal-stream:getState') as Promise<TerminalStreamState>,
+  onTerminalStreamStateChanged: (callback: (data: TerminalStreamStateChange) => void) => {
+    const handler = (_event: IpcRendererEvent, data: TerminalStreamStateChange): void =>
+      callback(data)
+    ipcRenderer.on('terminal-stream:state', handler)
+    return (): void => {
+      ipcRenderer.removeListener('terminal-stream:state', handler)
+    }
+  },
 
   // Tmux
   tmuxIsAvailable: () => ipcRenderer.invoke('tmux:isAvailable') as Promise<boolean>,
@@ -1407,6 +1425,7 @@ const api = {
     ? {
         perfDiagnostics: () => ipcRenderer.invoke('perf:diagnostics'),
         perfIpcLog: () => ipcRenderer.invoke('perf:ipcLog'),
+        perfDisconnectTerminalClients: () => ipcRenderer.invoke('perf:disconnectTerminalClients'),
         perfOpenProject: (path: string) => ipcRenderer.invoke('perf:openProject', { path }),
       }
     : {}),

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -66,9 +66,11 @@
   let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null
   let receivedChars = 0
   let startTerminal: (() => void) | null = null
+  let terminalStreamPaused = false
 
   const MAX_RECONNECT_ATTEMPTS = 30
   const MAX_RECONNECT_DELAY = 8000
+  const MAX_REPLAY_CHARS_PER_FRAME = 16_384
 
   function attachWebgl(term: Terminal): void {
     if (webglAddonRef) return
@@ -156,12 +158,24 @@
     return "'" + path.replace(/'/g, "'\\''") + "'"
   }
 
-  function scrollPreservingWrite(term: Terminal, data: string): void {
+  function recordPerfTerminalWrite(data: string): void {
+    if (!window.api.perfDiagnostics) return
+    const marker = 'CANOPY_REPLAY_DONE'
+    if (!data.includes(marker)) return
+    const w = window as unknown as {
+      __canopyTerminalMarkers?: Record<string, Record<string, true>>
+    }
+    w.__canopyTerminalMarkers ??= {}
+    w.__canopyTerminalMarkers[sessionId] ??= {}
+    w.__canopyTerminalMarkers[sessionId][marker] = true
+  }
+
+  function scrollPreservingWrite(term: Terminal, data: string, onParsed?: () => void): void {
     const buffer = term.buffer.active
     const isAtBottom = buffer.viewportY >= buffer.baseY
 
     if (isAtBottom) {
-      term.write(data)
+      term.write(data, onParsed)
     } else {
       const savedY = buffer.viewportY
       term.write(data, () => {
@@ -169,13 +183,15 @@
         if (currentY !== savedY) {
           term.scrollLines(savedY - currentY)
         }
+        onParsed?.()
       })
     }
   }
 
   function writeBurst(term: Terminal, data: string): void {
+    const recordParsed = (): void => recordPerfTerminalWrite(data)
     if (!isWindows) {
-      scrollPreservingWrite(term, data)
+      scrollPreservingWrite(term, data, recordParsed)
       return
     }
     // Honor the TUI's last DECTCEM intent: if the burst itself ended with
@@ -187,7 +203,7 @@
     const tuiWantsHidden = lastDectcem?.[0].endsWith('l') ?? false
     const prefixed = cursorHiddenForBurst ? data : '\x1b[?25l' + data
     cursorHiddenForBurst = true
-    scrollPreservingWrite(term, prefixed)
+    scrollPreservingWrite(term, prefixed, recordParsed)
     if (cursorRestoreTimer !== null) clearTimeout(cursorRestoreTimer)
     if (tuiWantsHidden) return
     cursorRestoreTimer = setTimeout(() => {
@@ -247,14 +263,21 @@
     writeScheduled = true
     writeRafId = requestAnimationFrame(() => {
       writeRafId = null
-      const frameData = pendingData
-      pendingData = ''
       writeScheduled = false
+      if (disposed || !pendingData) return
+
+      const frameData =
+        pendingData.length > MAX_REPLAY_CHARS_PER_FRAME
+          ? pendingData.slice(0, MAX_REPLAY_CHARS_PER_FRAME)
+          : pendingData
+      pendingData = pendingData.slice(frameData.length)
       writeBurst(term, frameData)
+      flushPendingData(term)
     })
   }
 
   function scheduleReconnect(term: Terminal): void {
+    if (terminalStreamPaused) return
     if (reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
       setConnectionStatus(sessionId, 'disconnected')
       return
@@ -265,13 +288,13 @@
     const delay = Math.min(500 * Math.pow(2, reconnectAttempt), MAX_RECONNECT_DELAY)
     reconnectAttempt++
     reconnectTimer = setTimeout(() => {
-      if (disposed) return
+      if (disposed || terminalStreamPaused) return
       connectWs(term)
     }, delay)
   }
 
   function connectWs(term: Terminal): void {
-    if (disposed) return
+    if (disposed || terminalStreamPaused) return
     if (
       wsRef &&
       (wsRef.readyState === WebSocket.OPEN || wsRef.readyState === WebSocket.CONNECTING)
@@ -285,9 +308,7 @@
     wsRef = ws
 
     ws.onopen = (): void => {
-      if (reconnectAttempt > 0) {
-        clearConnectionStatus(sessionId)
-      }
+      clearConnectionStatus(sessionId)
       reconnectAttempt = 0
     }
 
@@ -299,21 +320,13 @@
       // `visible` let pendingData accumulate while hidden and replay after
       // show; with a bounded cap the head got truncated and deltas were
       // applied to a stale buffer (overlapping / row-shifted TUI output).
-      if (!writeScheduled) {
-        writeScheduled = true
-        writeRafId = requestAnimationFrame(() => {
-          writeRafId = null
-          const frameData = pendingData
-          pendingData = ''
-          writeScheduled = false
-          writeBurst(term, frameData)
-        })
-      }
+      flushPendingData(term)
     }
 
     ws.onclose = (): void => {
       if (disposed) return
       wsRef = null
+      if (terminalStreamPaused) return
       scheduleReconnect(term)
     }
 
@@ -409,6 +422,34 @@
     let keystrokeHandler: ((e: KeyboardEvent) => void) | null = null
     let reclaimPtyHandler: (() => void) | null = null
     let reclaimTextarea: HTMLTextAreaElement | null = null
+    let cleanupTerminalStreamState: (() => void) | null = null
+
+    function applyTerminalStreamState(data: {
+      state: 'paused' | 'resumed'
+      pauseReasons: Array<'lock-screen' | 'suspend'>
+    }): void {
+      terminalStreamPaused = data.state === 'paused' || data.pauseReasons.length > 0
+      if (terminalStreamPaused) {
+        disconnectWs({ suppressStatus: true })
+        clearConnectionStatus(sessionId)
+        return
+      }
+      if (visible && termRef) {
+        connectWs(termRef)
+        flushPendingData(termRef)
+      }
+    }
+
+    cleanupTerminalStreamState = window.api.onTerminalStreamStateChanged((data) => {
+      applyTerminalStreamState(data)
+    })
+
+    void window.api
+      .getTerminalStreamState()
+      .then((data) => {
+        if (!disposed) applyTerminalStreamState(data)
+      })
+      .catch(() => {})
 
     function initTerminal(): void {
       if (disposed) return
@@ -673,6 +714,7 @@
       startTerminal = null
       cleanupSession(sessionId)
       cleanupKeystrokeSession(sessionId)
+      cleanupTerminalStreamState?.()
       if (keystrokeHandler) containerEl.removeEventListener('keydown', keystrokeHandler, true)
       if (reclaimPtyHandler) {
         containerEl.removeEventListener('pointerdown', reclaimPtyHandler)

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -161,13 +161,18 @@
   function recordPerfTerminalWrite(data: string): void {
     if (!window.api.perfDiagnostics) return
     const marker = 'CANOPY_REPLAY_DONE'
-    if (!data.includes(marker)) return
     const w = window as unknown as {
       __canopyTerminalMarkers?: Record<string, Record<string, true>>
+      __canopyTerminalTail?: Record<string, string>
     }
-    w.__canopyTerminalMarkers ??= {}
-    w.__canopyTerminalMarkers[sessionId] ??= {}
-    w.__canopyTerminalMarkers[sessionId][marker] = true
+    w.__canopyTerminalTail ??= {}
+    const combined = (w.__canopyTerminalTail[sessionId] ?? '') + data
+    if (combined.includes(marker)) {
+      w.__canopyTerminalMarkers ??= {}
+      w.__canopyTerminalMarkers[sessionId] ??= {}
+      w.__canopyTerminalMarkers[sessionId][marker] = true
+    }
+    w.__canopyTerminalTail[sessionId] = combined.slice(-(marker.length - 1))
   }
 
   function scrollPreservingWrite(term: Terminal, data: string, onParsed?: () => void): void {

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -266,10 +266,11 @@
       writeScheduled = false
       if (disposed || !pendingData) return
 
-      const frameData =
-        pendingData.length > MAX_REPLAY_CHARS_PER_FRAME
-          ? pendingData.slice(0, MAX_REPLAY_CHARS_PER_FRAME)
-          : pendingData
+      let cut = MAX_REPLAY_CHARS_PER_FRAME
+      const lastCode = pendingData.charCodeAt(cut - 1)
+      if (lastCode >= 0xd800 && lastCode <= 0xdbff) cut -= 1
+
+      const frameData = pendingData.length > cut ? pendingData.slice(0, cut) : pendingData
       pendingData = pendingData.slice(frameData.length)
       writeBurst(term, frameData)
       flushPendingData(term)
@@ -423,6 +424,7 @@
     let reclaimPtyHandler: (() => void) | null = null
     let reclaimTextarea: HTMLTextAreaElement | null = null
     let cleanupTerminalStreamState: (() => void) | null = null
+    let sawTerminalStreamEvent = false
 
     function applyTerminalStreamState(data: {
       state: 'paused' | 'resumed'
@@ -441,13 +443,14 @@
     }
 
     cleanupTerminalStreamState = window.api.onTerminalStreamStateChanged((data) => {
+      sawTerminalStreamEvent = true
       applyTerminalStreamState(data)
     })
 
     void window.api
       .getTerminalStreamState()
       .then((data) => {
-        if (!disposed) applyTerminalStreamState(data)
+        if (!disposed && !sawTerminalStreamEvent) applyTerminalStreamState(data)
       })
       .catch(() => {})
 

--- a/src/renderer/src/lib/terminal/TerminalInstance.svelte
+++ b/src/renderer/src/lib/terminal/TerminalInstance.svelte
@@ -175,6 +175,16 @@
     w.__canopyTerminalTail[sessionId] = combined.slice(-(marker.length - 1))
   }
 
+  function cleanupPerfTerminalWriteState(): void {
+    if (!window.api.perfDiagnostics) return
+    const w = window as unknown as {
+      __canopyTerminalMarkers?: Record<string, Record<string, true>>
+      __canopyTerminalTail?: Record<string, string>
+    }
+    delete w.__canopyTerminalMarkers?.[sessionId]
+    delete w.__canopyTerminalTail?.[sessionId]
+  }
+
   function scrollPreservingWrite(term: Terminal, data: string, onParsed?: () => void): void {
     const buffer = term.buffer.active
     const isAtBottom = buffer.viewportY >= buffer.baseY
@@ -723,6 +733,7 @@
       cleanupSession(sessionId)
       cleanupKeystrokeSession(sessionId)
       cleanupTerminalStreamState?.()
+      cleanupPerfTerminalWriteState()
       if (keystrokeHandler) containerEl.removeEventListener('keydown', keystrokeHandler, true)
       if (reclaimPtyHandler) {
         containerEl.removeEventListener('pointerdown', reclaimPtyHandler)


### PR DESCRIPTION
## What

Pauses terminal stream reconnects while the OS session is locked or suspended, then resumes visible terminal panes after unlock/wake. Replayed terminal output is now flushed to xterm in bounded animation-frame chunks to keep the renderer responsive.

## Why

Users reported that after locking macOS overnight and unlocking the next day, Canopy could freeze while terminal output replayed rapidly. This keeps PTY processes alive but prevents Chromium/xterm from processing a large replay burst in one blocking frame.

## How to test

1. Run `npm run build`.
2. Run `npm run lint`.
3. Run `npm run perf:terminal-replay`.
4. On macOS, open a terminal pane, leave output-producing work running, lock the screen, then unlock and verify Canopy reconnects without a long UI freeze.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [ ] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly
- [x] Feature docs in `docs/` updated (behavior, config, errors, security — if any changed)