### PR TITLE
fix(worktree): survive Windows file locks in create/remove lifecycle

### DIFF
--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -209,8 +209,11 @@ Example configuration (JSON):
 ## Source files
 
 - Worktree setup runner: `src/main/worktree/WorktreeSetupRunner.ts`
-- Git worktree operations: `src/main/git/GitRepository.ts` (methods `worktreeAdd`, `worktreeAddCheckout`, `worktreeRemove`, `listWorktrees`, `getUnmergedCommits`, `getStatusPorcelain`)
+- Git worktree operations: `src/main/git/GitRepository.ts` (methods `worktreeAdd`, `worktreeAddCheckout`, `worktreeRemove`, `worktreePrune`, `listWorktrees`, `getUnmergedCommits`, `getStatusPorcelain`, `hasInitializedSubmodules`, `isBranchMerged`, `branchExists`)
+- Removal failure taxonomy: `src/main/git/worktreeRemoval.ts` (`classifyWorktreeRemoveError`, `REMOVE_RETRY_DELAYS_MS`)
 - Setup action types: `src/main/db/types.ts` (`WorktreeSetupAction`, `WorktreeSetupProgress`)
+- Removal preflight/consent gate: `src/renderer/src/lib/worktrees/removalConsent.ts` (`confirmWorktreeRemoval`) and `src/renderer/src/lib/worktrees/removalGuard.ts` (`removalNeedsForceConsent`, shared with the remote host guard)
+- Remote removal RPC: `worktree.prepareRemove` / `worktree.remove` in `src/renderer-shared/rpc/methodList.ts`, handled by `src/renderer/src/lib/remote/HostRpcServer.ts` (mirrored in `mobile/src/lib/remote/protocol/rpc-methods.ts`)
 - Worktree agent status: `src/renderer/src/lib/agents/worktreeStatus.svelte.ts`
 - Agent state: `src/renderer/src/lib/agents/agentState.svelte.ts`
-- Preload (worktree API): `src/preload/index.ts` (`gitWorktreeAdd`, `gitWorktreeCheckout`, `gitWorktreeRemove`, `runWorktreeSetup`, `abortWorktreeSetup`, `onWorktreeSetupProgress`)
+- Preload (worktree API): `src/preload/index.ts` (`gitWorktreeAdd`, `gitWorktreeCheckout`, `gitWorktreeRemove`, `worktreeCreate`, `worktreePrepareRemove`, `worktreeRemoveWithBranch`, `runWorktreeSetup`, `abortWorktreeSetup`, `onWorktreeSetupProgress`)

--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -36,26 +36,34 @@ Agents (Claude, Gemini, OpenCode, Codex) can run in dedicated worktrees for isol
 ### Removing a worktree
 
 1. User removes a worktree from the sidebar or via the command palette ("Remove Current Worktree").
-2. The app may check for uncommitted changes or unmerged commits before proceeding.
-3. All tabs associated with that worktree path are closed; if the removed worktree is currently
-   selected, the selection switches to the main worktree first so no UI keeps polling a
-   disappearing path.
-4. The main process prepares the directory for deletion (Windows deletes a directory only when
-   nothing holds a handle inside it):
-   - kills every PTY whose cwd lies inside the worktree — including full process trees — and
-     waits (bounded) until the processes actually exit,
-   - stops file-tree and git watchers subscribed inside the path and waits for the native
-     unsubscribes.
+2. Preflight (`worktree:prepareRemove`) reports what a safe removal needs: uncommitted changes,
+   unmerged commits, and initialized submodules (git refuses to remove those worktrees even when
+   clean and documents `--force` as the remedy) all set `forceRequired`, so the destructive
+   confirmation runs BEFORE any teardown starts.
+3. All tabs associated with that worktree path are closed with removal semantics — PTYs are
+   tree-killed and awaited until the processes actually exit, BEFORE their session records are
+   dropped. If the removed worktree is currently selected, the selection switches to the main
+   worktree first so no UI keeps polling a disappearing path.
+4. The main process sweeps remaining holders (Windows deletes a directory only when nothing holds
+   a handle inside it): any other PTY whose cwd lies inside the worktree is tree-killed and
+   awaited, and file-tree/git watchers subscribed inside the path are stopped and awaited.
 5. `git worktree remove <path>` runs without `--force` first. On failure the error is classified:
-   - "is not a working tree" → a previous attempt already unregistered the worktree; skip to
-     cleanup instead of retrying git,
-   - lock symptoms (permission denied, directory not empty, EBUSY…) → retried with `--force` and
-     backoff (transient locks from dying processes or AV scans clear within seconds),
-   - dirty-tree refusal → retried with `--force` (only when the caller allowed forcing).
-6. After unregistration, `git worktree prune` clears stale admin records and the directory is
-   verified to be gone; remnants are deleted with `fs.rm` retries. If files are still held open
-   by another process, the result carries `leftoverPath` and the UI shows a toast instead of
-   silently leaving a ghost folder.
+   - "is not a working tree" → a previous attempt already unregistered the worktree; continue to
+     the verified cleanup instead of retrying git,
+   - broken `.git` link (a ghost left by an earlier failed removal) → git cannot verify the tree,
+     so this proceeds only with the destructive-consent flag; the — prunable — registration is
+     cleared by `git worktree prune` below,
+   - lock symptoms (permission denied, directory not empty, EBUSY…) → retried WITHOUT `--force`
+     with backoff (forcing does not bypass OS file locks; time does — transient locks from dying
+     processes or AV scans clear within seconds). When retries run out while git still owns the
+     worktree, the removal FAILS with the tree and registration intact — no fallback deletion,
+   - dirty-tree or force-required refusals (e.g. submodules) → retried with `--force` only when
+     the caller passed the destructive-consent flag.
+6. After unregistration, `git worktree prune` clears stale admin records and the absence of the
+   path is verified against `git worktree list` BEFORE any raw filesystem cleanup — if git still
+   lists it, the removal fails without touching files. Then remnants are deleted with `fs.rm`
+   retries; files still held open by another process are reported via `leftoverPath` (surfaced as
+   a toast) instead of silently leaving a ghost folder.
 7. Branch deletion (when requested) runs even if the worktree removal needed the fallback paths —
    an aborted flow no longer leaves stray branches.
 8. The git watcher updates the sidebar.

--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -35,11 +35,19 @@ Agents (Claude, Gemini, OpenCode, Codex) can run in dedicated worktrees for isol
 
 ### Removing a worktree
 
-1. User removes a worktree from the sidebar or via the command palette ("Remove Current Worktree").
-2. Preflight (`worktree:prepareRemove`) reports what a safe removal needs: uncommitted changes,
-   unmerged commits, and initialized submodules (git refuses to remove those worktrees even when
-   clean and documents `--force` as the remedy) all set `forceRequired`, so the destructive
-   confirmation runs BEFORE any teardown starts.
+1. User removes a worktree from the sidebar (worktrees list or project tree), via the command
+   palette ("Remove Current Worktree"), or remotely from the mobile app.
+2. Every entry point runs the same preflight/consent gate BEFORE any teardown. Preflight
+   (`worktree:prepareRemove`) reports what a safe removal needs: uncommitted changes, unmerged
+   commits, and initialized submodules (git refuses to remove those worktrees even when clean and
+   documents `--force` as the remedy) all set `forceRequired`:
+   - local flows share `confirmWorktreeRemoval()` — warnings appear in the confirmation, and only
+     that informed confirmation authorizes `--force`; when the preflight itself fails (ghost
+     worktree with a broken checkout) the confirmation is explicitly destructive,
+   - the mobile flow calls the `worktree.prepareRemove` RPC and shows the warnings on the device;
+     independently, the host rejects an unconsented force-required `worktree.remove` BEFORE
+     closing any tabs, so a stale or missing device-side preflight cannot destroy live host
+     context for a removal that would fail anyway.
 3. All tabs associated with that worktree path are closed with removal semantics — PTYs are
    tree-killed and awaited until the processes actually exit, BEFORE their session records are
    dropped. If the removed worktree is currently selected, the selection switches to the main

--- a/docs/core/worktree.md
+++ b/docs/core/worktree.md
@@ -35,12 +35,37 @@ Agents (Claude, Gemini, OpenCode, Codex) can run in dedicated worktrees for isol
 
 ### Removing a worktree
 
-1. User right-clicks a worktree in the sidebar and selects "Remove".
+1. User removes a worktree from the sidebar or via the command palette ("Remove Current Worktree").
 2. The app may check for uncommitted changes or unmerged commits before proceeding.
-3. Renderer calls `window.api.gitWorktreeRemove(repoRoot, path, force)`.
-4. `GitRepository.worktreeRemove()` runs `git worktree remove <path>` (with `--force` if force is true).
-5. All tabs associated with that worktree path are closed, killing their PTY sessions.
-6. The git watcher updates the sidebar.
+3. All tabs associated with that worktree path are closed; if the removed worktree is currently
+   selected, the selection switches to the main worktree first so no UI keeps polling a
+   disappearing path.
+4. The main process prepares the directory for deletion (Windows deletes a directory only when
+   nothing holds a handle inside it):
+   - kills every PTY whose cwd lies inside the worktree — including full process trees — and
+     waits (bounded) until the processes actually exit,
+   - stops file-tree and git watchers subscribed inside the path and waits for the native
+     unsubscribes.
+5. `git worktree remove <path>` runs without `--force` first. On failure the error is classified:
+   - "is not a working tree" → a previous attempt already unregistered the worktree; skip to
+     cleanup instead of retrying git,
+   - lock symptoms (permission denied, directory not empty, EBUSY…) → retried with `--force` and
+     backoff (transient locks from dying processes or AV scans clear within seconds),
+   - dirty-tree refusal → retried with `--force` (only when the caller allowed forcing).
+6. After unregistration, `git worktree prune` clears stale admin records and the directory is
+   verified to be gone; remnants are deleted with `fs.rm` retries. If files are still held open
+   by another process, the result carries `leftoverPath` and the UI shows a toast instead of
+   silently leaving a ghost folder.
+7. Branch deletion (when requested) runs even if the worktree removal needed the fallback paths —
+   an aborted flow no longer leaves stray branches.
+8. The git watcher updates the sidebar.
+
+### Creation pre-flight
+
+`worktree:create` refuses an existing non-empty target directory with a clear message BEFORE any
+git call (an empty leftover directory is removed automatically). If `git worktree add` fails
+after creating a branch (`-b`), the branch is rolled back — a failed creation no longer leaves a
+stray local branch behind.
 
 ### Checking unmerged commits
 

