### PR TITLE
refactor(icons): finish migration off deprecated lucide-svelte

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -5768,12 +5768,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following npm package may be included in this product:
 
  - @lucide/svelte@1.21.0
- - lucide-svelte@1.0.1
 
-These packages each contain the following license:
+This package contains the following license:
 
 ISC License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "dompurify": "^3.4.11",
         "electron-updater": "^6.8.9",
         "fuzzysort": "^3.1.0",
-        "lucide-svelte": "^1.0.1",
         "marked": "^18.0.5",
         "neverthrow": "^8.2.0",
         "node-pty": "^1.1.0",
@@ -9241,15 +9240,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-svelte": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-1.0.1.tgz",
-      "integrity": "sha512-WvzZgk0pqzgda+AErLvgWxHkfg/+GgUwqKMRHvzt0IqyMdmyEDzDCk3Z+Wo/3y753oIgx8u9Q4eUbWkghFa8Jg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "svelte": "^3 || ^4 || ^5.0.0-next.42"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "dompurify": "^3.4.11",
     "electron-updater": "^6.8.9",
     "fuzzysort": "^3.1.0",
-    "lucide-svelte": "^1.0.1",
     "marked": "^18.0.5",
     "neverthrow": "^8.2.0",
     "node-pty": "^1.1.0",

