### PR TITLE
fix: download Electron binary in postinstall for Electron 42

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
-    "postinstall": "electron-builder install-app-deps && generate-license-file -i package.json -o THIRD-PARTY-NOTICES --overwrite",
+    "postinstall": "electron-builder install-app-deps && install-electron && generate-license-file -i package.json -o THIRD-PARTY-NOTICES --overwrite",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win",
     "build:mac": "npm run build && electron-builder --mac",


### PR DESCRIPTION
## What

Adds `install-electron` to the root `postinstall` script (between `electron-builder install-app-deps` and `generate-license-file`).

## Why

Electron 42 removed the automatic binary download from its own `postinstall`. After a fresh `npm install`, `node_modules/electron` has no `dist/` (no `path.txt`), so `electron-vite dev`/`preview` fails immediately with **`Error: Electron uninstall`** (hit during local smoke testing of #283). CI `build` doesn't surface this because it bundles without launching Electron; packaged builds fetch their own Electron via @electron/get. Only local `npm run dev` / preview need the binary in `node_modules`.

`install-electron` is the bin Electron 42 ships precisely to replicate the old download-on-install behavior.

## Checklist

- [x] `npm run postinstall` runs end-to-end (install-app-deps → install-electron → generate-license-file), exit 0
- [x] After install, `node_modules/electron/dist` + `path.txt` present → `npm run dev` launches
- [x] Only `package.json` changed (no notices/lockfile churn)