### PR TITLE
build(deps): group electron + native modules in one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,21 @@ updates:
     labels:
       - dependencies
     groups:
+      # Native modules are rebuilt against Electron's ABI by `install-app-deps`
+      # (postinstall). better-sqlite3 must support the Electron ABI it is rebuilt
+      # against — a version mismatch broke the build in #273. Keep Electron and the
+      # native modules in ONE PR (majors included, unlike every other group) so they
+      # are reviewed and rebuilt together, never a stray Electron major landing alone.
+      # Listed first so these three are pulled out of the catch-all `npm` group below.
+      electron-native:
+        patterns:
+          - 'electron'
+          - 'better-sqlite3'
+          - 'node-pty'
+        update-types:
+          - major
+          - minor
+          - patch
       npm:
         patterns:
           - '*'


### PR DESCRIPTION
## Why
`better-sqlite3` (and `node-pty`) are native modules rebuilt against Electron's ABI by `electron-builder install-app-deps` (postinstall). A version mismatch between Electron and better-sqlite3 broke the build in #273 (better-sqlite3 12.8.0 had no prebuild for the Electron 42 ABI). Without coupling, a Dependabot Electron major can land alone and reintroduce that break. This safeguard keeps the security-update flow intact while preventing the isolated-major failure mode (chosen over a hard `overrides` pin, which would silently block all updates incl. security patches).

## What
New `electron-native` Dependabot group on the root npm ecosystem covering `electron`, `better-sqlite3`, `node-pty`. It is the only group that **includes majors**, so an Electron major arrives in one PR alongside the native modules — reviewed and rebuilt together. The build + `install-app-deps` run pre-merge surfaces any ABI break before it merges. Listed before the catch-all `npm` group so the three packages are pulled out of it (Dependabot assigns each dep to the first matching group).

## Checklist
- [x] `electron-native` group added before the catch-all `npm` group
- [x] Group includes `major` so Electron majors never land in isolation
- [x] Human review gate + security-update flow unchanged
- [x] YAML parses; group present