--- a/src/renderer/src/components/browser/BrowserError.svelte
+++ b/src/renderer/src/components/browser/BrowserError.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RotateCw } from 'lucide-svelte'
+  import { RotateCw } from '@lucide/svelte'
 
   let {
     errorDescription,

--- a/src/renderer/src/components/browser/BrowserToolbar.svelte
+++ b/src/renderer/src/components/browser/BrowserToolbar.svelte
@@ -11,7 +11,7 @@
     X,
     Smartphone,
     Star,
-  } from 'lucide-svelte'
+  } from '@lucide/svelte'
 
   let {
     url,

--- a/src/renderer/src/components/dialogs/CrashReportDialog.svelte
+++ b/src/renderer/src/components/dialogs/CrashReportDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { TriangleAlert } from 'lucide-svelte'
+  import { TriangleAlert } from '@lucide/svelte'
   import type { CrashReportData } from '../../lib/stores/dialogs.svelte'
 
   let {

--- a/src/renderer/src/components/diff/ChangesPanel.svelte
+++ b/src/renderer/src/components/diff/ChangesPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { match } from 'ts-pattern'
-  import { RotateCw, Check, X } from 'lucide-svelte'
+  import { RotateCw, Check, X } from '@lucide/svelte'
   import { openDiffTab } from '../../lib/stores/tabs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import { confirm } from '../../lib/stores/dialogs.svelte'

--- a/src/renderer/src/components/diff/DiffPane.svelte
+++ b/src/renderer/src/components/diff/DiffPane.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
   import { match } from 'ts-pattern'
-  import { Search, RotateCw, ChevronRight, Copy } from 'lucide-svelte'
+  import { Search, RotateCw, ChevronRight, Copy } from '@lucide/svelte'
   import { getAiSessions, focusSessionByPtyId } from '../../lib/stores/tabs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import type { DiffChange, DiffFile } from '../../lib/types/diff'

--- a/src/renderer/src/components/notch/NotchNotificationRow.svelte
+++ b/src/renderer/src/components/notch/NotchNotificationRow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ShieldAlert, CircleDot, Loader, AlertTriangle, ChevronRight } from 'lucide-svelte'
+  import { ShieldAlert, CircleDot, Loader, TriangleAlert, ChevronRight } from '@lucide/svelte'
 
   interface Props {
     session: {
@@ -71,7 +71,7 @@
     {:else if isActive}
       <span class="flex animate-spin-slow motion-reduce:animate-none"><Loader size={15} /></span>
     {:else if session.status === 'error'}
-      <AlertTriangle size={15} />
+      <TriangleAlert size={15} />
     {:else}
       <CircleDot size={15} />
     {/if}

--- a/src/renderer/src/components/notch/NotchOverlay.svelte
+++ b/src/renderer/src/components/notch/NotchOverlay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
-  import { TerminalSquare, Loader, ShieldAlert, Sparkles } from 'lucide-svelte'
+  import { SquareTerminal, Loader, ShieldAlert, Sparkles } from '@lucide/svelte'
   import NotchNotificationRow from './NotchNotificationRow.svelte'
 
   interface NotchSession {
@@ -152,7 +152,7 @@
         {:else if aggregateStatus === 'waitingPermission'}
           <ShieldAlert size={15} />
         {:else}
-          <TerminalSquare size={15} />
+          <SquareTerminal size={15} />
         {/if}
       </span>
       <span

--- a/src/renderer/src/components/palette/CommandPalette.svelte
+++ b/src/renderer/src/components/palette/CommandPalette.svelte
@@ -9,7 +9,7 @@
     PanelLeft,
     Sliders,
     Terminal,
-  } from 'lucide-svelte'
+  } from '@lucide/svelte'
   import {
     workspaceState,
     toggleSidebar,

--- a/src/renderer/src/components/preferences/_partials/sectionMeta.ts
+++ b/src/renderer/src/components/preferences/_partials/sectionMeta.ts
@@ -12,7 +12,7 @@ import {
   Code,
   Braces,
   Wrench,
-  TerminalSquare,
+  SquareTerminal,
   Hammer,
   GitBranch,
   ListChecks,
@@ -95,7 +95,7 @@ export const sectionMeta: Record<string, SectionMeta> = {
     keywords: 'skills tools agents',
   },
   Terminal: {
-    icon: TerminalSquare,
+    icon: SquareTerminal,
     description: 'tmux session persistence and terminal behavior',
     keywords: 'terminal tmux mouse close detach kill ask session persistence',
   },

--- a/src/renderer/src/components/shared/Toast.svelte
+++ b/src/renderer/src/components/shared/Toast.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Globe, ExternalLink, X } from 'lucide-svelte'
+  import { Globe, ExternalLink, X } from '@lucide/svelte'
   import { toastState, dismissToast } from '../../lib/stores/toast.svelte'
   import { openTool } from '../../lib/stores/tabs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'

--- a/src/renderer/src/components/shared/ToolIcon.svelte
+++ b/src/renderer/src/components/shared/ToolIcon.svelte
@@ -5,7 +5,7 @@
     SvglGeminiLogo as GeminiLogo,
     SvglGitLogo as GitLogo,
   } from '@selemondev/svgl-svelte'
-  import { Terminal, Globe, FileText, Code } from 'lucide-svelte'
+  import { Terminal, Globe, FileText, Code } from '@lucide/svelte'
 
   let { icon, size = 14 }: { icon: string; size?: number } = $props()
 </script>

--- a/src/renderer/src/components/sidebar/ToolSection.svelte
+++ b/src/renderer/src/components/sidebar/ToolSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ChevronRight } from 'lucide-svelte'
+  import { ChevronRight } from '@lucide/svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
   import { getRunningCountByTool } from '../../lib/stores/tabs.svelte'
   import { getTools, getToolAvailability } from '../../lib/stores/tools.svelte'


### PR DESCRIPTION
## Why
`lucide-svelte` is the deprecated, unscoped package; the project already moved 49 files to the scoped `@lucide/svelte` and was left with 11 stragglers plus a redundant dependency. Finishing the migration removes the duplicate icon library (smaller install, one source of icon truth) and drops a deprecated package before it bitrots.

## What
- Switch the last 11 `.svelte` importers from `lucide-svelte` to `@lucide/svelte`.
- Remove `lucide-svelte` from `dependencies` (+ lockfile + THIRD-PARTY-NOTICES).
- Use canonical lucide v1 names for the icons renamed in the migrated files (instead of deprecated aliases):
  - `AlertTriangle` → `TriangleAlert` (NotchNotificationRow)
  - `TerminalSquare` → `SquareTerminal` (NotchOverlay)
- Review follow-up: also drop the deprecated `TerminalSquare` alias in `sectionMeta.ts` (file was already on `@lucide/svelte`) → `SquareTerminal`.

## Scope
This PR's goal is removing the `lucide-svelte` **package**. A scan found other **pre-existing** deprecated aliases in files that were already on `@lucide/svelte` and are unrelated to this migration: `Loader2`, `Filter`, `FileJson`, `FileAudio`, `FileVideo`, `CircleHelp`, `MoreHorizontal` (7 files). These are intentionally **out of scope** here and can be cleaned up in a separate `refactor(icons)` sweep to keep this PR focused.

## Checklist
- [x] All 11 importers migrated; no `from 'lucide-svelte'` left in `src/`
- [x] Renamed icons verified as valid `@lucide/svelte` exports
- [x] `lucide-svelte` removed from package.json + lockfile + THIRD-PARTY-NOTICES
- [x] Review finding (TerminalSquare in sectionMeta.ts) resolved
- [x] `npm run svelte-check` — 0 errors
- [x] `npm run build` — green (exit 0)