### PR TITLE
fix(taskTracker): surface underlying error when sending task to agent

### DIFF
--- a/docs/integrations/task-tracker.md
+++ b/docs/integrations/task-tracker.md
@@ -210,6 +210,8 @@ When a GitHub tracker has an empty `projectKey`, Canopy reads the git remote URL
 | `TaskContextBuildFailed`   | "Could not build the task context..."            | Task details/comments/attachments could not be fetched or formatted       |
 | `TaskContextPasteFailed`   | "Could not paste the task into the agent..."     | Target agent session rejected or lost the paste target                    |
 
+For the four statuses that carry an underlying error — `AgentStartFailed`, `TabFocusFailed`, `TaskContextBuildFailed`, and `TaskContextPasteFailed` — the banner appends that detail as `"{message} — {detail}"` (e.g. the provider, path, or agent error) so the cause is visible without DevTools. The other statuses show the generic message only.
+
 ## Security and privacy
 
 - Authentication tokens are stored via the `KeychainTokenStore`, which persists credentials in `PreferencesStore` keyed by `provider:baseUrl`. The legacy migration moves plaintext tokens from connection-specific preference keys to this store and deletes the originals.

--- a/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
+++ b/src/renderer/src/components/taskTracker/BranchCreateForm.svelte
@@ -20,6 +20,7 @@
     agentStartFailedOutcome,
     logTaskToAgentFailure,
     sendTaskToAgentContext,
+    taskToAgentUserMessage,
     type TaskToAgentOutcome,
   } from '../../lib/taskTracker/taskToAgent'
   import { safeDirName } from '../../lib/sanitize'
@@ -359,7 +360,7 @@
   ): void {
     contextSendFailed = true
     operationStatus = 'Worktree created'
-    operationError = outcome.message
+    operationError = taskToAgentUserMessage(outcome)
     logTaskToAgentFailure(outcome, metadata)
   }
 

--- a/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPickerModal.svelte
@@ -12,6 +12,7 @@
     noActiveAgentOutcome,
     sendTaskToAgentContext,
     tabFocusFailedOutcome,
+    taskToAgentUserMessage,
   } from '../../lib/taskTracker/taskToAgent'
   import BranchCreateForm from './BranchCreateForm.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
@@ -287,7 +288,7 @@
     if (!result) {
       const outcome = noActiveAgentOutcome()
       sendStatus = ''
-      sendError = outcome.message
+      sendError = taskToAgentUserMessage(outcome)
       sendingTaskKey = ''
       logTaskToAgentFailure(outcome, { taskKey: task.key, connectionId })
       return
@@ -298,7 +299,7 @@
     } catch (error) {
       const outcome = tabFocusFailedOutcome(error, result.pane.sessionId)
       sendStatus = ''
-      sendError = outcome.message
+      sendError = taskToAgentUserMessage(outcome)
       sendingTaskKey = ''
       logTaskToAgentFailure(outcome, {
         taskKey: task.key,
@@ -320,7 +321,7 @@
     sendingTaskKey = ''
     sendStatus = ''
     if (outcome.status !== 'sent') {
-      sendError = outcome.message
+      sendError = taskToAgentUserMessage(outcome)
       logTaskToAgentFailure(outcome, {
         taskKey: task.key,
         connectionId,

--- a/src/renderer/src/lib/taskTracker/taskToAgent.ts
+++ b/src/renderer/src/lib/taskTracker/taskToAgent.ts
@@ -106,6 +106,29 @@ export async function sendTaskToAgentContext(
   }
 }
 
+export function taskToAgentErrorDetail(
+  outcome: Exclude<TaskToAgentOutcome, { status: 'sent' }>,
+): string | undefined {
+  return outcome.status === 'agent-start-failed' ||
+    outcome.status === 'tab-focus-failed' ||
+    outcome.status === 'context-build-failed' ||
+    outcome.status === 'paste-failed'
+    ? outcome.errorMessage
+    : undefined
+}
+
+/**
+ * User-facing message for a failed send: the generic message plus the underlying
+ * error detail when one is available. Surfacing the detail lets users report the
+ * real cause (e.g. from the task-tracker provider) without opening DevTools.
+ */
+export function taskToAgentUserMessage(
+  outcome: Exclude<TaskToAgentOutcome, { status: 'sent' }>,
+): string {
+  const detail = taskToAgentErrorDetail(outcome)
+  return detail ? `${outcome.message} — ${detail}` : outcome.message
+}
+
 export function logTaskToAgentFailure(
   outcome: Exclude<TaskToAgentOutcome, { status: 'sent' }>,
   metadata: {

--- a/src/renderer/src/lib/taskTracker/taskToAgent.ts
+++ b/src/renderer/src/lib/taskTracker/taskToAgent.ts
@@ -141,13 +141,7 @@ export function logTaskToAgentFailure(
   console.error('Task to agent failed', {
     outcome: outcome.status,
     message: outcome.message,
-    errorMessage:
-      outcome.status === 'agent-start-failed' ||
-      outcome.status === 'tab-focus-failed' ||
-      outcome.status === 'context-build-failed' ||
-      outcome.status === 'paste-failed'
-        ? outcome.errorMessage
-        : undefined,
+    errorMessage: taskToAgentErrorDetail(outcome),
     taskKey: metadata.taskKey,
     connectionId: metadata.connectionId,
     selectedAgentId: metadata.selectedAgentId,


### PR DESCRIPTION
## What

When sending a Jira/tracker task to an agent fails, the error banner now shows the underlying error detail (`outcome.errorMessage`) inline, not just the generic message. Adds `taskToAgentUserMessage()` / `taskToAgentErrorDetail()` helpers and uses them in TaskPickerModal and BranchCreateForm.

## Why

A user reported that tracker tasks can't be sent to the agent — banners show only **`Could not build the task context`** or **`the selected agent could not be started`**. The real cause *is* already captured (`outcome.errorMessage` from the failing IPC/provider/agent call) but the UI hides it, so the failure is undiagnosable without DevTools — which the maintainers can't use here because the affected Jira integration only exists in the reporting user's environment.

Surfacing the detail turns the next field report into an actionable error string (e.g. the exact provider/path/agent error), unblocking the root-cause fix. It's also a genuine UX improvement.

This is a **diagnostic step, not the root-cause fix** — the attachment download is already `Promise.allSettled` (a failed `.md` can't throw), so the build-context failure originates earlier (path/config/provider); the surfaced detail will pinpoint which.

## Checklist

- [x] `npm run svelte-check` — 0 errors
- [x] `eslint` on changed files — clean
- [x] No change to send-flow behavior (only the displayed message)
- [ ] Root-cause fix — follow-up, pending the real error string from the reporting user