--- a/e2e/app-state.spec.ts
+++ b/e2e/app-state.spec.ts
@@ -1349,6 +1349,65 @@ test('main process exposes and publishes app state snapshots', async ({ electron
     expect(execSync('git branch --list CANOPY-GHOST', { cwd: tmpDir }).toString().trim()).toBe('')
   }
 
+  // Submodule force-requirement: git refuses to remove a worktree containing an
+  // initialized submodule even when clean — preflight must surface it as
+  // forceRequired so the consent dialog runs BEFORE tab teardown, and the consented
+  // removal must retry with --force.
+  const submoduleSourcePath = `${tmpDir}-submodule-source`
+  const submoduleWorktreePath = `${tmpDir}-submodule-worktree`
+  extraTmpPaths.push(submoduleSourcePath, submoduleWorktreePath)
+  execFileSync('git', ['init', submoduleSourcePath])
+  execSync('git commit --allow-empty -m init', { cwd: submoduleSourcePath })
+  execSync('git branch CANOPY-SUBMODULE HEAD', { cwd: tmpDir })
+  execFileSync('git', ['worktree', 'add', submoduleWorktreePath, 'CANOPY-SUBMODULE'], {
+    cwd: tmpDir,
+  })
+  execFileSync(
+    'git',
+    ['-c', 'protocol.file.allow=always', 'submodule', 'add', submoduleSourcePath, 'sub'],
+    { cwd: submoduleWorktreePath },
+  )
+  execSync('git commit -m "add submodule"', { cwd: submoduleWorktreePath })
+
+  const submodulePreflight = await workspacePage.evaluate(
+    ({ projectPath, worktreePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.worktreePrepareRemove({
+        repoRoot: projectPath,
+        worktreePath,
+        branch: 'CANOPY-SUBMODULE',
+      })
+    },
+    { projectPath: tmpDir, worktreePath: submoduleWorktreePath },
+  )
+  expect(submodulePreflight.forceRequired).toBe(true)
+  expect(submodulePreflight.warnings).toContain(
+    'Contains git submodules — git requires a forced removal.',
+  )
+
+  const submoduleRemoveResult = await workspacePage.evaluate(
+    ({ projectPath, worktreePath }) => {
+      const api = (window as unknown as { api: Required<AppStateApi> }).api
+      return api.worktreeRemoveWithBranch({
+        repoRoot: projectPath,
+        worktreePath,
+        branch: 'CANOPY-SUBMODULE',
+        deleteBranch: true,
+        forceOnFailure: true,
+      })
+    },
+    { projectPath: tmpDir, worktreePath: submoduleWorktreePath },
+  )
+  expect(submoduleRemoveResult.worktreeRemoved).toBe(true)
+  expect(submoduleRemoveResult.forcedWorktreeRemove).toBe(true)
+  expect(submoduleRemoveResult.branchDeleted).toBe(true)
+  await expect(
+    stat(submoduleWorktreePath).then(
+      () => true,
+      () => false,
+    ),
+  ).resolves.toBe(false)
+
   const injectedFocusResult = await workspacePage.evaluate((projectPath) => {
     const api = (window as unknown as { api: Required<AppStateApi> }).api
     if (typeof api.tabFocusSession !== 'function') {

--- a/e2e/app-state.spec.ts
+++ b/e2e/app-state.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures'
-import { execFileSync, execSync } from 'child_process'
+import { execFileSync, execSync, spawn } from 'child_process'
 import { mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
@@ -1283,6 +1283,7 @@ test('main process exposes and publishes app state snapshots', async ({ electron
     branchDeleted: true,
     forcedWorktreeRemove: false,
     forcedBranchDelete: true,
+    leftoverPath: null,
   })
   await expect(
     stat(removeWorktreePath).then(
@@ -1291,6 +1292,62 @@ test('main process exposes and publishes app state snapshots', async ({ electron
     ),
   ).resolves.toBe(false)
   expect(execSync('git branch --list CANOPY-REMOVE', { cwd: tmpDir }).toString().trim()).toBe('')
+
+  // Partial-success path: a ghost worktree (unregistered by a previous failed
+  // attempt, directory left behind) whose debris contains a file another process
+  // holds open without delete sharing. Removal must still succeed and report the
+  // surviving directory via leftoverPath instead of throwing. Windows-only: the
+  // no-share file lock has no POSIX equivalent.
+  if (process.platform === 'win32') {
+    const ghostWorktreePath = `${tmpDir}-ghost-worktree`
+    extraTmpPaths.push(ghostWorktreePath)
+    execSync('git branch CANOPY-GHOST HEAD', { cwd: tmpDir })
+    execFileSync('git', ['worktree', 'add', ghostWorktreePath, 'CANOPY-GHOST'], { cwd: tmpDir })
+    // Turn it into the ghost state observed in the field: the .git link deleted by
+    // an earlier failed removal, directory (with content) left on disk, and the —
+    // now prunable — registration still present so the removal path validates.
+    await rm(join(ghostWorktreePath, '.git'), { force: true })
+
+    const lockedFile = join(ghostWorktreePath, 'feature.txt')
+    const locker = spawn(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-Command',
+        `$f=[System.IO.File]::Open('${lockedFile.replace(/\\/g, '\\\\')}','Open','Read','None'); Start-Sleep -Seconds 60`,
+      ],
+      { stdio: 'ignore' },
+    )
+    try {
+      // Give PowerShell a moment to acquire the handle.
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+      const ghostRemoveResult = await workspacePage.evaluate(
+        ({ projectPath, worktreePath }) => {
+          const api = (window as unknown as { api: Required<AppStateApi> }).api
+          return api.worktreeRemoveWithBranch({
+            repoRoot: projectPath,
+            worktreePath,
+            branch: 'CANOPY-GHOST',
+            deleteBranch: true,
+            forceOnFailure: true,
+          })
+        },
+        { projectPath: tmpDir, worktreePath: ghostWorktreePath },
+      )
+      expect(ghostRemoveResult.worktreeRemoved).toBe(true)
+      expect(ghostRemoveResult.branchDeleted).toBe(true)
+      expect(ghostRemoveResult.leftoverPath).not.toBeNull()
+      await expect(
+        stat(ghostWorktreePath).then(
+          () => true,
+          () => false,
+        ),
+      ).resolves.toBe(true)
+    } finally {
+      locker.kill()
+    }
+    expect(execSync('git branch --list CANOPY-GHOST', { cwd: tmpDir }).toString().trim()).toBe('')
+  }
 
   const injectedFocusResult = await workspacePage.evaluate((projectPath) => {
     const api = (window as unknown as { api: Required<AppStateApi> }).api

--- a/mobile/src/components/worktrees/worktree-row.tsx
+++ b/mobile/src/components/worktrees/worktree-row.tsx
@@ -22,33 +22,50 @@ export function WorktreeRow({ worktree, repoRoot, onPress }: WorktreeRowProps): 
   const [removing, setRemoving] = useState(false)
   const canRemove = !worktree.isMain && repoRoot !== null && api !== null && !removing
 
-  const confirmRemove = (): void => {
+  const runRemove = async (force: boolean): Promise<void> => {
+    if (!api || !repoRoot) return
+    setRemoving(true)
+    try {
+      const result = await api.worktree.remove({ repoRoot, path: worktree.path, force })
+      if (result?.leftoverPath) {
+        Alert.alert(
+          'Worktree removed with leftovers',
+          `Some files are still in use by another process and were left at:\n${result.leftoverPath}`,
+        )
+      }
+    } catch (e) {
+      Alert.alert('Could not remove worktree', e instanceof Error ? e.message : String(e))
+    } finally {
+      setRemoving(false)
+    }
+  }
+
+  const confirmRemove = async (): Promise<void> => {
     if (!canRemove || !api || !repoRoot) return
-    Alert.alert('Remove worktree', `Remove "${worktree.branch}"?`, [
+    // Informed consent BEFORE the host tears anything down: the preflight reports
+    // what a safe removal needs (uncommitted changes, unmerged commits,
+    // submodules), and only an explicit confirmation authorizes --force. The host
+    // rejects an unconsented force-required removal, so a stale/failed preflight
+    // degrades safely.
+    let forceRequired = false
+    let warnings: string[] = []
+    try {
+      const preflight = await api.worktree.prepareRemove({ repoRoot, path: worktree.path })
+      forceRequired = preflight.forceRequired
+      warnings = preflight.warnings
+    } catch {
+      // Preflight unavailable (older host or broken worktree) — fall through to a
+      // plain confirmation; the host-side guard still protects the worktree.
+    }
+    const message = forceRequired
+      ? `${warnings.join('\n')}\n\nForce-remove "${worktree.branch}" anyway?`
+      : `Remove "${worktree.branch}"?`
+    Alert.alert('Remove worktree', message, [
       { text: 'Cancel', style: 'cancel' },
       {
-        text: 'Remove',
+        text: forceRequired ? 'Force remove' : 'Remove',
         style: 'destructive',
-        onPress: async () => {
-          setRemoving(true)
-          try {
-            const result = await api.worktree.remove({
-              repoRoot,
-              path: worktree.path,
-              force: false,
-            })
-            if (result?.leftoverPath) {
-              Alert.alert(
-                'Worktree removed with leftovers',
-                `Some files are still in use by another process and were left at:\n${result.leftoverPath}`,
-              )
-            }
-          } catch (e) {
-            Alert.alert('Could not remove worktree', e instanceof Error ? e.message : String(e))
-          } finally {
-            setRemoving(false)
-          }
-        },
+        onPress: () => void runRemove(forceRequired),
       },
     ])
   }

--- a/mobile/src/components/worktrees/worktree-row.tsx
+++ b/mobile/src/components/worktrees/worktree-row.tsx
@@ -44,8 +44,9 @@ export function WorktreeRow({ worktree, repoRoot, onPress }: WorktreeRowProps): 
               )
             }
           } catch (e) {
-            setRemoving(false)
             Alert.alert('Could not remove worktree', e instanceof Error ? e.message : String(e))
+          } finally {
+            setRemoving(false)
           }
         },
       },

--- a/mobile/src/components/worktrees/worktree-row.tsx
+++ b/mobile/src/components/worktrees/worktree-row.tsx
@@ -32,7 +32,17 @@ export function WorktreeRow({ worktree, repoRoot, onPress }: WorktreeRowProps): 
         onPress: async () => {
           setRemoving(true)
           try {
-            await api.worktree.remove({ repoRoot, path: worktree.path, force: false })
+            const result = await api.worktree.remove({
+              repoRoot,
+              path: worktree.path,
+              force: false,
+            })
+            if (result?.leftoverPath) {
+              Alert.alert(
+                'Worktree removed with leftovers',
+                `Some files are still in use by another process and were left at:\n${result.leftoverPath}`,
+              )
+            }
           } catch (e) {
             setRemoving(false)
             Alert.alert('Could not remove worktree', e instanceof Error ? e.message : String(e))

--- a/mobile/src/components/worktrees/worktree-row.tsx
+++ b/mobile/src/components/worktrees/worktree-row.tsx
@@ -47,15 +47,20 @@ export function WorktreeRow({ worktree, repoRoot, onPress }: WorktreeRowProps): 
     // submodules), and only an explicit confirmation authorizes --force. The host
     // rejects an unconsented force-required removal, so a stale/failed preflight
     // degrades safely.
-    let forceRequired = false
+    let forceRequired = true
     let warnings: string[] = []
     try {
       const preflight = await api.worktree.prepareRemove({ repoRoot, path: worktree.path })
       forceRequired = preflight.forceRequired
       warnings = preflight.warnings
     } catch {
-      // Preflight unavailable (older host or broken worktree) — fall through to a
-      // plain confirmation; the host-side guard still protects the worktree.
+      // Preflight unavailable (older host or broken/ghost worktree) — mirror the
+      // desktop confirmWorktreeRemoval() contract and fail CLOSED: warn that the
+      // state cannot be verified and send force only after destructive consent
+      // (the host guard rejects an unconsented removal anyway).
+      warnings = [
+        'The worktree state could not be verified (broken checkout or older host) — files inside may include unsaved work.',
+      ]
     }
     const message = forceRequired
       ? `${warnings.join('\n')}\n\nForce-remove "${worktree.branch}" anyway?`

--- a/mobile/src/lib/remote/RemoteApi.ts
+++ b/mobile/src/lib/remote/RemoteApi.ts
@@ -50,7 +50,9 @@ export interface RemoteApi {
   worktree: {
     add: (args: RpcMethods['worktree.add']['params']) => Promise<void>
     addCheckout: (args: RpcMethods['worktree.addCheckout']['params']) => Promise<void>
-    remove: (args: RpcMethods['worktree.remove']['params']) => Promise<void>
+    remove: (
+      args: RpcMethods['worktree.remove']['params'],
+    ) => Promise<RpcMethods['worktree.remove']['result']>
   }
   project: {
     attach: (path: string) => Promise<void>

--- a/mobile/src/lib/remote/RemoteApi.ts
+++ b/mobile/src/lib/remote/RemoteApi.ts
@@ -53,6 +53,9 @@ export interface RemoteApi {
     remove: (
       args: RpcMethods['worktree.remove']['params'],
     ) => Promise<RpcMethods['worktree.remove']['result']>
+    prepareRemove: (
+      args: RpcMethods['worktree.prepareRemove']['params'],
+    ) => Promise<RpcMethods['worktree.prepareRemove']['result']>
   }
   project: {
     attach: (path: string) => Promise<void>
@@ -102,6 +105,7 @@ export function createRemoteApi(rpc: DataChannelRpc): RemoteApi {
       add: (args) => client.call('worktree.add', args),
       addCheckout: (args) => client.call('worktree.addCheckout', args),
       remove: (args) => client.call('worktree.remove', args),
+      prepareRemove: (args) => client.call('worktree.prepareRemove', args),
     },
     project: {
       attach: (path) => client.call('project.attach', { path }),

--- a/mobile/src/lib/remote/protocol/rpc-methods.ts
+++ b/mobile/src/lib/remote/protocol/rpc-methods.ts
@@ -110,7 +110,8 @@ export interface RpcMethods {
   }
   'worktree.remove': {
     params: { repoRoot: string; path: string; force: boolean }
-    result: void
+    /** leftoverPath is set when some files could not be deleted (still held open). */
+    result: { leftoverPath: string | null }
   }
   'project.attach': {
     params: { path: string }

--- a/mobile/src/lib/remote/protocol/rpc-methods.ts
+++ b/mobile/src/lib/remote/protocol/rpc-methods.ts
@@ -113,6 +113,18 @@ export interface RpcMethods {
     /** leftoverPath is set when some files could not be deleted (still held open). */
     result: { leftoverPath: string | null }
   }
+  /** Read-only removal preflight — collect informed force consent BEFORE worktree.remove. */
+  'worktree.prepareRemove': {
+    params: { repoRoot: string; path: string }
+    result: {
+      hasUncommittedChanges: boolean
+      unmergedCommitCount: number
+      branchMerged: boolean
+      forceRequired: boolean
+      canDeleteBranch: boolean
+      warnings: string[]
+    }
+  }
   'project.attach': {
     params: { path: string }
     result: void

--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -363,6 +363,39 @@ export class WindowManager {
     watchers.clear()
   }
 
+  /**
+   * Stop every watcher (any window) holding native directory handles inside
+   * `dirPath` and wait for the unsubscribes to complete. On Windows a live
+   * ReadDirectoryChangesW handle blocks directory deletion, so worktree removal
+   * must tear these down BEFORE `git worktree remove` — the renderer re-arms its
+   * watchers when the selection settles afterwards.
+   */
+  async disposeWatchersUnderPathAndWait(dirPath: string): Promise<void> {
+    const base = comparableWorkspacePath(dirPath).replace(/\/+$/, '')
+    const prefix = `${base}/`
+    const inside = (p: string): boolean => {
+      const c = comparableWorkspacePath(p)
+      return c === base || c.startsWith(prefix)
+    }
+
+    const waits: Promise<unknown>[] = []
+    for (const watchers of this.gitWatchers.values()) {
+      for (const [key, gitWatcher] of [...watchers]) {
+        if (inside(gitWatcher.root)) {
+          waits.push(gitWatcher.stop())
+          watchers.delete(key)
+        }
+      }
+    }
+    for (const [wcId, fileWatcher] of [...this.fileWatchers]) {
+      if (inside(fileWatcher.root)) {
+        waits.push(fileWatcher.stop().unwrapOr(undefined))
+        this.fileWatchers.delete(wcId)
+      }
+    }
+    await Promise.all(waits)
+  }
+
   setFileWatcher(wcId: number, watcher: FileTreeWatcher): void {
     this.fileWatchers.set(wcId, watcher)
   }

--- a/src/main/commands/tabCommands.ts
+++ b/src/main/commands/tabCommands.ts
@@ -257,7 +257,11 @@ export class ToolSessionService {
     return { sessionId: session.id, wsUrl: '' }
   }
 
-  async killPty(sessionId: string, killTmux?: boolean): Promise<void> {
+  async killPty(
+    sessionId: string,
+    killTmux?: boolean,
+    options?: { treeWait?: boolean },
+  ): Promise<void> {
     const tmuxName = this.deps.ptyManager.getTmuxSessionName(sessionId)
     this.deps.terminalStreamService.destroy(sessionId)
     if (killTmux && tmuxName && TmuxManagerStatics.isCanopySession(tmuxName)) {
@@ -267,7 +271,13 @@ export class ToolSessionService {
         // Session may already be gone.
       }
     }
-    this.deps.ptyManager.kill(sessionId)
+    if (options?.treeWait) {
+      // Removal flow: the session record must survive until the whole process tree
+      // is dead, or the directory being deleted still holds live cwd handles.
+      await this.deps.ptyManager.killAndWait(sessionId)
+    } else {
+      this.deps.ptyManager.kill(sessionId)
+    }
   }
 
   isAgentTool(toolId: string): boolean {
@@ -500,7 +510,11 @@ interface ClosePanePayload extends TabCommandPayloadBase {
   paneId: string
 }
 
-interface CloseAllForWorktreePayload extends TabCommandPayloadBase {}
+interface CloseAllForWorktreePayload extends TabCommandPayloadBase {
+  /** Worktree-removal variant: tree-kill PTYs and WAIT for process exit so the
+   *  directory holds no live cwd/file handles when `git worktree remove` runs. */
+  forRemoval?: boolean
+}
 
 interface ReopenClosedTabPayload extends TabCommandPayloadBase {
   options?: {
@@ -2516,6 +2530,7 @@ export class TabCommandService {
     await this.cleanupPanes(
       sender,
       tabs.flatMap((tab) => allPaneSnapshots(tab.rootSplit)),
+      { treeWait: payload.forRemoval === true },
     )
 
     try {
@@ -3733,7 +3748,11 @@ export class TabCommandService {
     }
   }
 
-  private async cleanupPanes(sender: WebContents, panes: PaneSnapshot[]): Promise<void> {
+  private async cleanupPanes(
+    sender: WebContents,
+    panes: PaneSnapshot[],
+    options?: { treeWait?: boolean },
+  ): Promise<void> {
     await Promise.all(
       panes.map(async (pane) => {
         if (
@@ -3754,7 +3773,7 @@ export class TabCommandService {
           if (this.deps.toolSessions.isAgentTool(pane.toolId)) {
             this.deps.toolSessions.destroyAgentSession(pane.sessionId)
           }
-          await this.deps.toolSessions.killPty(pane.sessionId, !!pane.tmuxSessionName)
+          await this.deps.toolSessions.killPty(pane.sessionId, !!pane.tmuxSessionName, options)
         }
       }),
     )

--- a/src/main/fileWatcher/FileTreeWatcher.ts
+++ b/src/main/fileWatcher/FileTreeWatcher.ts
@@ -59,12 +59,26 @@ export class FileTreeWatcher {
     private readonly onChange: (events: FileChangeEvent[]) => void,
   ) {}
 
+  /** Directory this watcher holds native handles on (worktree removal must stop it first). */
+  get root(): string {
+    return this.repoRoot
+  }
+
   start(): ResultAsync<void, FileWatcherError> {
     if (this.subscription) return okAsync(undefined)
 
     return fromExternalCall(
       watcher.subscribe(this.repoRoot, this.handleEvents, {
         ignore: [...SAFETY_IGNORE_PATTERNS],
+        // Pin the native OS backend. Without this @parcel/watcher probes for a
+        // `watchman` binary at startup, printing a noisy "'watchman' is not
+        // recognized..." error to stderr on every launch on Windows.
+        backend:
+          process.platform === 'win32'
+            ? 'windows'
+            : process.platform === 'darwin'
+              ? 'fs-events'
+              : 'inotify',
       }),
       (e): FileWatcherError => ({
         _tag: 'WatchStartFailed',

--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -449,6 +449,20 @@ export class GitRepository {
     })
   }
 
+  /**
+   * True when the worktree contains at least one initialized (populated) submodule.
+   * Git refuses `worktree remove` for such worktrees even when clean and documents
+   * --force as the remedy — preflights must surface this as a force requirement
+   * BEFORE any teardown starts. Uninitialized submodules (status lines starting
+   * with '-') don't block removal.
+   */
+  static hasInitializedSubmodules(worktreePath: string): ResultAsync<boolean, GitError> {
+    const git = simpleGit(worktreePath)
+    return gitCall('submodule status', git.raw(['submodule', 'status'])).map((raw) =>
+      raw.split('\n').some((line) => line.trim().length > 0 && !line.trimStart().startsWith('-')),
+    )
+  }
+
   /** Drop stale worktree registrations whose directories are gone. */
   static worktreePrune(repoRoot: string): ResultAsync<void, GitError> {
     const git = simpleGit(repoRoot)

--- a/src/main/git/GitRepository.ts
+++ b/src/main/git/GitRepository.ts
@@ -1,4 +1,4 @@
-import { ok, err, okAsync, type Result, type ResultAsync } from 'neverthrow'
+import { ok, err, okAsync, errAsync, type Result, type ResultAsync } from 'neverthrow'
 import simpleGit from 'simple-git'
 import { readFileSync, statSync } from 'fs'
 import { join } from 'path'
@@ -159,10 +159,19 @@ export class GitRepository {
 
   static getBranch(repoRoot: string): ResultAsync<string | null, GitError> {
     const git = simpleGit(repoRoot)
-    return gitCall('rev-parse', git.revparse(['--abbrev-ref', 'HEAD'])).map((raw) => {
-      const branch = raw.trim()
-      return branch === 'HEAD' ? null : branch
-    })
+    return gitCall('rev-parse', git.revparse(['--abbrev-ref', 'HEAD']))
+      .map((raw) => {
+        const branch = raw.trim()
+        return branch === 'HEAD' ? null : branch
+      })
+      .orElse((e) => {
+        // A repository with no commits yet has an unborn HEAD — rev-parse fails with
+        // "ambiguous argument 'HEAD'". That is a legitimate repo state, not an error.
+        if (e._tag === 'GitCommandFailed' && /ambiguous argument 'HEAD'/.test(e.message)) {
+          return okAsync<string | null, GitError>(null)
+        }
+        return errAsync(e)
+      })
   }
 
   static getRemoteUrl(repoRoot: string, remote = 'origin'): ResultAsync<string, GitError> {
@@ -437,6 +446,22 @@ export class GitRepository {
       const args = ['worktree', 'remove', path]
       if (force) args.push('--force')
       return gitCall('worktree remove', git.raw(args)).map(() => undefined)
+    })
+  }
+
+  /** Drop stale worktree registrations whose directories are gone. */
+  static worktreePrune(repoRoot: string): ResultAsync<void, GitError> {
+    const git = simpleGit(repoRoot)
+    return gitCall('worktree prune', git.raw(['worktree', 'prune'])).map(() => undefined)
+  }
+
+  static branchExists(repoRoot: string, name: string): ResultAsync<boolean, GitError> {
+    return validateRef(name).asyncAndThen(() => {
+      const git = simpleGit(repoRoot)
+      return gitCall(
+        'branch list',
+        git.raw(['branch', '--list', '--format=%(refname:short)', name]),
+      ).map((output) => output.split('\n').some((line) => line.trim() === name))
     })
   }
 

--- a/src/main/git/GitWatcher.ts
+++ b/src/main/git/GitWatcher.ts
@@ -58,6 +58,11 @@ export class GitWatcher {
     this.lastInfo = initialInfo ?? null
   }
 
+  /** Directory this watcher holds native handles on (worktree removal must stop it first). */
+  get root(): string {
+    return this.repoRoot
+  }
+
   start(): ResultAsync<void, GitError> {
     if (this.subscription) return okAsync(undefined)
 
@@ -66,6 +71,14 @@ export class GitWatcher {
       watcher.subscribe(gitDir, this.handleEvents, {
         // Skip write-heavy / irrelevant subdirs to keep event volume low.
         ignore: ['objects', 'logs', 'hooks', 'lfs', 'modules'],
+        // Pin the native OS backend — see FileTreeWatcher.start for why (silences
+        // @parcel/watcher's noisy `watchman` binary probe on startup).
+        backend:
+          process.platform === 'win32'
+            ? 'windows'
+            : process.platform === 'darwin'
+              ? 'fs-events'
+              : 'inotify',
       }),
       (e): GitError => ({
         _tag: 'WatcherStartFailed',

--- a/src/main/git/worktreeRemoval.test.ts
+++ b/src/main/git/worktreeRemoval.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { classifyWorktreeRemoveError } from './worktreeRemoval'
+
+describe('classifyWorktreeRemoveError', () => {
+  it('detects an already-unregistered worktree (partial success of a prior attempt)', () => {
+    expect(
+      classifyWorktreeRemoveError(
+        "fatal: 'C:/Users/x/canopy/worktrees/gakko/wt' is not a working tree",
+      ),
+    ).toBe('already-removed')
+  })
+
+  it('detects dirty-tree refusals (needs --force, not a retry)', () => {
+    expect(
+      classifyWorktreeRemoveError(
+        "fatal: 'wt' contains modified or untracked files, use --force to delete it",
+      ),
+    ).toBe('dirty')
+  })
+
+  it.each([
+    "unable to unlink 'Apps/foo.ts': Permission denied",
+    "warning: failed to delete 'C:/x/y': Directory not empty",
+    'Access is denied.',
+    'rm: cannot remove: Device or resource busy',
+    'EBUSY: resource busy or locked',
+    'EPERM: operation not permitted',
+  ])('classifies Windows lock symptoms as locked: %s', (msg) => {
+    expect(classifyWorktreeRemoveError(msg)).toBe('locked')
+  })
+
+  it('falls through to other for unrecognized failures', () => {
+    expect(classifyWorktreeRemoveError('fatal: repository is corrupt')).toBe('other')
+  })
+})

--- a/src/main/git/worktreeRemoval.test.ts
+++ b/src/main/git/worktreeRemoval.test.ts
@@ -29,6 +29,22 @@ describe('classifyWorktreeRemoveError', () => {
     expect(classifyWorktreeRemoveError(msg)).toBe('locked')
   })
 
+  it('classifies a broken .git link (field ghost state) as broken-link', () => {
+    expect(
+      classifyWorktreeRemoveError(
+        "fatal: validation failed, cannot remove working tree: 'C:/x/wt/.git' does not exist",
+      ),
+    ).toBe('broken-link')
+  })
+
+  it('classifies the submodule refusal as force-required (git documents --force)', () => {
+    expect(
+      classifyWorktreeRemoveError(
+        'fatal: working trees containing submodules cannot be moved or removed',
+      ),
+    ).toBe('force-required')
+  })
+
   it('falls through to other for unrecognized failures', () => {
     expect(classifyWorktreeRemoveError('fatal: repository is corrupt')).toBe('other')
   })

--- a/src/main/git/worktreeRemoval.ts
+++ b/src/main/git/worktreeRemoval.ts
@@ -8,11 +8,23 @@
  * cleanup. Blindly force-retrying (the old behavior) turned partial successes into
  * hard failures and left stray branches and ghost folders behind.
  */
-export type WorktreeRemoveErrorKind = 'already-removed' | 'locked' | 'dirty' | 'other'
+export type WorktreeRemoveErrorKind =
+  'already-removed' | 'broken-link' | 'locked' | 'dirty' | 'force-required' | 'other'
 
 export function classifyWorktreeRemoveError(message: string): WorktreeRemoveErrorKind {
   if (/is not a working tree/i.test(message)) return 'already-removed'
+  // A registered worktree whose `.git` link file is gone (the classic field ghost:
+  // an earlier removal deleted the link, then died on locks). Git refuses to touch
+  // it — with or without --force — and cannot verify cleanliness, so callers must
+  // treat its content as potentially unsaved work.
+  if (/validation failed, cannot remove working tree/i.test(message)) return 'broken-link'
   if (/contains modified or untracked files/i.test(message)) return 'dirty'
+  // Git refuses these even when clean and documents --force as the remedy
+  // (worktrees containing submodules) — same consent gate as a dirty tree, since
+  // forcing may discard submodule-local state git could not verify.
+  if (/containing submodules cannot be (?:moved or )?removed/i.test(message)) {
+    return 'force-required'
+  }
   if (
     /unable to unlink|failed to delete|Permission denied|Access is denied|Directory not empty|Device or resource busy|EBUSY|EPERM|EACCES|Invalid argument/i.test(
       message,

--- a/src/main/git/worktreeRemoval.ts
+++ b/src/main/git/worktreeRemoval.ts
@@ -1,0 +1,28 @@
+/**
+ * Failure taxonomy for `git worktree remove` on real filesystems (esp. Windows).
+ *
+ * A removal that races dying PTY shells, editors, or AV scanners fails in ways that
+ * need OPPOSITE reactions: a lock is transient (retry with backoff), while
+ * "is not a working tree" means a previous attempt already unregistered the
+ * worktree — retrying git is pointless and the remaining work is filesystem
+ * cleanup. Blindly force-retrying (the old behavior) turned partial successes into
+ * hard failures and left stray branches and ghost folders behind.
+ */
+export type WorktreeRemoveErrorKind = 'already-removed' | 'locked' | 'dirty' | 'other'
+
+export function classifyWorktreeRemoveError(message: string): WorktreeRemoveErrorKind {
+  if (/is not a working tree/i.test(message)) return 'already-removed'
+  if (/contains modified or untracked files/i.test(message)) return 'dirty'
+  if (
+    /unable to unlink|failed to delete|Permission denied|Access is denied|Directory not empty|Device or resource busy|EBUSY|EPERM|EACCES|Invalid argument/i.test(
+      message,
+    )
+  ) {
+    return 'locked'
+  }
+  return 'other'
+}
+
+/** Backoff schedule for lock-classified retries: dying process trees on Windows
+ *  release their cwd/file handles within a couple of seconds. */
+export const REMOVE_RETRY_DELAYS_MS = [500, 1000, 1500, 2000]

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1962,15 +1962,21 @@ export function registerIpcHandlers(
       await ptyManager.killUnderPathAndWait(worktree.path)
       await windowManager.disposeWatchersUnderPathAndWait(worktree.path)
 
-      // Retry with backoff instead of one blind force-retry: transient locks (AV
-      // scanners, just-killed process trees) clear within seconds, while
-      // "is not a working tree" means a previous attempt already unregistered the
-      // worktree — retrying git is pointless, only filesystem cleanup remains.
+      // Retry with backoff and classify failures instead of one blind force-retry.
+      // The two behaviors behind git's --force are deliberately decoupled:
+      // - LOCKS are retried WITHOUT force (--force does not bypass OS file locks;
+      //   time does — AV scans and just-killed process trees release handles within
+      //   seconds) and degrade to the fs-cleanup path below when retries run out.
+      // - A DIRTY tree gets --force only when the caller passed forceOnFailure,
+      //   i.e. the user consented to a destructive removal in the confirm dialog.
+      // - "is not a working tree" means a previous attempt already unregistered the
+      //   worktree — retrying git is pointless, only filesystem cleanup remains.
       let forcedWorktreeRemove = false
       let unregistered = false
-      const attempts = [false, ...(forceOnFailure ? REMOVE_RETRY_DELAYS_MS.map(() => true) : [])]
-      for (let i = 0; i < attempts.length; i++) {
-        const force = attempts[i]
+      let lockRetriesExhausted = false
+      let force = false
+      let lockRetries = 0
+      for (;;) {
         const result = await GitRepository.worktreeRemove(resolvedRepo, worktree.path, force)
         if (result.isOk()) {
           unregistered = true
@@ -1983,22 +1989,29 @@ export function registerIpcHandlers(
           unregistered = true
           break
         }
-        const isLastAttempt = i === attempts.length - 1
-        // A dirty tree needs --force (next attempt), not a wait; locks need both.
-        if (isLastAttempt || (kind !== 'locked' && kind !== 'dirty')) {
-          throw new Error(`Git worktree remove failed: ${message}`)
+        if (kind === 'dirty' && !force && forceOnFailure) {
+          force = true
+          continue
+        }
+        if (kind === 'locked' && lockRetries < REMOVE_RETRY_DELAYS_MS.length) {
+          await new Promise((r) => setTimeout(r, REMOVE_RETRY_DELAYS_MS[lockRetries++]))
+          continue
         }
         if (kind === 'locked') {
-          await new Promise((r) =>
-            setTimeout(r, REMOVE_RETRY_DELAYS_MS[Math.min(i, REMOVE_RETRY_DELAYS_MS.length - 1)]),
-          )
+          // A handle outlived every retry — the exact worst case this flow exists
+          // for. Fall through to the graceful cleanup below (fs.rm + prune +
+          // leftover reporting) instead of surfacing a raw git fatal.
+          lockRetriesExhausted = true
+          break
         }
+        throw new Error(`Git worktree remove failed: ${message}`)
       }
 
-      // The registration is gone — make sure stale admin records don't linger and
-      // the directory itself is really deleted (git gives up on the first locked
-      // file and leaves everything else behind as a ghost folder).
-      await GitRepository.worktreePrune(resolvedRepo).unwrapOr(undefined)
+      // Make sure the directory is really deleted (git gives up on the first locked
+      // file and leaves everything else behind as a ghost folder) and stale admin
+      // records don't linger. When git never managed to unregister (persistent
+      // lock), deleting the worktree's `.git` link file lets `worktree prune` clear
+      // the registration even though some content files are still held open.
       let leftoverPath: string | null = null
       if (fs.existsSync(worktree.path)) {
         try {
@@ -2010,10 +2023,16 @@ export function registerIpcHandlers(
           })
         } catch {
           // Some files are still held open by another process — report instead of
-          // failing: the worktree IS removed from git, only debris remains.
+          // failing: only debris remains and the registration is cleared below.
+        }
+        if (lockRetriesExhausted && fs.existsSync(worktree.path)) {
+          await fs.promises
+            .rm(path.join(worktree.path, '.git'), { force: true, maxRetries: 3, retryDelay: 200 })
+            .catch(() => {})
         }
         if (fs.existsSync(worktree.path)) leftoverPath = worktree.path
       }
+      await GitRepository.worktreePrune(resolvedRepo).unwrapOr(undefined)
 
       let branchDeleted = false
       let forcedBranchDelete = false

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1974,20 +1974,17 @@ export function registerIpcHandlers(
       // - "is not a working tree" means a previous attempt already unregistered the
       //   worktree — retrying git is pointless, only filesystem cleanup remains.
       let forcedWorktreeRemove = false
-      let unregistered = false
       let force = false
       let lockRetries = 0
       for (;;) {
         const result = await GitRepository.worktreeRemove(resolvedRepo, worktree.path, force)
         if (result.isOk()) {
-          unregistered = true
           forcedWorktreeRemove = force
           break
         }
         const message = gitErrorMessage(result.error)
         const kind = classifyWorktreeRemoveError(message)
         if (kind === 'already-removed') {
-          unregistered = true
           break
         }
         if (kind === 'broken-link') {
@@ -2044,10 +2041,9 @@ export function registerIpcHandlers(
             'No files were deleted — please retry.',
         )
       }
-      // Verified against `git worktree list`: the registration is gone, whether
-      // git's own remove did it or the prune fallback (broken-link ghosts reach
-      // here with the loop-local flag still false).
-      unregistered = true
+      // Past this gate the registration is verifiably gone — whether git's own
+      // remove did it or the prune fallback (broken-link ghosts included) — so the
+      // result below reports worktreeRemoved: true unconditionally.
 
       // The directory itself may still exist: git gives up on the first locked file
       // and leaves everything else behind as a ghost folder. Best-effort delete,
@@ -2087,7 +2083,7 @@ export function registerIpcHandlers(
       }
 
       return {
-        worktreeRemoved: unregistered,
+        worktreeRemoved: true,
         branchDeleted,
         forcedWorktreeRemove,
         forcedBranchDelete,

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -36,6 +36,7 @@ import { DEFAULT_IGNORE_PATTERNS } from '../fileWatcher/defaults'
 import { fileWatcherErrorMessage } from '../fileWatcher/errors'
 import { runWorktreeSetup } from '../worktree/WorktreeSetupRunner'
 import { classifyWorktreeRemoveError, REMOVE_RETRY_DELAYS_MS } from '../git/worktreeRemoval'
+import { comparableWorkspacePath } from '../db/workspacePaths'
 
 const execFileAsync = promisify(execFile)
 const WORKTREE_BASE_DIR_PREF_KEY = 'worktrees.baseDir'
@@ -1966,14 +1967,14 @@ export function registerIpcHandlers(
       // The two behaviors behind git's --force are deliberately decoupled:
       // - LOCKS are retried WITHOUT force (--force does not bypass OS file locks;
       //   time does — AV scans and just-killed process trees release handles within
-      //   seconds) and degrade to the fs-cleanup path below when retries run out.
-      // - A DIRTY tree gets --force only when the caller passed forceOnFailure,
-      //   i.e. the user consented to a destructive removal in the confirm dialog.
+      //   seconds).
+      // - A DIRTY tree (or git's force-required refusals, e.g. submodules) gets
+      //   --force only when the caller passed forceOnFailure, i.e. the user
+      //   consented to a destructive removal in the confirm dialog.
       // - "is not a working tree" means a previous attempt already unregistered the
       //   worktree — retrying git is pointless, only filesystem cleanup remains.
       let forcedWorktreeRemove = false
       let unregistered = false
-      let lockRetriesExhausted = false
       let force = false
       let lockRetries = 0
       for (;;) {
@@ -1989,7 +1990,22 @@ export function registerIpcHandlers(
           unregistered = true
           break
         }
-        if (kind === 'dirty' && !force && forceOnFailure) {
+        if (kind === 'broken-link') {
+          // Registered worktree whose .git link is gone — the classic field ghost.
+          // Git refuses to manage it (force does not help) and cannot verify the
+          // tree is clean, so its content may include unsaved work: only the
+          // destructive-consent flag authorizes cleaning it up. Prune below drops
+          // the (prunable) registration; fs cleanup handles the debris.
+          if (!forceOnFailure) {
+            throw new Error(
+              `Worktree at ${worktree.path} has a broken .git link (likely debris of an ` +
+                'earlier failed removal). Its files cannot be verified as saved — retry with ' +
+                'the destructive option to delete the folder anyway.',
+            )
+          }
+          break
+        }
+        if ((kind === 'dirty' || kind === 'force-required') && !force && forceOnFailure) {
           force = true
           continue
         }
@@ -1998,20 +2014,40 @@ export function registerIpcHandlers(
           continue
         }
         if (kind === 'locked') {
-          // A handle outlived every retry — the exact worst case this flow exists
-          // for. Fall through to the graceful cleanup below (fs.rm + prune +
-          // leftover reporting) instead of surfacing a raw git fatal.
-          lockRetriesExhausted = true
-          break
+          // A handle outlived every retry while git still tracks the worktree.
+          // NEVER touch the tree here: the lock classifier is heuristic (EPERM/
+          // EACCES also match) and git has not verified cleanliness — deleting
+          // could destroy uncommitted work without consent. Keep tree and
+          // registration intact and report an actionable failure instead.
+          throw new Error(
+            `Worktree removal failed: files inside are still locked by another process. ` +
+              `Close applications using files under ${worktree.path} and try again.`,
+          )
         }
         throw new Error(`Git worktree remove failed: ${message}`)
       }
 
-      // Make sure the directory is really deleted (git gives up on the first locked
-      // file and leaves everything else behind as a ghost folder) and stale admin
-      // records don't linger. When git never managed to unregister (persistent
-      // lock), deleting the worktree's `.git` link file lets `worktree prune` clear
-      // the registration even though some content files are still held open.
+      // Git no longer manages the worktree — clear stale admin records and confirm
+      // the unregistration against `git worktree list` BEFORE any raw filesystem
+      // cleanup or branch deletion. If the registration somehow survived, fail
+      // loudly rather than deleting files git still tracks.
+      await GitRepository.worktreePrune(resolvedRepo).unwrapOr(undefined)
+      const remaining = await GitRepository.listWorktrees(resolvedRepo).unwrapOr(null)
+      if (
+        remaining === null ||
+        remaining.some(
+          (wt) => comparableWorkspacePath(wt.path) === comparableWorkspacePath(worktree.path),
+        )
+      ) {
+        throw new Error(
+          `Worktree removal failed: git still lists ${worktree.path} as a worktree. ` +
+            'No files were deleted — please retry.',
+        )
+      }
+
+      // The directory itself may still exist: git gives up on the first locked file
+      // and leaves everything else behind as a ghost folder. Best-effort delete,
+      // reporting anything that survives instead of failing.
       let leftoverPath: string | null = null
       if (fs.existsSync(worktree.path)) {
         try {
@@ -2023,16 +2059,10 @@ export function registerIpcHandlers(
           })
         } catch {
           // Some files are still held open by another process — report instead of
-          // failing: only debris remains and the registration is cleared below.
-        }
-        if (lockRetriesExhausted && fs.existsSync(worktree.path)) {
-          await fs.promises
-            .rm(path.join(worktree.path, '.git'), { force: true, maxRetries: 3, retryDelay: 200 })
-            .catch(() => {})
+          // failing: the worktree IS unregistered, only debris remains.
         }
         if (fs.existsSync(worktree.path)) leftoverPath = worktree.path
       }
-      await GitRepository.worktreePrune(resolvedRepo).unwrapOr(undefined)
 
       let branchDeleted = false
       let forcedBranchDelete = false

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1889,10 +1889,22 @@ export function registerIpcHandlers(
           )
         : false
 
+      // Git refuses to remove a worktree containing initialized submodules even
+      // when the tree is clean and documents --force as the remedy — the consent
+      // dialog must know about this BEFORE any tab teardown starts, or the removal
+      // deterministically fails after the tabs are already gone. Probe failures
+      // degrade to false: the removal loop still reports the refusal clearly.
+      const hasSubmodules = await GitRepository.hasInitializedSubmodules(worktree.path).unwrapOr(
+        false,
+      )
+
       const warnings: string[] = []
       if (hasUncommittedChanges) warnings.push('Has uncommitted changes.')
       if (unmergedCommits.length > 0) {
         warnings.push(`${unmergedCommits.length} unmerged commit(s) not on any remote.`)
+      }
+      if (hasSubmodules) {
+        warnings.push('Contains git submodules — git requires a forced removal.')
       }
 
       return {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -2044,6 +2044,10 @@ export function registerIpcHandlers(
             'No files were deleted — please retry.',
         )
       }
+      // Verified against `git worktree list`: the registration is gone, whether
+      // git's own remove did it or the prune fallback (broken-link ghosts reach
+      // here with the loop-local flag still false).
+      unregistered = true
 
       // The directory itself may still exist: git gives up on the first locked file
       // and leaves everything else behind as a ghost folder. Best-effort delete,

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -35,6 +35,7 @@ import { FileTreeWatcher } from '../fileWatcher/FileTreeWatcher'
 import { DEFAULT_IGNORE_PATTERNS } from '../fileWatcher/defaults'
 import { fileWatcherErrorMessage } from '../fileWatcher/errors'
 import { runWorktreeSetup } from '../worktree/WorktreeSetupRunner'
+import { classifyWorktreeRemoveError, REMOVE_RETRY_DELAYS_MS } from '../git/worktreeRemoval'
 
 const execFileAsync = promisify(execFile)
 const WORKTREE_BASE_DIR_PREF_KEY = 'worktrees.baseDir'
@@ -260,6 +261,10 @@ interface WorktreeRemoveWithBranchResult {
   branchDeleted: boolean
   forcedWorktreeRemove: boolean
   forcedBranchDelete: boolean
+  /** Set when the worktree was unregistered but some files could not be deleted
+   *  (still held open by another process) — the UI should tell the user instead
+   *  of leaving a silent ghost folder behind. */
+  leftoverPath: string | null
 }
 
 // Dedupe concurrent first-use OS auth prompts for the autofill path. When two
@@ -1783,22 +1788,66 @@ export function registerIpcHandlers(
       const resolvedRepo = await validateWorktreeScopedPathAccess(event.sender.id, payload.repoRoot)
       const worktreePath = await validateWorktreeCreationPath(event.sender.id, payload.worktreePath)
 
-      if (payload.mode === 'new') {
-        const result = await GitRepository.worktreeAdd(
-          resolvedRepo,
-          worktreePath,
-          payload.branch,
-          payload.baseBranch,
-        )
-        unwrapOrThrow(result, gitErrorMessage)
-      } else {
-        const result = await GitRepository.worktreeAddCheckout(
-          resolvedRepo,
-          worktreePath,
-          payload.branch,
-          payload.createLocalTracking ?? false,
-        )
-        unwrapOrThrow(result, gitErrorMessage)
+      // Pre-flight the target directory BEFORE any git call. `git worktree add`
+      // refuses an existing directory AFTER creating the branch (-b), which used to
+      // leave a stray branch plus a raw `fatal:` in the UI whenever debris of an
+      // earlier failed removal sat at the target path.
+      if (fs.existsSync(worktreePath)) {
+        const entries = await fs.promises.readdir(worktreePath).catch(() => null)
+        if (entries && entries.length === 0) {
+          await fs.promises.rm(worktreePath, { recursive: true, force: true })
+        } else {
+          throw new Error(
+            `Target folder already exists and is not empty: ${worktreePath}. ` +
+              'It is not a registered worktree — likely debris of a previously failed removal. ' +
+              'Remove or rename it, then try again.',
+          )
+        }
+      }
+
+      // Track whether this call is about to CREATE a local branch, so a failed
+      // `worktree add` can roll it back instead of leaving a stray branch behind.
+      const createdBranchCandidate =
+        payload.mode === 'new'
+          ? payload.branch
+          : (payload.createLocalTracking ?? false) && payload.branch.includes('/')
+            ? payload.branch.slice(payload.branch.indexOf('/') + 1)
+            : null
+      const branchExistedBefore = createdBranchCandidate
+        ? await GitRepository.branchExists(resolvedRepo, createdBranchCandidate).unwrapOr(true)
+        : true
+
+      try {
+        if (payload.mode === 'new') {
+          const result = await GitRepository.worktreeAdd(
+            resolvedRepo,
+            worktreePath,
+            payload.branch,
+            payload.baseBranch,
+          )
+          unwrapOrThrow(result, gitErrorMessage)
+        } else {
+          const result = await GitRepository.worktreeAddCheckout(
+            resolvedRepo,
+            worktreePath,
+            payload.branch,
+            payload.createLocalTracking ?? false,
+          )
+          unwrapOrThrow(result, gitErrorMessage)
+        }
+      } catch (e) {
+        if (createdBranchCandidate && !branchExistedBefore) {
+          const existsNow = await GitRepository.branchExists(
+            resolvedRepo,
+            createdBranchCandidate,
+          ).unwrapOr(false)
+          if (existsNow) {
+            await GitRepository.deleteBranch(resolvedRepo, createdBranchCandidate, true).unwrapOr(
+              undefined,
+            )
+          }
+        }
+        throw e
       }
 
       return { branch: payload.branch, worktreePath }
@@ -1902,24 +1951,75 @@ export function registerIpcHandlers(
       const forceOnFailure = payload.forceOnFailure ?? false
       const canDeleteBranch = worktree.branch !== '(detached)' && worktree.branch !== '(unknown)'
       const shouldDeleteBranch = payload.deleteBranch ?? canDeleteBranch
+      if (shouldDeleteBranch && !canDeleteBranch) {
+        throw new Error('Cannot delete branch for detached or unknown worktree')
+      }
 
+      // Windows deletes directories only when nothing holds a handle inside them.
+      // Tear down our own holders FIRST and wait until they are really gone:
+      // shells/agents cwd'd in the worktree (dying processes keep their cwd handle
+      // until fully exited) and native watcher subscriptions.
+      await ptyManager.killUnderPathAndWait(worktree.path)
+      await windowManager.disposeWatchersUnderPathAndWait(worktree.path)
+
+      // Retry with backoff instead of one blind force-retry: transient locks (AV
+      // scanners, just-killed process trees) clear within seconds, while
+      // "is not a working tree" means a previous attempt already unregistered the
+      // worktree — retrying git is pointless, only filesystem cleanup remains.
       let forcedWorktreeRemove = false
-      try {
-        const result = await GitRepository.worktreeRemove(resolvedRepo, worktree.path, false)
-        unwrapOrThrow(result, gitErrorMessage)
-      } catch (e) {
-        if (!forceOnFailure) throw e
-        const forcedResult = await GitRepository.worktreeRemove(resolvedRepo, worktree.path, true)
-        unwrapOrThrow(forcedResult, gitErrorMessage)
-        forcedWorktreeRemove = true
+      let unregistered = false
+      const attempts = [false, ...(forceOnFailure ? REMOVE_RETRY_DELAYS_MS.map(() => true) : [])]
+      for (let i = 0; i < attempts.length; i++) {
+        const force = attempts[i]
+        const result = await GitRepository.worktreeRemove(resolvedRepo, worktree.path, force)
+        if (result.isOk()) {
+          unregistered = true
+          forcedWorktreeRemove = force
+          break
+        }
+        const message = gitErrorMessage(result.error)
+        const kind = classifyWorktreeRemoveError(message)
+        if (kind === 'already-removed') {
+          unregistered = true
+          break
+        }
+        const isLastAttempt = i === attempts.length - 1
+        // A dirty tree needs --force (next attempt), not a wait; locks need both.
+        if (isLastAttempt || (kind !== 'locked' && kind !== 'dirty')) {
+          throw new Error(`Git worktree remove failed: ${message}`)
+        }
+        if (kind === 'locked') {
+          await new Promise((r) =>
+            setTimeout(r, REMOVE_RETRY_DELAYS_MS[Math.min(i, REMOVE_RETRY_DELAYS_MS.length - 1)]),
+          )
+        }
+      }
+
+      // The registration is gone — make sure stale admin records don't linger and
+      // the directory itself is really deleted (git gives up on the first locked
+      // file and leaves everything else behind as a ghost folder).
+      await GitRepository.worktreePrune(resolvedRepo).unwrapOr(undefined)
+      let leftoverPath: string | null = null
+      if (fs.existsSync(worktree.path)) {
+        try {
+          await fs.promises.rm(worktree.path, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 300,
+          })
+        } catch {
+          // Some files are still held open by another process — report instead of
+          // failing: the worktree IS removed from git, only debris remains.
+        }
+        if (fs.existsSync(worktree.path)) leftoverPath = worktree.path
       }
 
       let branchDeleted = false
       let forcedBranchDelete = false
       if (shouldDeleteBranch) {
-        if (!canDeleteBranch) {
-          throw new Error('Cannot delete branch for detached or unknown worktree')
-        }
+        // Branch deletion must run even when the worktree removal needed the
+        // fallback paths above — aborting halfway used to leave stray branches.
         try {
           const result = await GitRepository.deleteBranch(resolvedRepo, worktree.branch, false)
           unwrapOrThrow(result, gitErrorMessage)
@@ -1934,10 +2034,11 @@ export function registerIpcHandlers(
       }
 
       return {
-        worktreeRemoved: true,
+        worktreeRemoved: unregistered,
         branchDeleted,
         forcedWorktreeRemove,
         forcedBranchDelete,
+        leftoverPath,
       }
     },
   )
@@ -3407,15 +3508,26 @@ export function registerIpcHandlers(
 
   ipcMain.handle(
     'trackerConfig:getCurrentUser',
-    async (_event, payload: { repoRoot?: string; trackerId?: string }) => {
+    async (
+      _event,
+      payload: { repoRoot?: string; trackerId?: string },
+    ): Promise<{ ok: true; value: string } | { ok: false; error: string }> => {
+      // Envelope instead of a rejected promise: this call is the credential PROBE
+      // that hydration runs on every worktree switch, so an expired token is an
+      // expected outcome — a rejection here made Electron print a full
+      // "Error occurred in handler" stack to the console each time. The preload
+      // bridge unwraps the envelope back into a throw for the renderer.
       const resolved = await resolveEffectiveConfig(payload.repoRoot)
-      if (!resolved) throw new Error('No tracker configured')
+      if (!resolved) return { ok: false, error: 'No tracker configured' }
       const result = await taskTrackerManager.getCurrentUserFromConfig(
         resolved.config,
         payload.trackerId,
         payload.repoRoot,
       )
-      return unwrapOrThrow(result, taskTrackerErrorMessage)
+      return result.match(
+        (value) => ({ ok: true as const, value }),
+        (e) => ({ ok: false as const, error: taskTrackerErrorMessage(e) }),
+      )
     },
   )
 

--- a/src/main/pty/PtyManager.ts
+++ b/src/main/pty/PtyManager.ts
@@ -203,24 +203,41 @@ export class PtyManager {
     for (const [id, session] of [...this.sessions]) {
       const cwd = comparableWorkspacePath(session.cwd)
       if (cwd !== base && !cwd.startsWith(prefix)) continue
-      waits.push(
-        new Promise<void>((resolve) => {
-          const timer = setTimeout(resolve, timeoutMs)
-          session.pty.onExit(() => {
-            clearTimeout(timer)
-            resolve()
-          })
-          this.terminateProcessTree(session.pty.pid)
-          try {
-            session.pty.kill()
-          } catch {
-            // PTY already exited — the timeout resolves the wait.
-          }
-          this.sessions.delete(id)
-        }),
-      )
+      waits.push(this.killSessionTreeAndWait(id, session, timeoutMs))
     }
     return Promise.all(waits).then(() => undefined)
+  }
+
+  /**
+   * Tree-kill one PTY and wait (bounded) until the process actually exits — the
+   * removal-flow variant of kill(): a fire-and-forget kill returns while the dying
+   * shell still holds its cwd handle, which blocks directory deletion on Windows.
+   */
+  killAndWait(id: string, timeoutMs = 4000): Promise<void> {
+    const session = this.sessions.get(id)
+    if (!session) return Promise.resolve()
+    return this.killSessionTreeAndWait(id, session, timeoutMs)
+  }
+
+  private killSessionTreeAndWait(
+    id: string,
+    session: PtySession,
+    timeoutMs: number,
+  ): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, timeoutMs)
+      session.pty.onExit(() => {
+        clearTimeout(timer)
+        resolve()
+      })
+      this.terminateProcessTree(session.pty.pid)
+      try {
+        session.pty.kill()
+      } catch {
+        // PTY already exited — the timeout resolves the wait.
+      }
+      this.sessions.delete(id)
+    })
   }
 
   hasChildProcess(id: string): Promise<boolean> {

--- a/src/main/pty/PtyManager.ts
+++ b/src/main/pty/PtyManager.ts
@@ -189,6 +189,12 @@ export class PtyManager {
    * deleting the directory immediately after a fire-and-forget kill() races the
    * teardown and fails with lock errors. Kills the whole process tree: children
    * spawned inside a directory being deleted must not outlive it.
+   *
+   * Known limitation: `session.cwd` is the SPAWN cwd — there is no OSC7/cwd
+   * tracking, so a shell spawned elsewhere that later `cd`s into the worktree is
+   * not matched (its lock is still handled by the caller's retry/cleanup path),
+   * and one that `cd`s out is killed unnecessarily. Acceptable best-effort: the
+   * dominant case is the tab auto-opened with the worktree as cwd that stays there.
    */
   killUnderPathAndWait(dirPath: string, timeoutMs = 4000): Promise<void> {
     const base = comparableWorkspacePath(dirPath).replace(/\/+$/, '')

--- a/src/main/pty/PtyManager.ts
+++ b/src/main/pty/PtyManager.ts
@@ -5,10 +5,12 @@ import { execFile, execFileSync } from 'child_process'
 import os from 'os'
 import { getLoginEnv } from '../shell/loginEnv'
 import { BLOCKED_ENV_VARS } from '../security/envBlocklist'
+import { comparableWorkspacePath } from '../db/workspacePaths'
 
 interface PtySession {
   id: string
   pty: IPty
+  cwd: string
   tmuxSessionName?: string
 }
 
@@ -81,7 +83,12 @@ export class PtyManager {
       env,
     })
 
-    const session: PtySession = { id, pty: p, tmuxSessionName: options?.tmuxSessionName }
+    const session: PtySession = {
+      id,
+      pty: p,
+      cwd: options?.cwd ?? os.homedir(),
+      tmuxSessionName: options?.tmuxSessionName,
+    }
     this.sessions.set(id, session)
 
     // Remove the session when the PTY exits on its own (shell `exit`, agent CLI
@@ -173,6 +180,41 @@ export class PtyManager {
       }
       this.sessions.delete(id)
     }
+  }
+
+  /**
+   * Kill every PTY whose cwd sits inside `dirPath` (a worktree about to be removed)
+   * and wait — bounded — until the underlying processes actually exit. Windows keeps
+   * a shell's cwd directory handle alive until the process is fully gone, so
+   * deleting the directory immediately after a fire-and-forget kill() races the
+   * teardown and fails with lock errors. Kills the whole process tree: children
+   * spawned inside a directory being deleted must not outlive it.
+   */
+  killUnderPathAndWait(dirPath: string, timeoutMs = 4000): Promise<void> {
+    const base = comparableWorkspacePath(dirPath).replace(/\/+$/, '')
+    const prefix = `${base}/`
+    const waits: Promise<void>[] = []
+    for (const [id, session] of [...this.sessions]) {
+      const cwd = comparableWorkspacePath(session.cwd)
+      if (cwd !== base && !cwd.startsWith(prefix)) continue
+      waits.push(
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, timeoutMs)
+          session.pty.onExit(() => {
+            clearTimeout(timer)
+            resolve()
+          })
+          this.terminateProcessTree(session.pty.pid)
+          try {
+            session.pty.kill()
+          } catch {
+            // PTY already exited — the timeout resolves the wait.
+          }
+          this.sessions.delete(id)
+        }),
+      )
+    }
+    return Promise.all(waits).then(() => undefined)
   }
 
   hasChildProcess(id: string): Promise<boolean> {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -227,6 +227,8 @@ interface WorktreeRemoveWithBranchResult {
   branchDeleted: boolean
   forcedWorktreeRemove: boolean
   forcedBranchDelete: boolean
+  /** Path left on disk when some files could not be deleted (held by another process). */
+  leftoverPath: string | null
 }
 
 interface AgentHookEventData {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -580,7 +580,7 @@ interface CanopyAPI {
     },
   ) => Promise<TabCommandResult>
   tabClosePane: (worktreePath: string, tabId: string, paneId: string) => Promise<TabCommandResult>
-  tabCloseAllForWorktree: (worktreePath: string) => Promise<TabCommandResult>
+  tabCloseAllForWorktree: (worktreePath: string, forRemoval?: boolean) => Promise<TabCommandResult>
   tabSetActiveTab: (worktreePath: string, tabId: string) => Promise<TabCommandResult>
   tabMoveTab: (
     worktreePath: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -488,9 +488,10 @@ const api = {
       tabId,
       paneId,
     }),
-  tabCloseAllForWorktree: (worktreePath: string) =>
+  tabCloseAllForWorktree: (worktreePath: string, forRemoval?: boolean) =>
     ipcRenderer.invoke('tab:command:closeAllForWorktree', {
       worktreePath,
+      forRemoval,
     }),
   tabSetActiveTab: (worktreePath: string, tabId: string) =>
     ipcRenderer.invoke('tab:command:setActiveTab', {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1270,8 +1270,16 @@ const api = {
     trackerId?: string,
     params?: { statuses?: string[]; assignedToMe?: boolean; boardId?: string; projectKey?: string },
   ) => ipcRenderer.invoke('trackerConfig:fetchTasks', { repoRoot, trackerId, ...params }),
-  trackerConfigGetCurrentUser: (repoRoot?: string, trackerId?: string) =>
-    ipcRenderer.invoke('trackerConfig:getCurrentUser', { repoRoot, trackerId }),
+  trackerConfigGetCurrentUser: async (repoRoot?: string, trackerId?: string) => {
+    // Main returns an {ok} envelope so expected auth failures don't spam the main
+    // console; rethrow here to preserve the renderer-facing contract.
+    const result = (await ipcRenderer.invoke('trackerConfig:getCurrentUser', {
+      repoRoot,
+      trackerId,
+    })) as { ok: true; value: string } | { ok: false; error: string }
+    if (!result.ok) throw new Error(result.error)
+    return result.value
+  },
   trackerConfigFetchTaskComments: (
     repoRoot: string | undefined,
     taskKey: string,

--- a/src/renderer-shared/rpc/methodList.ts
+++ b/src/renderer-shared/rpc/methodList.ts
@@ -123,6 +123,20 @@ export interface RpcMethods {
     /** leftoverPath is set when some files could not be deleted (still held open). */
     result: { leftoverPath: string | null }
   }
+  /** Read-only removal preflight: peers must collect informed force consent from
+   *  their user BEFORE calling worktree.remove — the host also enforces this and
+   *  rejects an unconsented force-required removal without tearing anything down. */
+  'worktree.prepareRemove': {
+    params: { repoRoot: string; path: string }
+    result: {
+      hasUncommittedChanges: boolean
+      unmergedCommitCount: number
+      branchMerged: boolean
+      forceRequired: boolean
+      canDeleteBranch: boolean
+      warnings: string[]
+    }
+  }
 
   // Project management — peer can attach a new directory to the host workspace.
   'project.attach': {

--- a/src/renderer-shared/rpc/methodList.ts
+++ b/src/renderer-shared/rpc/methodList.ts
@@ -120,7 +120,8 @@ export interface RpcMethods {
   }
   'worktree.remove': {
     params: { repoRoot: string; path: string; force: boolean }
-    result: void
+    /** leftoverPath is set when some files could not be deleted (still held open). */
+    result: { leftoverPath: string | null }
   }
 
   // Project management — peer can attach a new directory to the host workspace.

--- a/src/renderer/src/components/layout/MainLayout.svelte
+++ b/src/renderer/src/components/layout/MainLayout.svelte
@@ -574,12 +574,17 @@
 {#if dialogState.current.type === 'input'}
   <InputDialog {...dialogState.current.props} />
 {:else if dialogState.current.type === 'createWorktree'}
-  <CreateWorktreeModal
-    onClose={closeDialog}
-    repoRoot={dialogState.current.repoRoot}
-    workspaceId={dialogState.current.workspaceId}
-    baseBranch={dialogState.current.baseBranch}
-  />
+  <!-- Keyed by dialog identity: re-showing the dialog must remount the modal with a
+       clean slate — an {:else if} on `type` alone keeps the old instance alive, so a
+       reopen used to show the previous attempt's error state. -->
+  {#key dialogState.current}
+    <CreateWorktreeModal
+      onClose={closeDialog}
+      repoRoot={dialogState.current.repoRoot}
+      workspaceId={dialogState.current.workspaceId}
+      baseBranch={dialogState.current.baseBranch}
+    />
+  {/key}
 {:else if dialogState.current.type === 'preferences'}
   <PreferencesModal section={dialogState.current.section} />
 {:else if dialogState.current.type === 'taskPicker'}

--- a/src/renderer/src/components/palette/CommandPalette.svelte
+++ b/src/renderer/src/components/palette/CommandPalette.svelte
@@ -36,6 +36,7 @@
     showTmuxBrowser,
   } from '../../lib/stores/dialogs.svelte'
   import { getTools, getToolAvailability } from '../../lib/stores/tools.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
 
   let { onClose }: { onClose: () => void } = $props()
 
@@ -493,13 +494,26 @@
                 })
               }
 
-              await window.api.worktreeRemoveWithBranch({
+              // This command removes the CURRENT worktree: close its tabs and
+              // leave it BEFORE the removal, otherwise live shells and watchers
+              // hold Windows file locks inside the directory being deleted.
+              if (!(await closeAllTabsForWorktree(wtPath))) return
+              const main = workspaceState.worktrees.find((w) => w.isMain)
+              if (main) selectWorktree(main.path)
+
+              const result = await window.api.worktreeRemoveWithBranch({
                 repoRoot: operationRoot,
                 worktreePath: wtPath,
                 branch,
                 deleteBranch,
-                forceOnFailure: preflight.forceRequired,
+                // Transient locks need the force-retry path even for a clean tree.
+                forceOnFailure: true,
               })
+              if (result.leftoverPath) {
+                addToast(
+                  `Worktree removed, but some files are still in use and were left at ${result.leftoverPath}`,
+                )
+              }
             } catch (err) {
               await confirm({
                 title: 'Git Error',

--- a/src/renderer/src/components/palette/CommandPalette.svelte
+++ b/src/renderer/src/components/palette/CommandPalette.svelte
@@ -497,7 +497,7 @@
               // This command removes the CURRENT worktree: close its tabs and
               // leave it BEFORE the removal, otherwise live shells and watchers
               // hold Windows file locks inside the directory being deleted.
-              if (!(await closeAllTabsForWorktree(wtPath))) return
+              if (!(await closeAllTabsForWorktree(wtPath, { forRemoval: true }))) return
               const main = workspaceState.worktrees.find((w) => w.isMain)
               if (main) selectWorktree(main.path)
 

--- a/src/renderer/src/components/palette/CommandPalette.svelte
+++ b/src/renderer/src/components/palette/CommandPalette.svelte
@@ -506,8 +506,11 @@
                 worktreePath: wtPath,
                 branch,
                 deleteBranch,
-                // Transient locks need the force-retry path even for a clean tree.
-                forceOnFailure: true,
+                // Lock retries and cleanup run unconditionally in the main flow;
+                // this flag only authorizes --force for a DIRTY tree, so it must
+                // carry exactly the consent the (destructive-styled) dialog asked
+                // for at preflight time.
+                forceOnFailure: preflight.forceRequired,
               })
               if (result.leftoverPath) {
                 addToast(

--- a/src/renderer/src/components/palette/CommandPalette.svelte
+++ b/src/renderer/src/components/palette/CommandPalette.svelte
@@ -37,6 +37,7 @@
   } from '../../lib/stores/dialogs.svelte'
   import { getTools, getToolAvailability } from '../../lib/stores/tools.svelte'
   import { addToast } from '../../lib/stores/toast.svelte'
+  import { confirmWorktreeRemoval } from '../../lib/worktrees/removalConsent'
 
   let { onClose }: { onClose: () => void } = $props()
 
@@ -465,28 +466,17 @@
             const branch = selectedWt.branch
             const operationRoot = workspaceState.worktrees.find((w) => w.isMain)?.path ?? root
             try {
-              const preflight = await window.api.worktreePrepareRemove({
+              // Shared preflight/consent gate (same as the sidebar flows): warnings
+              // and destructive consent are collected BEFORE any teardown.
+              const consent = await confirmWorktreeRemoval({
                 repoRoot: operationRoot,
                 worktreePath: wtPath,
                 branch,
               })
-
-              const msg =
-                preflight.warnings.length > 0
-                  ? preflight.warnings.join('\n') + '\n\nRemove this worktree?'
-                  : `Remove worktree "${branch}"?`
-
-              const ok = await confirm({
-                title: 'Remove Worktree',
-                message: msg,
-                details: wtPath,
-                confirmLabel: 'Remove',
-                destructive: preflight.forceRequired,
-              })
-              if (!ok) return
+              if (!consent.ok) return
 
               let deleteBranch = false
-              if (preflight.canDeleteBranch) {
+              if (consent.preflight?.canDeleteBranch) {
                 deleteBranch = await confirm({
                   title: 'Delete Branch?',
                   message: `Delete local branch "${branch}"? It has been fully merged.`,
@@ -507,10 +497,9 @@
                 branch,
                 deleteBranch,
                 // Lock retries and cleanup run unconditionally in the main flow;
-                // this flag only authorizes --force for a DIRTY tree, so it must
-                // carry exactly the consent the (destructive-styled) dialog asked
-                // for at preflight time.
-                forceOnFailure: preflight.forceRequired,
+                // this flag only authorizes --force for dirty/force-required
+                // refusals, so it must carry exactly the consent collected above.
+                forceOnFailure: consent.force,
               })
               if (result.leftoverPath) {
                 addToast(

--- a/src/renderer/src/components/sidebar/GitSection.svelte
+++ b/src/renderer/src/components/sidebar/GitSection.svelte
@@ -237,6 +237,7 @@
 </script>
 
 <span class="sr-only" aria-live="polite">{loading ? `${loading} in progress…` : ''}</span>
+<span class="sr-only" aria-live="polite">{prLoading ? 'Checking pull requests…' : ''}</span>
 <CollapsibleSection title="GIT" sectionKey="git" borderTop>
   {#snippet headerExtra()}
     <span class="flex items-center gap-1 min-w-0">
@@ -412,7 +413,10 @@
       <!-- The PR rows below depend on a network round-trip — show where they will
            appear instead of popping them in with no warning. -->
       <div class="flex items-center gap-2.5 w-full h-7 px-3 text-sm text-text-faint">
-        <LoaderCircle size={13} class="animate-spin flex-shrink-0" />
+        <LoaderCircle
+          size={13}
+          class="animate-spin-slow flex-shrink-0 motion-reduce:animate-none"
+        />
         <span class="flex-1">Checking pull requests…</span>
       </div>
     {/if}

--- a/src/renderer/src/components/sidebar/GitSection.svelte
+++ b/src/renderer/src/components/sidebar/GitSection.svelte
@@ -175,14 +175,21 @@
   // The github store map needs the GitHub API integration; fall back to the gh CLI (same auth as
   // PR creation) so the "View PR" row appears even without it — with the PR state for a chip.
   let fallbackPR = $state<{ number: number; state: string; isDraft: boolean } | null>(null)
+  // The gh-CLI fallback takes a network round-trip: without a pending state the PR
+  // rows simply popped in seconds after the section rendered, looking broken.
+  let prLoading = $state(false)
   $effect(() => {
     const path = workspaceState.selectedWorktreePath ?? workspaceState.repoRoot
     const branch = workspaceState.branch
     // Re-check after any PR mutation elsewhere in the app (create/merge/close bump the tick).
     void getPRRefreshTick()
     fallbackPR = null
-    if (!path || !branch || branchPR) return
+    if (!path || !branch || branchPR) {
+      prLoading = false
+      return
+    }
     let cancelled = false
+    prLoading = true
     window.api
       .taskTrackerPRDetails(path, branch)
       .then((pr) => {
@@ -191,6 +198,9 @@
         }
       })
       .catch(() => {})
+      .finally(() => {
+        if (!cancelled) prLoading = false
+      })
     return () => {
       cancelled = true
     }
@@ -398,6 +408,14 @@
       aria-orientation="horizontal"
     ></div>
 
+    {#if prLoading && !existingPR}
+      <!-- The PR rows below depend on a network round-trip — show where they will
+           appear instead of popping them in with no warning. -->
+      <div class="flex items-center gap-2.5 w-full h-7 px-3 text-sm text-text-faint">
+        <LoaderCircle size={13} class="animate-spin flex-shrink-0" />
+        <span class="flex-1">Checking pull requests…</span>
+      </div>
+    {/if}
     {#if existingPR}
       {@const chip = prStateChip(existingPR.state, existingPR.isDraft)}
       <button
@@ -418,7 +436,7 @@
         {/if}
       </button>
     {/if}
-    {#if showCreatePRRow}
+    {#if showCreatePRRow && !prLoading}
       <button
         class="group flex items-center gap-2.5 w-full h-7 px-3 border-0 bg-transparent text-text text-sm font-inherit cursor-pointer text-left transition-colors duration-fast enabled:hover:bg-hover disabled:text-text-faint disabled:cursor-default"
         disabled={!workspaceState.branch}

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -156,7 +156,7 @@
     removingPaths.add(wt.path)
 
     try {
-      if (!(await closeAllTabsForWorktree(wt.path))) return
+      if (!(await closeAllTabsForWorktree(wt.path, { forRemoval: true }))) return
 
       // Leave the doomed worktree BEFORE removing it — keeping it selected leaves
       // watchers and pollers pointed at a path that is being deleted.

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -13,6 +13,7 @@
     type ProjectState,
   } from '../../lib/stores/workspace.svelte'
   import { showCreateWorktree, confirm } from '../../lib/stores/dialogs.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
   import { getTabsForWorktree, closeAllTabsForWorktree } from '../../lib/stores/tabs.svelte'
   import { allPanes } from '../../lib/stores/splitTree'
   import { worktreeBadges } from '../../lib/agents/agentState.svelte'
@@ -157,28 +158,34 @@
     try {
       if (!(await closeAllTabsForWorktree(wt.path))) return
 
+      // Leave the doomed worktree BEFORE removing it — keeping it selected leaves
+      // watchers and pollers pointed at a path that is being deleted.
+      if (workspaceState.selectedWorktreePath === wt.path) {
+        const main = project.worktrees.find((w) => w.isMain)
+        if (main) selectWorktree(main.path)
+      }
+
       const isDetached = wt.branch === '(detached)'
-      await window.api.worktreeRemoveWithBranch({
+      const result = await window.api.worktreeRemoveWithBranch({
         repoRoot,
         worktreePath: wt.path,
         branch: wt.branch,
         deleteBranch: !isDetached,
         forceOnFailure: true,
       })
+      if (result.leftoverPath) {
+        addToast(
+          `Worktree removed, but some files are still in use and were left at ${result.leftoverPath}`,
+        )
+      }
     } catch (err) {
       await confirm({
         title: 'Git Error',
         message: err instanceof Error ? err.message : String(err),
         confirmLabel: 'OK',
       })
-      return
     } finally {
       removingPaths.delete(wt.path)
-    }
-
-    if (workspaceState.selectedWorktreePath === wt.path) {
-      const main = project.worktrees.find((w) => w.isMain)
-      if (main) selectWorktree(main.path)
     }
   }
 

--- a/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
+++ b/src/renderer/src/components/sidebar/ProjectTreeSection.svelte
@@ -14,6 +14,7 @@
   } from '../../lib/stores/workspace.svelte'
   import { showCreateWorktree, confirm } from '../../lib/stores/dialogs.svelte'
   import { addToast } from '../../lib/stores/toast.svelte'
+  import { confirmWorktreeRemoval } from '../../lib/worktrees/removalConsent'
   import { getTabsForWorktree, closeAllTabsForWorktree } from '../../lib/stores/tabs.svelte'
   import { allPanes } from '../../lib/stores/splitTree'
   import { worktreeBadges } from '../../lib/agents/agentState.svelte'
@@ -150,6 +151,7 @@
   async function doRemoveWorktree(
     project: ProjectState,
     wt: { path: string; branch: string },
+    forceConsented: boolean,
   ): Promise<void> {
     const repoRoot = project.worktrees.find((w) => w.isMain)?.path ?? project.repoRoot
     if (!repoRoot || removingPaths.has(wt.path)) return
@@ -171,7 +173,7 @@
         worktreePath: wt.path,
         branch: wt.branch,
         deleteBranch: !isDetached,
-        forceOnFailure: true,
+        forceOnFailure: forceConsented,
       })
       if (result.leftoverPath) {
         addToast(
@@ -197,19 +199,18 @@
     e.stopPropagation()
     if (!project.repoRoot) return
 
+    const repoRoot = project.worktrees.find((w) => w.isMain)?.path ?? project.repoRoot
+    if (!repoRoot) return
     const isDetached = wt.branch === '(detached)'
-    const ok = await confirm({
-      title: 'Remove Worktree',
-      message: isDetached
-        ? `Remove worktree "${wt.path.split('/').pop()}"?`
-        : `Remove worktree and delete branch "${wt.branch}"?`,
-      details: wt.path,
-      confirmLabel: 'Remove',
-      destructive: true,
+    const consent = await confirmWorktreeRemoval({
+      repoRoot,
+      worktreePath: wt.path,
+      branch: isDetached ? (wt.path.split('/').pop() ?? wt.path) : wt.branch,
+      detailSuffix: isDetached ? undefined : `The local branch "${wt.branch}" will be deleted.`,
     })
-    if (!ok) return
+    if (!consent.ok) return
 
-    await doRemoveWorktree(project, wt)
+    await doRemoveWorktree(project, wt, consent.force)
   }
 
   function handleNewWorktree(e: MouseEvent, project: ProjectState): void {
@@ -320,19 +321,18 @@
     closeCtxMenu()
     if (!project.repoRoot) return
 
+    const repoRoot = project.worktrees.find((w) => w.isMain)?.path ?? project.repoRoot
+    if (!repoRoot) return
     const isDetached = wt.branch === '(detached)'
-    const ok = await confirm({
-      title: 'Remove Worktree',
-      message: isDetached
-        ? `Remove worktree "${wt.path.split('/').pop()}"?`
-        : `Remove worktree and delete branch "${wt.branch}"?`,
-      details: wt.path,
-      confirmLabel: 'Remove',
-      destructive: true,
+    const consent = await confirmWorktreeRemoval({
+      repoRoot,
+      worktreePath: wt.path,
+      branch: isDetached ? (wt.path.split('/').pop() ?? wt.path) : wt.branch,
+      detailSuffix: isDetached ? undefined : `The local branch "${wt.branch}" will be deleted.`,
     })
-    if (!ok) return
+    if (!consent.ok) return
 
-    await doRemoveWorktree(project, wt)
+    await doRemoveWorktree(project, wt, consent.force)
   }
 
   function statusDotBg(status: string): string {

--- a/src/renderer/src/components/sidebar/WorktreeSection.svelte
+++ b/src/renderer/src/components/sidebar/WorktreeSection.svelte
@@ -4,6 +4,7 @@
   import { closeAllTabsForWorktree } from '../../lib/stores/tabs.svelte'
   import { showCreateWorktree, confirm } from '../../lib/stores/dialogs.svelte'
   import { addToast } from '../../lib/stores/toast.svelte'
+  import { confirmWorktreeRemoval } from '../../lib/worktrees/removalConsent'
   import { Trash2 } from '@lucide/svelte'
   import CollapsibleSection from './CollapsibleSection.svelte'
   import {
@@ -77,16 +78,13 @@
     if (!repoRoot) return
 
     const isDetached = wt.branch === '(detached)'
-    const ok = await confirm({
-      title: 'Remove Worktree',
-      message: isDetached
-        ? `Remove worktree "${wt.path.split('/').pop()}"?`
-        : `Remove worktree and delete branch "${wt.branch}"?`,
-      details: wt.path,
-      confirmLabel: 'Remove',
-      destructive: true,
+    const consent = await confirmWorktreeRemoval({
+      repoRoot,
+      worktreePath: wt.path,
+      branch: isDetached ? (wt.path.split('/').pop() ?? wt.path) : wt.branch,
+      detailSuffix: isDetached ? undefined : `The local branch "${wt.branch}" will be deleted.`,
     })
-    if (!ok) return
+    if (!consent.ok) return
 
     if (!(await closeAllTabsForWorktree(wt.path, { forRemoval: true }))) return
 
@@ -103,7 +101,7 @@
         worktreePath: wt.path,
         branch: wt.branch,
         deleteBranch: !isDetached,
-        forceOnFailure: true,
+        forceOnFailure: consent.force,
       })
       if (result.leftoverPath) {
         addToast(

--- a/src/renderer/src/components/sidebar/WorktreeSection.svelte
+++ b/src/renderer/src/components/sidebar/WorktreeSection.svelte
@@ -88,7 +88,7 @@
     })
     if (!ok) return
 
-    if (!(await closeAllTabsForWorktree(wt.path))) return
+    if (!(await closeAllTabsForWorktree(wt.path, { forRemoval: true }))) return
 
     // Leave the doomed worktree BEFORE removing it — keeping it selected leaves
     // watchers and pollers pointed at a path that is being deleted.

--- a/src/renderer/src/components/sidebar/WorktreeSection.svelte
+++ b/src/renderer/src/components/sidebar/WorktreeSection.svelte
@@ -3,6 +3,7 @@
   import { workspaceState, selectWorktree } from '../../lib/stores/workspace.svelte'
   import { closeAllTabsForWorktree } from '../../lib/stores/tabs.svelte'
   import { showCreateWorktree, confirm } from '../../lib/stores/dialogs.svelte'
+  import { addToast } from '../../lib/stores/toast.svelte'
   import { Trash2 } from '@lucide/svelte'
   import CollapsibleSection from './CollapsibleSection.svelte'
   import {
@@ -89,26 +90,32 @@
 
     if (!(await closeAllTabsForWorktree(wt.path))) return
 
+    // Leave the doomed worktree BEFORE removing it — keeping it selected leaves
+    // watchers and pollers pointed at a path that is being deleted.
+    if (workspaceState.selectedWorktreePath === wt.path) {
+      const main = workspaceState.worktrees.find((w) => w.isMain)
+      if (main) selectWorktree(main.path)
+    }
+
     try {
-      await window.api.worktreeRemoveWithBranch({
+      const result = await window.api.worktreeRemoveWithBranch({
         repoRoot,
         worktreePath: wt.path,
         branch: wt.branch,
         deleteBranch: !isDetached,
         forceOnFailure: true,
       })
+      if (result.leftoverPath) {
+        addToast(
+          `Worktree removed, but some files are still in use and were left at ${result.leftoverPath}`,
+        )
+      }
     } catch (err) {
       await confirm({
         title: 'Git Error',
         message: err instanceof Error ? err.message : String(err),
         confirmLabel: 'OK',
       })
-      return
-    }
-
-    if (workspaceState.selectedWorktreePath === wt.path) {
-      const main = workspaceState.worktrees.find((w) => w.isMain)
-      if (main) selectWorktree(main.path)
     }
   }
 </script>

--- a/src/renderer/src/components/taskTracker/TaskPanel.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPanel.svelte
@@ -20,6 +20,7 @@
     isVerifyingCredentials,
     removeActiveTask,
     resolvePanelTask,
+    updatePanelTaskStatus,
   } from '../../lib/stores/taskTracker.svelte'
   import { showProjectTracker } from '../../lib/stores/dialogs.svelte'
   import { workspaceState } from '../../lib/stores/workspace.svelte'
@@ -231,6 +232,9 @@
         assigneeAvatarUrl: fullTask.assigneeAvatarUrl,
         url: fullTask.url,
       }
+      // Keep the left-sidebar chip in sync — it renders the store's panel task, not
+      // this panel-local copy.
+      updatePanelTaskStatus(fullTask.key, fullTask.status, fullTask.statusCategory)
       // Assignee avatar proxied to a data: URL (authenticated origin or public CDN + CSP).
       assigneeAvatar = ''
       if (fullTask?.assigneeAvatarUrl) {

--- a/src/renderer/src/lib/remote/HostRpcServer.ts
+++ b/src/renderer/src/lib/remote/HostRpcServer.ts
@@ -11,6 +11,7 @@ import {
   closeAllTabsForWorktree,
 } from '../stores/tabs.svelte'
 import { attachProject, selectWorktree, workspaceState } from '../stores/workspace.svelte'
+import { removalNeedsForceConsent } from '../worktrees/removalGuard'
 import { allPanes } from '../stores/splitTree'
 import { substituteLocalhost } from '../../../../renderer-shared/url/localhostSubstitution'
 import { remoteSession } from '../stores/remoteSession.svelte'
@@ -227,10 +228,31 @@ export class HostRpcServer {
       provider.rebroadcast()
     })
 
+    this.register('worktree.prepareRemove', async (params) => {
+      const repoRoot = assertString(params, 'repoRoot', 'worktree.prepareRemove')
+      const path = assertString(params, 'path', 'worktree.prepareRemove')
+      // The handler resolves the worktree (and its branch) from the validated
+      // path; the branch field of the IPC payload is not used for preflight.
+      return window.api.worktreePrepareRemove({ repoRoot, worktreePath: path, branch: '' })
+    })
+
     this.register('worktree.remove', async (params) => {
       const repoRoot = assertString(params, 'repoRoot', 'worktree.remove')
       const path = assertString(params, 'path', 'worktree.remove')
       const force = assertBoolean(params, 'force', 'worktree.remove')
+      // Consent gate BEFORE any teardown: a dirty/submodule worktree needs --force,
+      // and mobile must have collected that consent from its user (worktree.
+      // prepareRemove). Rejecting here keeps the host's tabs, PTYs, and selection
+      // fully intact — the old flow destroyed them first and then failed anyway.
+      const preflight = await window.api
+        .worktreePrepareRemove({ repoRoot, worktreePath: path, branch: '' })
+        .catch(() => null)
+      if (preflight && removalNeedsForceConsent(preflight, force)) {
+        throw new Error(
+          `Worktree removal requires force consent: ${preflight.warnings.join(' ')} ` +
+            'Confirm the forced removal on the device and retry.',
+        )
+      }
       // Same lifecycle as the local removal flows: close the worktree's tabs
       // (tree-killing PTYs and waiting for exit) and leave the worktree BEFORE
       // removing it — otherwise host tabs/watchers hold Windows file locks and the
@@ -246,6 +268,8 @@ export class HostRpcServer {
         repoRoot,
         worktreePath: path,
         deleteBranch: false,
+        // A failed preflight (ghost/broken worktree) falls through to the removal
+        // handler's own broken-link consent gate, so pass the peer's flag verbatim.
         forceOnFailure: force,
       })
       provider.rebroadcast()

--- a/src/renderer/src/lib/remote/HostRpcServer.ts
+++ b/src/renderer/src/lib/remote/HostRpcServer.ts
@@ -244,12 +244,17 @@ export class HostRpcServer {
       // and mobile must have collected that consent from its user (worktree.
       // prepareRemove). Rejecting here keeps the host's tabs, PTYs, and selection
       // fully intact — the old flow destroyed them first and then failed anyway.
+      // A FAILED preflight (ghost worktree with a broken checkout) fails CLOSED:
+      // git cannot verify the tree, so only explicit force consent may proceed.
       const preflight = await window.api
         .worktreePrepareRemove({ repoRoot, worktreePath: path, branch: '' })
         .catch(() => null)
-      if (preflight && removalNeedsForceConsent(preflight, force)) {
+      if (removalNeedsForceConsent(preflight, force)) {
+        const reason = preflight
+          ? preflight.warnings.join(' ')
+          : 'The worktree state could not be verified (broken or corrupted checkout).'
         throw new Error(
-          `Worktree removal requires force consent: ${preflight.warnings.join(' ')} ` +
+          `Worktree removal requires force consent: ${reason} ` +
             'Confirm the forced removal on the device and retry.',
         )
       }

--- a/src/renderer/src/lib/remote/HostRpcServer.ts
+++ b/src/renderer/src/lib/remote/HostRpcServer.ts
@@ -3,8 +3,14 @@ import type { RpcMethods, RpcMethodName } from '../../../../renderer-shared/rpc/
 import { StateSnapshotProvider } from './StateSnapshotProvider.svelte'
 import { PtyStreamForwarder } from './PtyStreamForwarder'
 import { checkAction, resetSessionGrants } from './actionGuard'
-import { openTool, closeTab, switchTab, tabsByWorktree } from '../stores/tabs.svelte'
-import { attachProject, selectWorktree } from '../stores/workspace.svelte'
+import {
+  openTool,
+  closeTab,
+  switchTab,
+  tabsByWorktree,
+  closeAllTabsForWorktree,
+} from '../stores/tabs.svelte'
+import { attachProject, selectWorktree, workspaceState } from '../stores/workspace.svelte'
 import { allPanes } from '../stores/splitTree'
 import { substituteLocalhost } from '../../../../renderer-shared/url/localhostSubstitution'
 import { remoteSession } from '../stores/remoteSession.svelte'
@@ -225,13 +231,25 @@ export class HostRpcServer {
       const repoRoot = assertString(params, 'repoRoot', 'worktree.remove')
       const path = assertString(params, 'path', 'worktree.remove')
       const force = assertBoolean(params, 'force', 'worktree.remove')
-      await window.api.worktreeRemoveWithBranch({
+      // Same lifecycle as the local removal flows: close the worktree's tabs
+      // (tree-killing PTYs and waiting for exit) and leave the worktree BEFORE
+      // removing it — otherwise host tabs/watchers hold Windows file locks and the
+      // rebroadcast ships stale tab/selection state for a removed path.
+      if (!(await closeAllTabsForWorktree(path, { forRemoval: true }))) {
+        throw new Error('Worktree removal cancelled: closing its tabs was declined on the host')
+      }
+      if (workspaceState.selectedWorktreePath === path) {
+        const main = workspaceState.worktrees.find((w) => w.isMain)
+        if (main) selectWorktree(main.path)
+      }
+      const result = await window.api.worktreeRemoveWithBranch({
         repoRoot,
         worktreePath: path,
         deleteBranch: false,
         forceOnFailure: force,
       })
       provider.rebroadcast()
+      return { leftoverPath: result.leftoverPath }
     })
 
     this.register('project.attach', async (params) => {

--- a/src/renderer/src/lib/stores/tabs.svelte.ts
+++ b/src/renderer/src/lib/stores/tabs.svelte.ts
@@ -972,7 +972,10 @@ async function resumeTab(tab: TabInfo): Promise<boolean> {
   }
 }
 
-export async function closeAllTabsForWorktree(worktreePath: string): Promise<boolean> {
+export async function closeAllTabsForWorktree(
+  worktreePath: string,
+  options?: { forRemoval?: boolean },
+): Promise<boolean> {
   const tabs = tabsByWorktree[worktreePath]
   if (!tabs || tabs.length === 0) return true
 
@@ -986,7 +989,7 @@ export async function closeAllTabsForWorktree(worktreePath: string): Promise<boo
     disposeEphemeralPaneState(p)
   }
 
-  const result = await window.api.tabCloseAllForWorktree(worktreePath)
+  const result = await window.api.tabCloseAllForWorktree(worktreePath, options?.forRemoval)
 
   if (saveTimers[worktreePath]) {
     clearTimeout(saveTimers[worktreePath])

--- a/src/renderer/src/lib/stores/taskTracker.svelte.ts
+++ b/src/renderer/src/lib/stores/taskTracker.svelte.ts
@@ -358,6 +358,21 @@ export function getPanelTasks(): PanelTaskContext[] {
   return panelTasks
 }
 
+/**
+ * Patch the sidebar's copy of a panel task after the panel itself refreshed (e.g. a
+ * status transition applied). Without this the left-sidebar chip kept the stale
+ * status until the worktree was re-selected and the whole resolution re-ran.
+ */
+export function updatePanelTaskStatus(
+  taskKey: string,
+  status: string | undefined,
+  statusCategory: string | undefined,
+): void {
+  const i = panelTasks.findIndex((t) => t.taskKey === taskKey)
+  if (i < 0) return
+  panelTasks[i] = { ...panelTasks[i], status, statusCategory }
+}
+
 export function selectPanelTask(taskKey: string): void {
   const i = panelTasks.findIndex((t) => t.taskKey === taskKey)
   if (i >= 0) panelTaskIndex = i

--- a/src/renderer/src/lib/worktrees/removalConsent.test.ts
+++ b/src/renderer/src/lib/worktrees/removalConsent.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { removalNeedsForceConsent } from './removalGuard'
+
+describe('removalNeedsForceConsent', () => {
+  it('blocks a force-required removal without the force flag (host guard for remote callers)', () => {
+    expect(removalNeedsForceConsent({ forceRequired: true }, false)).toBe(true)
+  })
+
+  it('allows a force-required removal once force consent was collected', () => {
+    expect(removalNeedsForceConsent({ forceRequired: true }, true)).toBe(false)
+  })
+
+  it('allows a clean removal without force', () => {
+    expect(removalNeedsForceConsent({ forceRequired: false }, false)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/worktrees/removalConsent.test.ts
+++ b/src/renderer/src/lib/worktrees/removalConsent.test.ts
@@ -13,4 +13,12 @@ describe('removalNeedsForceConsent', () => {
   it('allows a clean removal without force', () => {
     expect(removalNeedsForceConsent({ forceRequired: false }, false)).toBe(false)
   })
+
+  it('fails closed on a missing/failed preflight without force (ghost worktree)', () => {
+    expect(removalNeedsForceConsent(null, false)).toBe(true)
+  })
+
+  it('allows a missing-preflight removal once destructive consent was collected', () => {
+    expect(removalNeedsForceConsent(null, true)).toBe(false)
+  })
 })

--- a/src/renderer/src/lib/worktrees/removalConsent.ts
+++ b/src/renderer/src/lib/worktrees/removalConsent.ts
@@ -1,0 +1,67 @@
+import { confirm } from '../stores/dialogs.svelte'
+
+export { removalNeedsForceConsent } from './removalGuard'
+
+export interface WorktreeRemovalPreflight {
+  hasUncommittedChanges: boolean
+  unmergedCommitCount: number
+  branchMerged: boolean
+  forceRequired: boolean
+  canDeleteBranch: boolean
+  warnings: string[]
+}
+
+export interface WorktreeRemovalConsent {
+  ok: boolean
+  /** Destructive consent collected — authorizes --force for dirty/force-required refusals. */
+  force: boolean
+  preflight: WorktreeRemovalPreflight | null
+}
+
+/**
+ * The one preflight/consent gate used by every local removal entry point (sidebar,
+ * project tree, command palette). Runs `worktree:prepareRemove` FIRST and puts its
+ * warnings in the confirmation, so destructive consent is informed and collected
+ * before any teardown. When the preflight itself fails — e.g. a ghost worktree
+ * whose broken `.git` link makes `git status` impossible — it falls back to a
+ * generic destructive confirmation with force consent, which is exactly what the
+ * broken-link removal path requires.
+ */
+export async function confirmWorktreeRemoval(args: {
+  repoRoot: string
+  worktreePath: string
+  branch: string
+  /** Extra sentence appended to the confirmation (e.g. branch deletion notice). */
+  detailSuffix?: string
+}): Promise<WorktreeRemovalConsent> {
+  let preflight: WorktreeRemovalPreflight | null = null
+  try {
+    preflight = await window.api.worktreePrepareRemove({
+      repoRoot: args.repoRoot,
+      worktreePath: args.worktreePath,
+      branch: args.branch,
+    })
+  } catch {
+    // Ghost/broken worktrees cannot be preflighted — git cannot verify their
+    // state, so the confirmation below is explicitly destructive.
+  }
+
+  const warnings = preflight?.warnings ?? [
+    'The worktree state could not be verified (broken or corrupted checkout) — files inside may include unsaved work.',
+  ]
+  const forceRequired = preflight?.forceRequired ?? true
+
+  const lines = forceRequired ? [...warnings, ''] : []
+  lines.push(`Remove worktree "${args.branch}"?`)
+  if (args.detailSuffix) lines.push(args.detailSuffix)
+
+  const ok = await confirm({
+    title: 'Remove Worktree',
+    message: lines.join('\n'),
+    details: args.worktreePath,
+    confirmLabel: 'Remove',
+    destructive: forceRequired,
+  })
+
+  return { ok, force: forceRequired, preflight }
+}

--- a/src/renderer/src/lib/worktrees/removalGuard.ts
+++ b/src/renderer/src/lib/worktrees/removalGuard.ts
@@ -2,11 +2,14 @@
  * Whether a removal request may proceed without a fresh consent round-trip.
  * Shared rule for every entry point — local flows and the remote RPC host guard:
  * a preflight that demands force must be met by an explicit force flag BEFORE any
- * teardown (tabs, PTYs, selection) starts.
+ * teardown (tabs, PTYs, selection) starts. A missing/failed preflight (`null` —
+ * e.g. a ghost worktree whose broken checkout makes `git status` impossible)
+ * fails CLOSED: git cannot verify the tree, so it must be treated as
+ * force-required rather than waved through.
  */
 export function removalNeedsForceConsent(
-  preflight: { forceRequired: boolean },
+  preflight: { forceRequired: boolean } | null,
   force: boolean,
 ): boolean {
-  return preflight.forceRequired && !force
+  return (preflight?.forceRequired ?? true) && !force
 }

--- a/src/renderer/src/lib/worktrees/removalGuard.ts
+++ b/src/renderer/src/lib/worktrees/removalGuard.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether a removal request may proceed without a fresh consent round-trip.
+ * Shared rule for every entry point — local flows and the remote RPC host guard:
+ * a preflight that demands force must be met by an explicit force flag BEFORE any
+ * teardown (tabs, PTYs, selection) starts.
+ */
+export function removalNeedsForceConsent(
+  preflight: { forceRequired: boolean },
+  force: boolean,
+): boolean {
+  return preflight.forceRequired && !force
+}


### PR DESCRIPTION
## What

Makes worktree creation/removal robust on Windows and eliminates the error spam around both — plus two sidebar fixes reported alongside.

**Removal** (reproduced e2e on a real 58k-file repo: 26s hard failure + stray branch + ghost folder before → 11s clean, non-forced removal after):
- The main process now prepares the directory before `git worktree remove`: kills every PTY whose cwd lies inside the worktree (full process trees, awaited until exit — tab close used to fire-and-forget in 2ms) and stops file/git watchers subscribed under the path (a live `ReadDirectoryChangesW` handle blocks `rmdir`).
- Git failures are classified (`already-removed` / `locked` / `dirty`) with backoff retries instead of one blind force-retry that turned partial successes into `fatal: ... is not a working tree`.
- After unregistration: `git worktree prune`, directory-gone verification with `fs.rm` retries, and a `leftoverPath` result (surfaced as a toast) when another process still holds files — no more silent ghost folders.
- Branch deletion runs even when removal needed fallbacks — an aborted flow no longer leaves stray branches.
- Renderer flows (sidebar, project tree, command palette) close tabs AND leave the worktree before removing it. The palette flow — the only path for unmerged worktrees — previously did neither and never forced.

**Creation:**
- Pre-flight refuses a non-empty leftover target directory with an actionable message BEFORE any git call (an empty one is cleaned automatically), and rolls back the `-b` branch when `git worktree add` fails — failed creates used to leave stray local branches (observed live with a leftover `master` folder).
- The create-worktree modal is keyed by dialog identity, so reopening starts clean instead of showing the previous attempt's error.

**Noise silenced** (all observed in the field even when operations succeeded):
- unborn-HEAD repos (no commits yet) report `null` branch instead of a logged `ambiguous argument 'HEAD'` error,
- watcher backends are pinned per-OS — `@parcel/watcher` no longer probes for a `watchman` binary (`'watchman' is not recognized…` on every start),
- the tracker credential probe returns an `{ok}` envelope unwrapped in preload, so expected 401s stop printing full handler stacks on every worktree switch.

**Sidebar fixes:**
- applying a task status transition updates the left-sidebar chip immediately (used to require re-selecting the worktree),
- the GIT section shows a "Checking pull requests…" loader while the gh-CLI fallback is in flight.

## Why

Reported from live usage: worktree create/remove "często się wysypują" on Windows, console full of errors even on success. Root causes confirmed by e2e repro: the app raced its own lock holders (dying PTYs, native watchers, stale selection) and mishandled partial git failures.

## How to test

1. `npm run dev`, open a large repo, create a worktree (Existing/New branch) — a PowerShell tab auto-opens in it.
2. Remove the worktree via the command palette ("Remove Current Worktree") — it succeeds in seconds without force, the branch is deleted, the folder is gone, and the main-process console stays quiet.
3. Put debris at a worktree target path (non-empty folder) and create → actionable error before any git call, no stray branch afterwards.
4. Startup console: no `watchman` probe error, no `ambiguous argument 'HEAD'` for empty repos, no 401 handler stacks with expired tracker tokens.
5. Task panel → apply a status transition → the left-sidebar chip updates immediately.
6. `npm test` (98 tests), `npm run build`, `npm run lint`.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default) — n/a, bugfix
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands (win32-specific behavior is platform-gated)
- [x] Keyboard accessible — no new interactive elements beyond a status row
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly
- [x] Feature docs in `docs/` updated (`docs/core/worktree.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)