### PR TITLE
fix(worktree): validate paths against configured base

### DIFF
--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -58,9 +58,24 @@ Before removing a worktree or deleting a branch, the app can check for work that
 
 ### Worktree path validation
 
-Worktrees are intentionally created OUTSIDE the workspace (default `worktrees.baseDir` is `~/canopy/worktrees`), so the strict workspace-only containment used by other create operations does not apply. Both creation (`gitWorktreeAdd`, `gitWorktreeCheckout`) and removal (`gitWorktreeRemove`) accept any absolute path that resolves under either the user's home directory or any workspace path registered to the window. System locations like `/etc` or `C:\Program Files` remain blocked.
+Worktrees are intentionally created outside the workspace by default. New worktrees must
+resolve under the user-configured `worktrees.baseDir` preference, which defaults to
+`~/canopy/worktrees`. If the user changes that base directory in Preferences, creation is
+allowed under the configured directory even when it is outside the user's home directory
+or outside the currently attached workspace.
 
-Creation paths additionally walk up to the closest existing ancestor before realpath-normalizing, so a non-existent leaf is OK; the tail is then rechecked to reject escapes via `..`. The same TOCTOU-safe pattern as `validateCreationPath` is used.
+Creation paths walk up to the closest existing ancestor before realpath-normalizing, so a
+non-existent leaf is OK. The missing tail is then reattached and checked against the
+configured base directory to reject escapes via `..` or symlinked ancestors.
+
+Removal is validated differently because existing worktrees may have been created before
+the user changed `worktrees.baseDir`, or may live in another directory that Git still
+tracks for the repository. `gitWorktreeRemove`, `worktree:prepareRemove`, and
+`worktree:removeWithBranch` only accept an absolute path that exactly matches a non-main
+worktree returned by `git worktree list --porcelain` for the target repository. The main
+worktree and the current repo root are never removable through these handlers. When
+removing and deleting a branch, the branch to delete is derived from the matched Git
+worktree record, not from renderer-supplied payload data.
 
 Worktree-scoped git operations (`diff`, `stage`, `revert`, `commit`, push preflight,
 `push`, `pull`, `fetch`, `stash`, branch listing, branch create/delete, worktree create,
@@ -95,6 +110,15 @@ The sidebar shows an aggregate status badge for each worktree that has agent ses
 
 ## Configuration
 
+### Worktree base directory
+
+Configured in Preferences under the Worktrees section. Stored globally as
+`worktrees.baseDir`.
+
+| Key                 | Default              | Description                                                                                           |
+| ------------------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
+| `worktrees.baseDir` | `~/canopy/worktrees` | Base directory under which newly created worktrees must live. `~` expands to the user's home folder. |
+
 ### Worktree setup actions
 
 Configured in Preferences under the Git section (per workspace). Stored as `workspace:<workspaceId>:worktreeSetup`.
@@ -124,7 +148,11 @@ Example configuration (JSON):
 | `InvalidRef`                         | "Invalid git ref: \<ref\>"                               | Branch name starts with `-`                                                          |
 | Path not absolute                    | "Worktree path must be absolute"                         | Renderer passed a relative path to create or remove                                  |
 | No existing ancestor                 | "Access denied: no existing ancestor"                    | Creation path walks up past the filesystem root without finding an existing ancestor |
-| Path outside allowed roots           | "Access denied: worktree path outside home or workspace" | Resolved path is not under `$HOME` or a registered workspace                         |
+| Base path escapes ancestor           | "Access denied: worktree base path escapes ancestor"     | Configured `worktrees.baseDir` escapes its closest existing ancestor                 |
+| Path outside configured base         | "Access denied: worktree path outside configured base directory" | Creation path does not resolve under `worktrees.baseDir`                      |
+| Worktree not registered              | "Access denied: worktree is not registered for this repository" | Removal path does not exactly match a Git-listed worktree for the repository   |
+| Main worktree removal                | "Access denied: cannot remove the main worktree"         | Removal path matches the repository's main worktree                                  |
+| Current repo root removal            | "Access denied: cannot remove the current repo root"     | Removal path matches the repo root passed to the IPC handler                         |
 | Repo outside attached project        | "Access denied: path outside workspace"                  | Repo/worktree path is not a strict workspace path or exact attached project path      |
 | Path escapes ancestor                | "Access denied: worktree path escapes ancestor"          | Non-existent tail of the creation path escapes its ancestor via `..` or absolute ref |
 | Setup command timeout                | "Command timed out after 5 minutes"                      | A setup action's shell command did not exit within 300 seconds                       |

--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -62,11 +62,16 @@ Worktrees are intentionally created outside the workspace by default. New worktr
 resolve under the user-configured `worktrees.baseDir` preference, which defaults to
 `~/canopy/worktrees`. If the user changes that base directory in Preferences, creation is
 allowed under the configured directory even when it is outside the user's home directory
-or outside the currently attached workspace.
+or outside the currently attached workspace, provided the base directory was selected
+through the main-process directory picker and recorded as trusted.
 
 Creation paths walk up to the closest existing ancestor before realpath-normalizing, so a
 non-existent leaf is OK. The missing tail is then reattached and checked against the
-configured base directory to reject escapes via `..` or symlinked ancestors.
+configured base directory to reject escapes via `..` or symlinked ancestors. Because the
+renderer can write ordinary preferences, the configured base is not the sole authorization
+input: creation also requires the resolved base to live under the user's home directory,
+an attached workspace, a current main-process folder-selection grant, or the persisted
+main-only trusted base recorded from such a grant.
 
 Removal is validated differently because existing worktrees may have been created before
 the user changed `worktrees.baseDir`, or may live in another directory that Git still
@@ -115,9 +120,9 @@ The sidebar shows an aggregate status badge for each worktree that has agent ses
 Configured in Preferences under the Worktrees section. Stored globally as
 `worktrees.baseDir`.
 
-| Key                 | Default              | Description                                                                                           |
-| ------------------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
-| `worktrees.baseDir` | `~/canopy/worktrees` | Base directory under which newly created worktrees must live. `~` expands to the user's home folder. |
+| Key                 | Default              | Description                                                                                                                                                        |
+| ------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `worktrees.baseDir` | `~/canopy/worktrees` | Base directory under which newly created worktrees must live. `~` expands to the user's home folder. Use the Browse button to trust a base outside home/workspace. |
 
 ### Worktree setup actions
 
@@ -141,23 +146,24 @@ Example configuration (JSON):
 
 ## Error states
 
-| Error                                | User sees                                                | Cause                                                                                |
-| ------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `GitCommandFailed` (worktree add)    | "Git worktree add failed: \<message\>"                   | Branch already checked out in another worktree, or path already exists               |
-| `GitCommandFailed` (worktree remove) | "Git worktree remove failed: \<message\>"                | Worktree has uncommitted changes and force was not set                               |
-| `InvalidRef`                         | "Invalid git ref: \<ref\>"                               | Branch name starts with `-`                                                          |
-| Path not absolute                    | "Worktree path must be absolute"                         | Renderer passed a relative path to create or remove                                  |
-| No existing ancestor                 | "Access denied: no existing ancestor"                    | Creation path walks up past the filesystem root without finding an existing ancestor |
-| Base path escapes ancestor           | "Access denied: worktree base path escapes ancestor"     | Configured `worktrees.baseDir` escapes its closest existing ancestor                 |
-| Path outside configured base         | "Access denied: worktree path outside configured base directory" | Creation path does not resolve under `worktrees.baseDir`                      |
-| Worktree not registered              | "Access denied: worktree is not registered for this repository" | Removal path does not exactly match a Git-listed worktree for the repository   |
-| Main worktree removal                | "Access denied: cannot remove the main worktree"         | Removal path matches the repository's main worktree                                  |
-| Current repo root removal            | "Access denied: cannot remove the current repo root"     | Removal path matches the repo root passed to the IPC handler                         |
-| Repo outside attached project        | "Access denied: path outside workspace"                  | Repo/worktree path is not a strict workspace path or exact attached project path      |
-| Path escapes ancestor                | "Access denied: worktree path escapes ancestor"          | Non-existent tail of the creation path escapes its ancestor via `..` or absolute ref |
-| Setup command timeout                | "Command timed out after 5 minutes"                      | A setup action's shell command did not exit within 300 seconds                       |
-| Setup command failure                | "\<label\>: Command exited with code \<N\>"              | A setup action's shell command returned non-zero                                     |
-| Setup aborted                        | "Setup aborted"                                          | User cancelled the setup while it was running                                        |
+| Error                                | User sees                                                        | Cause                                                                                                             |
+| ------------------------------------ | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `GitCommandFailed` (worktree add)    | "Git worktree add failed: \<message\>"                           | Branch already checked out in another worktree, or path already exists                                            |
+| `GitCommandFailed` (worktree remove) | "Git worktree remove failed: \<message\>"                        | Worktree has uncommitted changes and force was not set                                                            |
+| `InvalidRef`                         | "Invalid git ref: \<ref\>"                                       | Branch name starts with `-`                                                                                       |
+| Path not absolute                    | "Worktree path must be absolute"                                 | Renderer passed a relative path to create or remove                                                               |
+| No existing ancestor                 | "Access denied: no existing ancestor"                            | Creation path walks up past the filesystem root without finding an existing ancestor                              |
+| Base path escapes ancestor           | "Access denied: worktree base path escapes ancestor"             | Configured `worktrees.baseDir` escapes its closest existing ancestor                                              |
+| Base directory not trusted           | "Access denied: worktree base directory is not trusted"          | Configured `worktrees.baseDir` is outside home/workspace and was not selected through a trusted main-process flow |
+| Path outside configured base         | "Access denied: worktree path outside configured base directory" | Creation path does not resolve under `worktrees.baseDir`                                                          |
+| Worktree not registered              | "Access denied: worktree is not registered for this repository"  | Removal path does not exactly match a Git-listed worktree for the repository                                      |
+| Main worktree removal                | "Access denied: cannot remove the main worktree"                 | Removal path matches the repository's main worktree                                                               |
+| Current repo root removal            | "Access denied: cannot remove the current repo root"             | Removal path matches the repo root passed to the IPC handler                                                      |
+| Repo outside attached project        | "Access denied: path outside workspace"                          | Repo/worktree path is not a strict workspace path or exact attached project path                                  |
+| Path escapes ancestor                | "Access denied: worktree path escapes ancestor"                  | Non-existent tail of the creation path escapes its ancestor via `..` or absolute ref                              |
+| Setup command timeout                | "Command timed out after 5 minutes"                              | A setup action's shell command did not exit within 300 seconds                                                    |
+| Setup command failure                | "\<label\>: Command exited with code \<N\>"                      | A setup action's shell command returned non-zero                                                                  |
+| Setup aborted                        | "Setup aborted"                                                  | User cancelled the setup while it was running                                                                     |
 
 ## Source files
 

--- a/src/main/commands/workspaceCommands.ts
+++ b/src/main/commands/workspaceCommands.ts
@@ -195,6 +195,10 @@ export class WorkspaceCommandService {
     paths.add(targetPath)
   }
 
+  getGrantedAttachPaths(webContentsId: number): string[] {
+    return [...(this.grantedAttachPathsByWindow.get(webContentsId) ?? [])]
+  }
+
   async initGitRepo(sender: WebContents, projectPath: string): Promise<WorkspaceCommandResult> {
     this.trackSender(sender)
     const resolved = await this.deps.validatePathAccess(sender.id, projectPath)

--- a/src/main/db/PreferencesStore.ts
+++ b/src/main/db/PreferencesStore.ts
@@ -2,7 +2,12 @@ import { safeStorage } from 'electron'
 import type { Database as BetterSqlite3Database } from 'better-sqlite3'
 import type { Database } from './Database'
 
-const ENCRYPTED_KEYS = new Set(['claude.apiKey', 'gemini.apiKey', 'opencode.apiKey'])
+const ENCRYPTED_KEYS = new Set([
+  'claude.apiKey',
+  'gemini.apiKey',
+  'opencode.apiKey',
+  'worktrees.baseDir.trustedResolved',
+])
 const ENCRYPTED_KEY_PREFIXES = ['taskTracker.token.']
 
 /**
@@ -18,6 +23,7 @@ const NON_EXPORTABLE_KEYS = new Set([
   'remote.lastPort',
   'remote.trustedDevices',
   'taskTracker.migratedToGlobalConfig',
+  'worktrees.baseDir.trustedResolved',
 ])
 
 const NON_EXPORTABLE_PREFIXES = ['workspace:']

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -36,6 +36,8 @@ import { fileWatcherErrorMessage } from '../fileWatcher/errors'
 import { runWorktreeSetup } from '../worktree/WorktreeSetupRunner'
 
 const execFileAsync = promisify(execFile)
+const WORKTREE_BASE_DIR_PREF_KEY = 'worktrees.baseDir'
+const TRUSTED_WORKTREE_BASE_DIR_PREF_KEY = 'worktrees.baseDir.trustedResolved'
 
 export interface IpcCommandBridge {
   grantAttachPath(webContentsId: number, targetPath: string): void
@@ -984,6 +986,9 @@ export function registerIpcHandlers(
     if (preferencesStore.isEncrypted(payload.key)) {
       throw new Error(`Refusing to set encrypted preference key "${payload.key}" via db:prefs:set`)
     }
+    if (payload.key === WORKTREE_BASE_DIR_PREF_KEY) {
+      await updateTrustedWorktreeBaseDir(event.sender.id, payload.value)
+    }
     const previousValue = preferencesStore.get(payload.key)
     preferencesStore.set(payload.key, payload.value)
     const valueChanged = previousValue !== payload.value
@@ -1685,10 +1690,7 @@ export function registerIpcHandlers(
       payload: { repoRoot: string; path: string; branch: string; baseBranch: string },
     ) => {
       const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
-      const expanded = payload.path.startsWith('~/')
-        ? os.homedir() + payload.path.slice(1)
-        : payload.path
-      const resolvedPath = await validateWorktreeCreationPath(expanded)
+      const resolvedPath = await validateWorktreeCreationPath(event.sender.id, payload.path)
       const result = await GitRepository.worktreeAdd(
         resolvedRepo,
         resolvedPath,
@@ -1711,10 +1713,7 @@ export function registerIpcHandlers(
       },
     ) => {
       const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
-      const expanded = payload.path.startsWith('~/')
-        ? os.homedir() + payload.path.slice(1)
-        : payload.path
-      const resolvedPath = await validateWorktreeCreationPath(expanded)
+      const resolvedPath = await validateWorktreeCreationPath(event.sender.id, payload.path)
       const result = await GitRepository.worktreeAddCheckout(
         resolvedRepo,
         resolvedPath,
@@ -1729,10 +1728,7 @@ export function registerIpcHandlers(
     'worktree:create',
     async (event, payload: WorktreeCreatePayload): Promise<WorktreeCreateResult> => {
       const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
-      const expandedPath = payload.worktreePath.startsWith('~/')
-        ? os.homedir() + payload.worktreePath.slice(1)
-        : payload.worktreePath
-      const worktreePath = await validateWorktreeCreationPath(expandedPath)
+      const worktreePath = await validateWorktreeCreationPath(event.sender.id, payload.worktreePath)
 
       if (payload.mode === 'new') {
         const result = await GitRepository.worktreeAdd(
@@ -2666,22 +2662,75 @@ export function registerIpcHandlers(
   }
 
   function configuredWorktreeBaseDir(): string {
-    const configured = preferencesStore.get('worktrees.baseDir')?.trim() || '~/canopy/worktrees'
+    const configured =
+      preferencesStore.get(WORKTREE_BASE_DIR_PREF_KEY)?.trim() || '~/canopy/worktrees'
     return expandHomePath(configured)
   }
 
+  async function isTrustedWorktreeBaseDir(wcId: number, resolvedBase: string): Promise<boolean> {
+    const home = await normalizeRealpathOrInput(os.homedir())
+    if (sameOrChildPath(resolvedBase, home)) return true
+
+    const windowPaths = windowManager.getWorkspacePaths(wcId)
+    const grantedPaths = workspaceCommandService.getGrantedAttachPaths(wcId)
+    const trustedPaths = await Promise.all(
+      [...windowPaths, ...grantedPaths].map(normalizeRealpathOrInput),
+    )
+    if (trustedPaths.some((trustedPath) => sameOrChildPath(resolvedBase, trustedPath))) {
+      return true
+    }
+
+    const trustedPref = preferencesStore.get(TRUSTED_WORKTREE_BASE_DIR_PREF_KEY)
+    return trustedPref ? samePath(resolvedBase, path.normalize(trustedPref)) : false
+  }
+
+  async function updateTrustedWorktreeBaseDir(
+    wcId: number,
+    configuredValue: string,
+  ): Promise<void> {
+    const trimmed = configuredValue.trim()
+    if (!trimmed) {
+      preferencesStore.delete(TRUSTED_WORKTREE_BASE_DIR_PREF_KEY)
+      return
+    }
+
+    const expandedBase = expandHomePath(trimmed)
+    const resolvedBaseResult = await fromExternalCall(
+      resolveWithExistingAncestor(
+        expandedBase,
+        'Access denied: worktree base path escapes ancestor',
+      ),
+      () => null,
+    )
+    if (resolvedBaseResult.isErr()) {
+      preferencesStore.delete(TRUSTED_WORKTREE_BASE_DIR_PREF_KEY)
+      return
+    }
+
+    const resolvedBase = resolvedBaseResult.value
+    if (await isTrustedWorktreeBaseDir(wcId, resolvedBase)) {
+      preferencesStore.set(TRUSTED_WORKTREE_BASE_DIR_PREF_KEY, resolvedBase)
+    } else {
+      preferencesStore.delete(TRUSTED_WORKTREE_BASE_DIR_PREF_KEY)
+    }
+  }
+
   // New worktrees are created under the user-configured base directory, which
-  // may be outside the open workspace and outside the user's home directory.
+  // may be outside the open workspace only when the main process has a trusted
+  // grant for that base, such as a native directory picker selection.
   // Canonicalize both missing-path tails against their nearest existing
   // ancestors before containment checks so symlinked base directories compare
   // consistently.
-  async function validateWorktreeCreationPath(targetPath: string): Promise<string> {
+  async function validateWorktreeCreationPath(wcId: number, targetPath: string): Promise<string> {
     const expandedTarget = expandHomePath(targetPath)
     const expandedBase = configuredWorktreeBaseDir()
     const resolvedBase = await resolveWithExistingAncestor(
       expandedBase,
       'Access denied: worktree base path escapes ancestor',
     )
+    if (!(await isTrustedWorktreeBaseDir(wcId, resolvedBase))) {
+      throw new Error('Access denied: worktree base directory is not trusted')
+    }
     const resolvedTarget = await resolveWithExistingAncestor(
       expandedTarget,
       'Access denied: worktree path escapes ancestor',
@@ -3534,10 +3583,7 @@ export function registerIpcHandlers(
     'taskTracker:createWorktreeFromTask',
     async (event, payload: TaskTrackerCreateWorktreeFromTaskPayload) => {
       const repoRoot = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
-      const expandedPath = payload.worktreePath.startsWith('~/')
-        ? os.homedir() + payload.worktreePath.slice(1)
-        : payload.worktreePath
-      const worktreePath = await validateWorktreeCreationPath(expandedPath)
+      const worktreePath = await validateWorktreeCreationPath(event.sender.id, payload.worktreePath)
       const branchName = await resolveTaskTrackerBranchName({ ...payload, repoRoot })
       const result = await GitRepository.worktreeAdd(
         repoRoot,

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1688,7 +1688,7 @@ export function registerIpcHandlers(
       const expanded = payload.path.startsWith('~/')
         ? os.homedir() + payload.path.slice(1)
         : payload.path
-      const resolvedPath = await validateWorktreeCreationPath(event.sender.id, expanded)
+      const resolvedPath = await validateWorktreeCreationPath(expanded)
       const result = await GitRepository.worktreeAdd(
         resolvedRepo,
         resolvedPath,
@@ -1714,7 +1714,7 @@ export function registerIpcHandlers(
       const expanded = payload.path.startsWith('~/')
         ? os.homedir() + payload.path.slice(1)
         : payload.path
-      const resolvedPath = await validateWorktreeCreationPath(event.sender.id, expanded)
+      const resolvedPath = await validateWorktreeCreationPath(expanded)
       const result = await GitRepository.worktreeAddCheckout(
         resolvedRepo,
         resolvedPath,
@@ -1732,7 +1732,7 @@ export function registerIpcHandlers(
       const expandedPath = payload.worktreePath.startsWith('~/')
         ? os.homedir() + payload.worktreePath.slice(1)
         : payload.worktreePath
-      const worktreePath = await validateWorktreeCreationPath(event.sender.id, expandedPath)
+      const worktreePath = await validateWorktreeCreationPath(expandedPath)
 
       if (payload.mode === 'new') {
         const result = await GitRepository.worktreeAdd(
@@ -1760,8 +1760,8 @@ export function registerIpcHandlers(
     'git:worktreeRemove',
     async (event, payload: { repoRoot: string; path: string; force: boolean }) => {
       const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
-      const resolvedTarget = await validateWorktreeExistingPath(event.sender.id, payload.path)
-      const result = await GitRepository.worktreeRemove(resolvedRepo, resolvedTarget, payload.force)
+      const worktree = await validateWorktreeRemovalPath(resolvedRepo, payload.path)
+      const result = await GitRepository.worktreeRemove(resolvedRepo, worktree.path, payload.force)
       return unwrapOrThrow(result, gitErrorMessage)
     },
   )
@@ -1770,28 +1770,25 @@ export function registerIpcHandlers(
     'worktree:prepareRemove',
     async (event, payload: WorktreePrepareRemovePayload): Promise<WorktreePrepareRemoveResult> => {
       const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
-      const resolvedTarget = await validateWorktreeExistingPath(
-        event.sender.id,
-        payload.worktreePath,
-      )
-      const isDetached = payload.branch === '(detached)'
+      const worktree = await validateWorktreeRemovalPath(resolvedRepo, payload.worktreePath)
+      const hasDeletableBranch = worktree.branch !== '(detached)' && worktree.branch !== '(unknown)'
 
-      const statusResult = await GitRepository.getStatusPorcelain(resolvedRepo, resolvedTarget)
+      const statusResult = await GitRepository.getStatusPorcelain(resolvedRepo, worktree.path)
       const status = unwrapOrThrow(statusResult, gitErrorMessage)
       const hasUncommittedChanges = status.trim().length > 0
 
-      const unmergedCommits = isDetached
-        ? []
-        : unwrapOrThrow(
-            await GitRepository.getUnmergedCommits(resolvedRepo, payload.branch),
+      const unmergedCommits = hasDeletableBranch
+        ? unwrapOrThrow(
+            await GitRepository.getUnmergedCommits(resolvedRepo, worktree.branch),
             gitErrorMessage,
           )
-      const branchMerged = isDetached
-        ? false
-        : unwrapOrThrow(
-            await GitRepository.isBranchMerged(resolvedRepo, payload.branch),
+        : []
+      const branchMerged = hasDeletableBranch
+        ? unwrapOrThrow(
+            await GitRepository.isBranchMerged(resolvedRepo, worktree.branch),
             gitErrorMessage,
           )
+        : false
 
       const warnings: string[] = []
       if (hasUncommittedChanges) warnings.push('Has uncommitted changes.')
@@ -1804,7 +1801,7 @@ export function registerIpcHandlers(
         unmergedCommitCount: unmergedCommits.length,
         branchMerged,
         forceRequired: warnings.length > 0,
-        canDeleteBranch: !isDetached && branchMerged,
+        canDeleteBranch: hasDeletableBranch && branchMerged,
         warnings,
       }
     },
@@ -1852,21 +1849,18 @@ export function registerIpcHandlers(
       payload: WorktreeRemoveWithBranchPayload,
     ): Promise<WorktreeRemoveWithBranchResult> => {
       const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
-      const resolvedTarget = await validateWorktreeExistingPath(
-        event.sender.id,
-        payload.worktreePath,
-      )
+      const worktree = await validateWorktreeRemovalPath(resolvedRepo, payload.worktreePath)
       const forceOnFailure = payload.forceOnFailure ?? false
-      const shouldDeleteBranch =
-        payload.deleteBranch ?? Boolean(payload.branch && payload.branch !== '(detached)')
+      const canDeleteBranch = worktree.branch !== '(detached)' && worktree.branch !== '(unknown)'
+      const shouldDeleteBranch = payload.deleteBranch ?? canDeleteBranch
 
       let forcedWorktreeRemove = false
       try {
-        const result = await GitRepository.worktreeRemove(resolvedRepo, resolvedTarget, false)
+        const result = await GitRepository.worktreeRemove(resolvedRepo, worktree.path, false)
         unwrapOrThrow(result, gitErrorMessage)
       } catch (e) {
         if (!forceOnFailure) throw e
-        const forcedResult = await GitRepository.worktreeRemove(resolvedRepo, resolvedTarget, true)
+        const forcedResult = await GitRepository.worktreeRemove(resolvedRepo, worktree.path, true)
         unwrapOrThrow(forcedResult, gitErrorMessage)
         forcedWorktreeRemove = true
       }
@@ -1874,16 +1868,16 @@ export function registerIpcHandlers(
       let branchDeleted = false
       let forcedBranchDelete = false
       if (shouldDeleteBranch) {
-        if (!payload.branch || payload.branch === '(detached)') {
-          throw new Error('Branch name is required when deleteBranch is true')
+        if (!canDeleteBranch) {
+          throw new Error('Cannot delete branch for detached or unknown worktree')
         }
         try {
-          const result = await GitRepository.deleteBranch(resolvedRepo, payload.branch, false)
+          const result = await GitRepository.deleteBranch(resolvedRepo, worktree.branch, false)
           unwrapOrThrow(result, gitErrorMessage)
           branchDeleted = true
         } catch (e) {
           if (!forceOnFailure) throw e
-          const forcedResult = await GitRepository.deleteBranch(resolvedRepo, payload.branch, true)
+          const forcedResult = await GitRepository.deleteBranch(resolvedRepo, worktree.branch, true)
           unwrapOrThrow(forcedResult, gitErrorMessage)
           branchDeleted = true
           forcedBranchDelete = true
@@ -2633,27 +2627,18 @@ export function registerIpcHandlers(
     return finalPath
   }
 
-  // Containment check shared by worktree validators: a resolved (realpath'd)
-  // path is acceptable if it lives under the user's home directory OR any
-  // workspace path registered to this window. Windows paths compare
-  // case-insensitively to match validatePathAccess.
-  async function isUnderHomeOrWorkspace(wcId: number, resolved: string): Promise<boolean> {
-    const homeReal = await normalizeRealpathOrInput(os.homedir())
-    const allowed = windowManager.getWorkspacePaths(wcId)
-    const resolvedAllowed = await Promise.all(allowed.map(normalizeRealpathOrInput))
-    const bases = [homeReal, ...resolvedAllowed]
-    return bases.some((base) => sameOrChildPath(resolved, base))
+  function expandHomePath(targetPath: string): string {
+    if (targetPath === '~') return os.homedir()
+    if (targetPath.startsWith('~/') || targetPath.startsWith('~\\')) {
+      return path.join(os.homedir(), targetPath.slice(2))
+    }
+    return targetPath
   }
 
-  // Worktrees are intentionally created OUTSIDE the workspace by design (the
-  // default `worktrees.baseDir` pref is `~/canopy/worktrees`), so the strict
-  // workspace-only containment used by validateCreationPath wrongly blocks
-  // them — most visibly on Windows where the home dir is never a workspace
-  // ancestor. This validator applies the same TOCTOU-safe ancestor walk and
-  // escape-via-`..` rejection, but relaxes containment to "under home OR
-  // workspace", which still prevents writes to system locations like /etc or
-  // C:\Program Files while permitting the documented worktree layout.
-  async function validateWorktreeCreationPath(wcId: number, targetPath: string): Promise<string> {
+  async function resolveWithExistingAncestor(
+    targetPath: string,
+    escapeMessage: string,
+  ): Promise<string> {
     if (!path.isAbsolute(targetPath)) {
       throw new Error('Worktree path must be absolute')
     }
@@ -2672,29 +2657,81 @@ export function registerIpcHandlers(
       }
     }
     const resolvedAncestor = path.normalize(await fs.promises.realpath(ancestor))
-    if (!(await isUnderHomeOrWorkspace(wcId, resolvedAncestor))) {
-      throw new Error('Access denied: worktree path outside home or workspace')
-    }
     const finalPath = path.join(resolvedAncestor, ...tail)
     const rel = path.relative(resolvedAncestor, finalPath)
     if (rel.startsWith('..') || path.isAbsolute(rel)) {
-      throw new Error('Access denied: worktree path escapes ancestor')
+      throw new Error(escapeMessage)
     }
     return finalPath
   }
 
-  // Same relaxed containment for existing worktree paths (remove). Removing
-  // an inactive worktree under ~/canopy/worktrees would otherwise fail
-  // because only the *active* worktree is in WindowManager's allow-list.
-  async function validateWorktreeExistingPath(wcId: number, targetPath: string): Promise<string> {
+  function configuredWorktreeBaseDir(): string {
+    const configured = preferencesStore.get('worktrees.baseDir')?.trim() || '~/canopy/worktrees'
+    return expandHomePath(configured)
+  }
+
+  // New worktrees are created under the user-configured base directory, which
+  // may be outside the open workspace and outside the user's home directory.
+  // Canonicalize both missing-path tails against their nearest existing
+  // ancestors before containment checks so symlinked base directories compare
+  // consistently.
+  async function validateWorktreeCreationPath(targetPath: string): Promise<string> {
+    const expandedTarget = expandHomePath(targetPath)
+    const expandedBase = configuredWorktreeBaseDir()
+    const resolvedBase = await resolveWithExistingAncestor(
+      expandedBase,
+      'Access denied: worktree base path escapes ancestor',
+    )
+    const resolvedTarget = await resolveWithExistingAncestor(
+      expandedTarget,
+      'Access denied: worktree path escapes ancestor',
+    )
+    if (!sameOrChildPath(resolvedTarget, resolvedBase)) {
+      throw new Error('Access denied: worktree path outside configured base directory')
+    }
+    return resolvedTarget
+  }
+
+  // Removing worktrees is not tied to the current workspace or configured base:
+  // old worktrees may live anywhere the user previously chose. Keep deletion
+  // constrained by Git ownership instead, and only accept the exact path Git
+  // reports for a non-main worktree in this repository.
+  async function validateWorktreeRemovalPath(
+    resolvedRepo: string,
+    targetPath: string,
+  ): Promise<{ path: string; branch: string }> {
     if (!path.isAbsolute(targetPath)) {
       throw new Error('Worktree path must be absolute')
     }
-    const resolved = path.normalize(await fs.promises.realpath(targetPath))
-    if (!(await isUnderHomeOrWorkspace(wcId, resolved))) {
-      throw new Error('Access denied: worktree path outside home or workspace')
+    if (samePath(path.normalize(targetPath), path.normalize(resolvedRepo))) {
+      throw new Error('Access denied: cannot remove the current repo root')
     }
-    return resolved
+
+    const worktrees = unwrapOrThrow(
+      await GitRepository.listWorktrees(resolvedRepo),
+      gitErrorMessage,
+    )
+
+    const matchedWorktree = worktrees.find((worktree) =>
+      samePath(path.normalize(targetPath), path.normalize(worktree.path)),
+    )
+    if (!matchedWorktree) {
+      throw new Error('Access denied: worktree is not registered for this repository')
+    }
+    if (matchedWorktree.isMain) {
+      throw new Error('Access denied: cannot remove the main worktree')
+    }
+
+    const resolved = path.normalize(await fs.promises.realpath(targetPath))
+    const listedPath = path.normalize(await fs.promises.realpath(matchedWorktree.path))
+    if (samePath(listedPath, path.normalize(resolvedRepo))) {
+      throw new Error('Access denied: cannot remove the current repo root')
+    }
+    if (!samePath(resolved, listedPath)) {
+      throw new Error('Access denied: worktree is not registered for this repository')
+    }
+
+    return { path: resolved, branch: matchedWorktree.branch }
   }
 
   async function createFileTreeFile(webContentsId: number, filePath: string): Promise<void> {
@@ -3500,7 +3537,7 @@ export function registerIpcHandlers(
       const expandedPath = payload.worktreePath.startsWith('~/')
         ? os.homedir() + payload.worktreePath.slice(1)
         : payload.worktreePath
-      const worktreePath = await validateWorktreeCreationPath(event.sender.id, expandedPath)
+      const worktreePath = await validateWorktreeCreationPath(expandedPath)
       const branchName = await resolveTaskTrackerBranchName({ ...payload, repoRoot })
       const result = await GitRepository.worktreeAdd(
         repoRoot,

--- a/src/renderer/src/components/preferences/GitPrefs.svelte
+++ b/src/renderer/src/components/preferences/GitPrefs.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-  import { FolderGit2, Terminal, FileText, ArrowRight, Trash2, Plus } from '@lucide/svelte'
+  import {
+    FolderGit2,
+    Terminal,
+    FileText,
+    ArrowRight,
+    Trash2,
+    Plus,
+    FolderOpen,
+  } from '@lucide/svelte'
   import { prefs, setPref, getPref } from '../../lib/stores/preferences.svelte'
   import CustomRadio from '../shared/CustomRadio.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
@@ -20,6 +28,11 @@
     } else {
       setPref('worktrees.baseDir', '')
     }
+  }
+
+  async function browseWorktreesDir(): Promise<void> {
+    const selected = await window.api.openFolder(worktreesDir || undefined)
+    if (selected) updateWorktreesDir(selected)
   }
 
   interface SetupCommandAction {
@@ -118,17 +131,28 @@
       search="worktree directory base path"
       layout="stacked"
     >
-      <input
-        class="w-full px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
-        type="text"
-        name="worktreesBaseDir"
-        aria-label="Worktrees base directory"
-        value={worktreesDir}
-        oninput={(e) => updateWorktreesDir(e.currentTarget.value)}
-        placeholder="~/canopy/worktrees"
-        spellcheck="false"
-        autocomplete="off"
-      />
+      <div class="flex gap-2">
+        <input
+          class="min-w-0 flex-1 px-2.5 py-1.5 border border-border rounded-md bg-bg-input text-text text-md font-inherit outline-none focus:border-focus-ring placeholder:text-text-faint"
+          type="text"
+          name="worktreesBaseDir"
+          aria-label="Worktrees base directory"
+          value={worktreesDir}
+          oninput={(e) => updateWorktreesDir(e.currentTarget.value)}
+          placeholder="~/canopy/worktrees"
+          spellcheck="false"
+          autocomplete="off"
+        />
+        <button
+          type="button"
+          class="h-8 w-8 shrink-0 inline-flex items-center justify-center rounded-md border border-border bg-bg-input text-text-secondary hover:text-text hover:border-border-strong focus:outline-none focus:border-focus-ring"
+          title="Browse"
+          aria-label="Browse for worktrees base directory"
+          onclick={browseWorktreesDir}
+        >
+          <FolderOpen size={14} />
+        </button>
+      </div>
     </PrefsRow>
   </PrefsSection>
 


### PR DESCRIPTION
## What

Fixes worktree path authorization so new worktrees are created under the configured `worktrees.baseDir`, while removal is allowed for Git-registered non-main worktrees regardless of where they were originally created.

## Why

Users can configure the worktree base directory in Preferences, so creation should respect that setting instead of hardcoding home/workspace containment. Existing worktrees may also live outside the current configured base, so removal must validate against Git’s registered worktree list rather than reject them by location.

## How to test

1. Set Worktrees base directory in Preferences to a custom path.
2. Create a new worktree and confirm it is created under that configured base directory.
3. Try to create a worktree outside the configured base directory and confirm it is rejected.
4. Remove an existing non-main Git worktree outside the configured base directory and confirm it succeeds.
5. Try to remove the main worktree/current repo root and confirm it is rejected.
6. Run `npm run typecheck:node`, `npm run typecheck`, `npm run lint`, and `npm run build`.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default)
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [ ] Keyboard accessible (all interactive elements reachable via keyboard)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly
- [x] Feature docs in `docs/` updated (behavior, config, errors, security — if any changed)
