### PR TITLE
fix: disable windows child process polling

### DIFF
--- a/docs/core/terminal.md
+++ b/docs/core/terminal.md
@@ -4,7 +4,8 @@
 
 **Status:** Stable
 **Introduced:** v0.1.0
-**Platforms:** All (macOS, Linux, Windows)
+**Platforms:** All (macOS, Linux, Windows). Shell child-process close warnings are
+macOS/Linux-only; Windows still shows AI agent-busy close warnings.
 
 ## Overview
 
@@ -64,7 +65,9 @@ macOS and Linux are unaffected — `writeBurst` falls through to a plain scroll-
 In split layouts, each pane shows a strip above the pane body with the pane title and actions:
 
 - **Detach pane to tab**: removes that pane from the current split and opens it as a new top-level tab.
-- **Close pane**: closes only that pane. If it is running processes, the same termination confirmation flow is shown before closing.
+- **Close pane**: closes only that pane. On macOS/Linux, panes with running shell child
+  processes use the same termination confirmation flow before closing. On Windows, shell panes do
+  not raise this warning; AI agent-busy warnings still apply.
 
 Clicking the strip also focuses the pane.
 
@@ -99,10 +102,15 @@ Detected URLs in terminal output are clickable. Behavior depends on the `urlOpen
 
 ### Tab close with active processes
 
-1. When a user closes a tab, the system checks whether the PTY has child processes (`pgrep -P <pid>` on Unix, `wmic` on Windows).
-2. For AI tool tabs, it checks whether the agent status is in an active state (thinking, tool calling, compacting, waiting for permission).
-3. If active processes are found, a confirmation dialog appears before the PTY is killed.
-4. On confirmation, all PTYs in the tab's split tree are killed.
+1. On macOS/Linux, when a user closes a shell tab, the system checks whether the PTY has
+   child processes with `pgrep -P <pid>`.
+2. On Windows, shell tabs do not run child-process close-warning checks because the available
+   process-tree probes are too expensive for responsive close preflights.
+3. For AI tool tabs on all platforms, it checks whether the agent status is in an active state
+   (thinking, tool calling, compacting, waiting for permission).
+4. If active shell processes on macOS/Linux or busy AI agents on any platform are found, a
+   confirmation dialog appears before the PTY is killed.
+5. On confirmation, all PTYs in the tab's split tree are killed.
 
 Closing all tabs for a worktree uses the same safety path. The renderer first aggregates active
 process warnings across tabs, then runs the unsaved-editor preflight for every open tab. If the

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1073,10 +1073,9 @@ app.on('before-quit', (event) => {
   // re-enter or tear down windows.
   persistOpenWindowConfigs()
 
-  // hasAnyActiveSession() is async (spawns `pgrep`/`wmic` per shell), but
-  // event.preventDefault() must be called synchronously. preventDefault
-  // when any tracked PTY exists, then re-decide async — if nothing is
-  // actually busy, re-enter via app.quit().
+  // hasAnyActiveSession() is async, but event.preventDefault() must be called
+  // synchronously. preventDefault when any tracked PTY exists, then re-decide
+  // async — if nothing is actually busy, re-enter via app.quit().
   if (!windowManager.isQuitting && windowManager.getAllWindows().some((w) => !w.isDestroyed())) {
     const anyTracked = windowManager.getAllWindows().some((w) => {
       const id = w.webContents.id

--- a/src/main/pty/PtyManager.ts
+++ b/src/main/pty/PtyManager.ts
@@ -180,6 +180,8 @@ export class PtyManager {
     if (!session) return Promise.resolve(false)
     // Windows process-tree probes (`wmic`, PowerShell CIM queries, etc.) are
     // too expensive for close-warning preflights and can visibly stall the app.
+    // Windows shell tabs therefore never raise running-process close warnings;
+    // agent-busy state is still checked separately by AgentSessionManager.
     if (process.platform === 'win32') return Promise.resolve(false)
 
     const pid = String(session.pty.pid)

--- a/src/main/pty/PtyManager.ts
+++ b/src/main/pty/PtyManager.ts
@@ -178,19 +178,16 @@ export class PtyManager {
   hasChildProcess(id: string): Promise<boolean> {
     const session = this.sessions.get(id)
     if (!session) return Promise.resolve(false)
+    // Windows process-tree probes (`wmic`, PowerShell CIM queries, etc.) are
+    // too expensive for close-warning preflights and can visibly stall the app.
+    if (process.platform === 'win32') return Promise.resolve(false)
+
     const pid = String(session.pty.pid)
-    const isWin = process.platform === 'win32'
-    const cmd = isWin ? 'wmic' : 'pgrep'
-    const args = isWin
-      ? ['process', 'where', `(ParentProcessId=${pid})`, 'get', 'ProcessId', '/FORMAT:CSV']
-      : ['-P', pid]
+    const cmd = 'pgrep'
+    const args = ['-P', pid]
     return new Promise<boolean>((resolve) => {
-      execFile(cmd, args, { encoding: 'utf-8', timeout: 2000 }, (err, stdout) => {
-        if (isWin) {
-          resolve(!err && stdout.trim().split('\n').length > 1)
-        } else {
-          resolve(!err)
-        }
+      execFile(cmd, args, { encoding: 'utf-8', timeout: 2000 }, (err) => {
+        resolve(!err)
       })
     })
   }


### PR DESCRIPTION
## What

Disables Windows child-process polling for PTY close-warning checks by returning `false` from `PtyManager.hasChildProcess()` on `win32`.

This prevents close-warning/session-warning paths from spawning `wmic` for non-agent tools, while preserving existing macOS/Linux behavior and AI agent busy warnings.

## Why

On Windows, launching non-AI tools can cause periodic app freezes and even brief cursor stalls. The confirmed expensive path was the Windows `wmic` process-tree probe used to decide whether to warn before closing a tab/window with a running non-agent process.

## How to test

- `npm run typecheck:node`
- `npm run build`
- On Windows:
  - launch a non-agent tool or run config
  - confirm normal interaction no longer periodically freezes
  - close the tool tab/pane and confirm no non-agent active-process warning appears
  - use close-all-tabs for the worktree and confirm it does not spawn `wmic`
  - launch an AI agent, make it busy, and confirm agent busy close warnings still appear
  - observe with Process Monitor/Task Manager that `wmic` is not spawned on tab close, pane close, close-all, window close, or app quit

## Checklist

- [x] Verified with `npm run typecheck:node`
- [x] Verified with `npm run build`
- [x] Kept Electron renderer/main/preload boundaries intact
- [x] No UI changes
- [ ] Windows manual QA completed
