### PR TITLE
feat(ui): shared Markdown component and in-app attachment viewer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,8 @@ window grouping so multiple projects that lived in one window reopen in that sam
 
 All display-only markdown (task descriptions/comments, PR bodies, changelog, license) renders
 through the shared `src/renderer/src/components/shared/Markdown.svelte` component (marked +
-DOMPurify with style tags/attributes forbidden) — never through ad-hoc `{@html}` pipelines.
+DOMPurify with a markdown-specific tag/attribute allowlist — no forms/controls/SVG, no
+style/class/id) — never through ad-hoc `{@html}` pipelines.
 
 ## Data storage
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,6 +71,10 @@ sessions, Git watchers, file watchers, remote sessions) that maintain in-memory 
 resources. Window snapshots are saved on close/quit and restored with their original project-to-
 window grouping so multiple projects that lived in one window reopen in that same window.
 
+All display-only markdown (task descriptions/comments, PR bodies, changelog, license) renders
+through the shared `src/renderer/src/components/shared/Markdown.svelte` component (marked +
+DOMPurify with style tags/attributes forbidden) — never through ad-hoc `{@html}` pipelines.
+
 ## Data storage
 
 Canopy uses a multi-tiered storage strategy to balance persistence, security, and portability:

--- a/docs/integrations/task-tracker.md
+++ b/docs/integrations/task-tracker.md
@@ -53,9 +53,16 @@ Jira maps `issuetype.subtask = true` to `subtask`, and normalizes type names (`U
 1. User selects a task from the list.
 2. Canopy fetches comments via `fetchTaskComments` and attachments via `fetchTaskAttachments`.
 3. Comments are truncated to 1000 characters each; a maximum of 15 recent comments are shown.
-4. Task description is truncated to 3000 characters.
+4. Task description is truncated to 3000 characters. Descriptions and comments render as
+   sanitized markdown through the shared `Markdown` component
+   (`src/renderer/src/components/shared/Markdown.svelte`).
 5. Attachments can be downloaded to a temp directory (`canopy-attachments-{uuid}` in `os.tmpdir()`). Downloads are capped at 50 MB per file with a 60-second timeout. The download URL must match the connection's `baseUrl` origin.
 6. Downloaded attachments are automatically cleaned up after 60 seconds.
+7. Clicking an attachment opens an in-app lightbox (`AttachmentLightbox`): images render
+   directly (proxied through the authenticated connection, addressed by task key +
+   attachment id only), every attachment offers **Save…** to disk via a native save
+   dialog (`taskTracker:attachmentSave`, suggested filename sanitized), and opening the
+   tracker in the browser is a secondary icon action.
 
 ### Task panel & write-back
 

--- a/docs/integrations/task-tracker.md
+++ b/docs/integrations/task-tracker.md
@@ -289,6 +289,10 @@ When a GitHub tracker has an empty `projectKey`, Canopy reads the git remote URL
 
 ## Error states
 
+Note: `taskTracker:attachmentSave` additionally throws plain validation errors that surface
+verbatim in a toast — `Invalid task key`, `Invalid attachment id`, `No tracker configured`,
+and `Attachment not found on this task`.
+
 | Error                      | User sees                                        | Cause                                                                     |
 | -------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------- |
 | `ConnectionNotFound`       | "Connection not found: {id}"                     | Deleted or invalid connection ID referenced                               |
@@ -332,6 +336,9 @@ For the four statuses that carry an underlying error — `AgentStartFailed`, `Ta
   - `providers/github.ts` - GitHub GraphQL API client
   - `errors.ts` - typed error union with message formatter
 - Store: `src/renderer/src/lib/stores/taskTracker.svelte.ts`
+- UI components: `src/renderer/src/components/taskTracker/AttachmentLightbox.svelte` (in-app
+  attachment viewer with save-to-disk) and `src/renderer/src/components/shared/Markdown.svelte`
+  (sanitized markdown rendering for descriptions/comments)
 - Components: `src/renderer/src/lib/taskTracker/`
   - `branchCreation.ts` - branch creation flow with stash/confirm dialogs
   - `taskContext.ts` - task context formatting for AI agents

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -4693,20 +4693,24 @@ export function registerIpcHandlers(
         payload.repoRoot,
       )
       const localPath = unwrapOrThrow(result, taskTrackerErrorMessage)
-      // Stage next to the destination and swap in only after the copy succeeded —
-      // copyFile() straight onto an existing file is non-atomic, so a mid-copy
-      // failure (full disk, disconnected volume) would destroy the user's
-      // previous file. rename() replaces existing destinations on all platforms.
-      const stagedPath = `${saveResult.filePath}.canopy-tmp-${Math.random().toString(36).slice(2, 10)}`
+      // Stage in an app-owned mkdtemp directory NEXT TO the destination (same
+      // volume, so the final rename never crosses filesystems) and swap in only
+      // after the copy succeeded — copyFile() straight onto an existing file is
+      // non-atomic, so a mid-copy failure would destroy the user's previous file.
+      // mkdtemp guarantees ownership of everything under the staging dir, making
+      // the cleanup below safe by construction (no risk of deleting a pre-existing
+      // sibling), and the short fixed basename cannot exceed name-length limits.
+      const stagingDir = await fs.promises.mkdtemp(
+        path.join(path.dirname(saveResult.filePath), '.canopy-save-'),
+      )
+      const stagedPath = path.join(stagingDir, 'staged')
       try {
-        // COPYFILE_EXCL: fail rather than write through a pre-existing staging path.
-        await fs.promises.copyFile(localPath, stagedPath, fs.constants.COPYFILE_EXCL)
+        await fs.promises.copyFile(localPath, stagedPath)
+        // rename() replaces existing destinations on all platforms.
         await fs.promises.rename(stagedPath, saveResult.filePath)
         return saveResult.filePath
-      } catch (e) {
-        await fs.promises.rm(stagedPath, { force: true }).catch(() => {})
-        throw e
       } finally {
+        await fs.promises.rm(stagingDir, { recursive: true, force: true }).catch(() => {})
         taskTrackerManager.cleanupAttachmentDir(localPath)
       }
     },

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -4699,7 +4699,8 @@ export function registerIpcHandlers(
       // previous file. rename() replaces existing destinations on all platforms.
       const stagedPath = `${saveResult.filePath}.canopy-tmp-${Math.random().toString(36).slice(2, 10)}`
       try {
-        await fs.promises.copyFile(localPath, stagedPath)
+        // COPYFILE_EXCL: fail rather than write through a pre-existing staging path.
+        await fs.promises.copyFile(localPath, stagedPath, fs.constants.COPYFILE_EXCL)
         await fs.promises.rename(stagedPath, saveResult.filePath)
         return saveResult.filePath
       } catch (e) {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -4700,17 +4700,23 @@ export function registerIpcHandlers(
       // mkdtemp guarantees ownership of everything under the staging dir, making
       // the cleanup below safe by construction (no risk of deleting a pre-existing
       // sibling), and the short fixed basename cannot exceed name-length limits.
-      const stagingDir = await fs.promises.mkdtemp(
-        path.join(path.dirname(saveResult.filePath), '.canopy-save-'),
-      )
-      const stagedPath = path.join(stagingDir, 'staged')
+      // The staging creation lives INSIDE the block owning the download's
+      // lifetime: an mkdtemp rejection (ACL forbidding directory creation,
+      // read-only share) must still clean up the temp download in finally.
+      let stagingDir: string | null = null
       try {
+        stagingDir = await fs.promises.mkdtemp(
+          path.join(path.dirname(saveResult.filePath), '.canopy-save-'),
+        )
+        const stagedPath = path.join(stagingDir, 'staged')
         await fs.promises.copyFile(localPath, stagedPath)
         // rename() replaces existing destinations on all platforms.
         await fs.promises.rename(stagedPath, saveResult.filePath)
         return saveResult.filePath
       } finally {
-        await fs.promises.rm(stagingDir, { recursive: true, force: true }).catch(() => {})
+        if (stagingDir) {
+          await fs.promises.rm(stagingDir, { recursive: true, force: true }).catch(() => {})
+        }
         taskTrackerManager.cleanupAttachmentDir(localPath)
       }
     },

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -4632,6 +4632,76 @@ export function registerIpcHandlers(
     },
   )
 
+  ipcMain.handle(
+    'taskTracker:attachmentSave',
+    async (
+      event,
+      payload: {
+        repoRoot?: string
+        trackerId?: string
+        taskKey: string
+        attachmentId: string
+      },
+    ): Promise<string | null> => {
+      // Same hardened addressing as attachmentPreview: the renderer supplies only
+      // task key + attachment id, the provider's own metadata decides URL and name.
+      if (typeof payload.taskKey !== 'string' || !TASK_KEY_RE.test(payload.taskKey)) {
+        throw new Error('Invalid task key')
+      }
+      if (
+        typeof payload.attachmentId !== 'string' ||
+        payload.attachmentId.length === 0 ||
+        payload.attachmentId.length > 2048
+      ) {
+        throw new Error('Invalid attachment id')
+      }
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (!win || win.isDestroyed()) return null
+      const resolved = await resolveEffectiveConfig(payload.repoRoot)
+      if (!resolved) throw new Error('No tracker configured')
+      const attachments = unwrapOrThrow(
+        await taskTrackerManager.fetchTaskAttachmentsFromConfig(
+          resolved.config,
+          payload.taskKey,
+          payload.trackerId,
+          payload.repoRoot,
+        ),
+        taskTrackerErrorMessage,
+      )
+      const attachment = attachments.find(
+        (a) => a.id === payload.attachmentId || a.url === payload.attachmentId,
+      )
+      if (!attachment) throw new Error('Attachment not found on this task')
+
+      // Ask for the destination FIRST — no download work for a cancelled dialog.
+      // The suggested filename comes from tracker metadata; strip anything
+      // path-like so it cannot steer the dialog outside the chosen directory.
+      const suggestedName =
+        (attachment.name || 'attachment').replace(/[\\/:*?"<>|]/g, '_').slice(0, 150) ||
+        'attachment'
+      const saveResult = await dialog.showSaveDialog(win, {
+        title: 'Save Attachment',
+        defaultPath: suggestedName,
+      })
+      if (saveResult.canceled || !saveResult.filePath) return null
+
+      const result = await taskTrackerManager.downloadAttachmentFromConfig(
+        resolved.config,
+        attachment.url,
+        attachment.name || 'attachment',
+        payload.trackerId,
+        payload.repoRoot,
+      )
+      const localPath = unwrapOrThrow(result, taskTrackerErrorMessage)
+      try {
+        await fs.promises.copyFile(localPath, saveResult.filePath)
+        return saveResult.filePath
+      } finally {
+        taskTrackerManager.cleanupAttachmentDir(localPath)
+      }
+    },
+  )
+
   // --- Worktree Setup ---
 
   const setupAbortControllers = new Map<number, AbortController>()

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -4693,9 +4693,18 @@ export function registerIpcHandlers(
         payload.repoRoot,
       )
       const localPath = unwrapOrThrow(result, taskTrackerErrorMessage)
+      // Stage next to the destination and swap in only after the copy succeeded —
+      // copyFile() straight onto an existing file is non-atomic, so a mid-copy
+      // failure (full disk, disconnected volume) would destroy the user's
+      // previous file. rename() replaces existing destinations on all platforms.
+      const stagedPath = `${saveResult.filePath}.canopy-tmp-${Math.random().toString(36).slice(2, 10)}`
       try {
-        await fs.promises.copyFile(localPath, saveResult.filePath)
+        await fs.promises.copyFile(localPath, stagedPath)
+        await fs.promises.rename(stagedPath, saveResult.filePath)
         return saveResult.filePath
+      } catch (e) {
+        await fs.promises.rm(stagedPath, { force: true }).catch(() => {})
+        throw e
       } finally {
         taskTrackerManager.cleanupAttachmentDir(localPath)
       }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1236,6 +1236,14 @@ interface CanopyAPI {
     attachmentId: string,
     trackerId?: string,
   ) => Promise<string>
+  /** Save an attachment to disk via a native save dialog; resolves with the saved
+   *  path, or null when the user cancelled. */
+  trackerConfigAttachmentSave: (
+    repoRoot: string | undefined,
+    taskKey: string,
+    attachmentId: string,
+    trackerId?: string,
+  ) => Promise<string | null>
 
   // GitHub PR features
   githubFetchBranchPRs: (repoRoot: string) => Promise<GitHubBranchPRMap>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1627,6 +1627,18 @@ const api = {
       attachmentId,
       trackerId,
     }) as Promise<string>,
+  trackerConfigAttachmentSave: (
+    repoRoot: string | undefined,
+    taskKey: string,
+    attachmentId: string,
+    trackerId?: string,
+  ) =>
+    ipcRenderer.invoke('taskTracker:attachmentSave', {
+      repoRoot,
+      taskKey,
+      attachmentId,
+      trackerId,
+    }) as Promise<string | null>,
 
   // GitHub PR features
   githubFetchBranchPRs: (repoRoot: string) =>

--- a/src/renderer/src/components/dialogs/AboutModal.svelte
+++ b/src/renderer/src/components/dialogs/AboutModal.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { marked } from 'marked'
-  import DOMPurify from 'dompurify'
   import { closeDialog } from '../../lib/stores/dialogs.svelte'
+  import Markdown from '../shared/Markdown.svelte'
 
   let containerEl: HTMLDivElement | undefined = $state()
   let version = $state('')
   let homepage = $state('')
-  let licenseHtml = $state('')
+  let licenseText = $state('')
 
   onMount(async () => {
     containerEl?.focus()
     const info = await window.api.getAboutInfo()
     version = info.version
     homepage = info.homepage
-    licenseHtml = DOMPurify.sanitize(await marked.parse(info.license))
+    licenseText = info.license
   })
 
   function handleKeydown(e: KeyboardEvent): void {
@@ -45,12 +44,6 @@
 
   function openHomepage(): void {
     window.api.openExternal(homepage)
-  }
-
-  function htmlContent(node: HTMLElement, content: () => string): void {
-    $effect(() => {
-      node.innerHTML = content()
-    })
   }
 </script>
 
@@ -90,13 +83,13 @@
       </button>
     {/if}
 
-    {#if licenseHtml}
+    {#if licenseText}
       <div class="mb-4">
         <h3 class="m-0 mb-2 text-md font-semibold text-text-secondary">License</h3>
         <div
           class="license-content max-h-50 overflow-y-auto p-3 bg-bg-input rounded-lg border border-border-subtle text-xs leading-normal text-text-secondary"
         >
-          <div use:htmlContent={() => licenseHtml}></div>
+          <Markdown source={licenseText} />
         </div>
       </div>
     {/if}

--- a/src/renderer/src/components/dialogs/ChangelogModal.svelte
+++ b/src/renderer/src/components/dialogs/ChangelogModal.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { marked } from 'marked'
-  import DOMPurify from 'dompurify'
   import { closeDialog } from '../../lib/stores/dialogs.svelte'
+  import Markdown from '../shared/Markdown.svelte'
 
   let containerEl: HTMLDivElement | undefined = $state()
 
@@ -12,7 +11,7 @@
 
   let { fromVersion }: Props = $props()
 
-  let entries: Array<{ version: string; date: string; html: string }> = $state([])
+  let entries: Array<{ version: string; date: string; body: string }> = $state([])
   let loading = $state(true)
   let error = $state(false)
 
@@ -20,13 +19,7 @@
     containerEl?.focus()
     const raw = await window.api.getChangelogSinceVersion(fromVersion)
     if (raw && raw.length > 0) {
-      entries = await Promise.all(
-        raw.map(async (e) => ({
-          version: e.version,
-          date: e.date,
-          html: DOMPurify.sanitize(await marked.parse(e.body)),
-        })),
-      )
+      entries = raw.map((e) => ({ version: e.version, date: e.date, body: e.body }))
     } else if (!raw) {
       error = true
     }
@@ -57,12 +50,6 @@
         first.focus()
       }
     }
-  }
-
-  function htmlContent(node: HTMLElement, content: () => string): void {
-    $effect(() => {
-      node.innerHTML = content()
-    })
   }
 </script>
 
@@ -113,17 +100,7 @@
               >
               <span class="text-sm text-text-faint">{entry.date}</span>
             </div>
-            <div
-              class="entry-body text-md leading-[1.6] text-text-secondary"
-              use:htmlContent={() => entry.html}
-              onclick={(e: MouseEvent) => {
-                const anchor = (e.target as HTMLElement).closest('a')
-                if (anchor?.href) {
-                  e.preventDefault()
-                  window.api.openExternal(anchor.href)
-                }
-              }}
-            ></div>
+            <Markdown source={entry.body} class="text-md leading-[1.6] text-text-secondary" />
           </div>
         {/each}
       {/if}

--- a/src/renderer/src/components/github/PRDetailsModal.svelte
+++ b/src/renderer/src/components/github/PRDetailsModal.svelte
@@ -9,6 +9,7 @@
   import { prStateChip } from '../../lib/github/prState'
   import { formatDateTime } from '../../lib/formatDate'
   import CustomSelect from '../shared/CustomSelect.svelte'
+  import Markdown from '../shared/Markdown.svelte'
 
   // Native PR panel: everything comes from the authenticated gh CLI, so no GitHub login is
   // required inside Canopy (the embedded browser has no session).
@@ -392,11 +393,9 @@
         <div class="flex flex-col gap-1">
           <span class={sectionLabelCls}>Description</span>
           {#if pr.body?.trim()}
-            <p
-              class="m-0 text-xs text-text leading-snug whitespace-pre-wrap break-words rounded-lg border border-border-subtle bg-bg-input px-3 py-2"
-            >
-              {pr.body}
-            </p>
+            <div class="rounded-lg border border-border-subtle bg-bg-input px-3 py-2">
+              <Markdown source={pr.body} class="text-xs text-text leading-snug break-words" />
+            </div>
           {:else}
             <p class="m-0 text-xs text-text-faint">No description.</p>
           {/if}

--- a/src/renderer/src/components/shared/Markdown.svelte
+++ b/src/renderer/src/components/shared/Markdown.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  import { marked } from 'marked'
+  import DOMPurify from 'dompurify'
+
+  // The one markdown renderer for the app: task descriptions/comments, PR bodies,
+  // notes preview, changelog, license. Parsing is async (marked may return a
+  // promise) and generation-guarded so a slower parse of an older source can never
+  // overwrite a newer one. Output is DOMPurify-sanitized; link clicks need no local
+  // handling — the main process blocks top-level navigation (`will-navigate`) and
+  // routes safe external URLs to the OS browser.
+  let { source = '', class: cls = '' }: { source?: string; class?: string } = $props()
+
+  let html = $state('')
+  let parseGen = 0
+
+  $effect(() => {
+    const gen = ++parseGen
+    const raw = source
+    if (!raw.trim()) {
+      html = ''
+      return
+    }
+    // GFM with newline-as-break matches how trackers (GitHub, YouTrack, Jira
+    // comments) treat single newlines in descriptions and comments.
+    Promise.resolve(marked.parse(raw, { gfm: true, breaks: true })).then((parsed) => {
+      if (gen !== parseGen) return
+      html = DOMPurify.sanitize(parsed)
+    })
+  })
+</script>
+
+<div class="md-content {cls}">
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized above -->
+  {@html html}
+</div>
+
+<style>
+  /* Em-based so the consumer's text size utility scales the whole document. */
+  .md-content :global(> :first-child) {
+    margin-top: 0;
+  }
+  .md-content :global(> :last-child) {
+    margin-bottom: 0;
+  }
+  .md-content :global(h1),
+  .md-content :global(h2),
+  .md-content :global(h3),
+  .md-content :global(h4),
+  .md-content :global(h5),
+  .md-content :global(h6) {
+    margin: 0.9em 0 0.35em;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--color-text);
+  }
+  .md-content :global(h1) {
+    font-size: 1.35em;
+  }
+  .md-content :global(h2) {
+    font-size: 1.2em;
+  }
+  .md-content :global(h3) {
+    font-size: 1.1em;
+  }
+  .md-content :global(h4),
+  .md-content :global(h5),
+  .md-content :global(h6) {
+    font-size: 1em;
+  }
+  .md-content :global(p) {
+    margin: 0.45em 0;
+    line-height: 1.5;
+  }
+  .md-content :global(ul),
+  .md-content :global(ol) {
+    margin: 0.45em 0;
+    padding-left: 1.4em;
+  }
+  .md-content :global(li) {
+    margin: 0.15em 0;
+    line-height: 1.5;
+  }
+  .md-content :global(li > ul),
+  .md-content :global(li > ol) {
+    margin: 0.1em 0;
+  }
+  .md-content :global(a) {
+    color: var(--color-accent-text);
+    text-decoration: none;
+  }
+  .md-content :global(a:hover) {
+    text-decoration: underline;
+  }
+  .md-content :global(code) {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.92em;
+    background: var(--color-bg-input);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 4px;
+    padding: 0.05em 0.3em;
+  }
+  .md-content :global(pre) {
+    margin: 0.55em 0;
+    padding: 0.6em 0.75em;
+    background: var(--color-bg-input);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 6px;
+    overflow-x: auto;
+  }
+  .md-content :global(pre code) {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    font-size: 0.92em;
+  }
+  .md-content :global(blockquote) {
+    margin: 0.55em 0;
+    padding: 0.1em 0.8em;
+    border-left: 3px solid var(--color-border);
+    color: var(--color-text-muted);
+  }
+  .md-content :global(hr) {
+    border: 0;
+    border-top: 1px solid var(--color-border-subtle);
+    margin: 0.8em 0;
+  }
+  .md-content :global(table) {
+    border-collapse: collapse;
+    margin: 0.55em 0;
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+  .md-content :global(th),
+  .md-content :global(td) {
+    border: 1px solid var(--color-border-subtle);
+    padding: 0.25em 0.6em;
+    text-align: left;
+  }
+  .md-content :global(th) {
+    background: var(--color-bg-input);
+    font-weight: 600;
+  }
+  .md-content :global(img) {
+    max-width: 100%;
+    border-radius: 6px;
+  }
+  .md-content :global(input[type='checkbox']) {
+    margin-right: 0.35em;
+  }
+</style>

--- a/src/renderer/src/components/shared/Markdown.svelte
+++ b/src/renderer/src/components/shared/Markdown.svelte
@@ -1,13 +1,32 @@
-<script lang="ts">
-  import { marked } from 'marked'
+<script lang="ts" module>
+  import { Marked } from 'marked'
   import DOMPurify from 'dompurify'
 
+  // Component-local Marked instance so the overrides below never leak into other
+  // `marked` consumers (the notes pane has its own pipeline). GFM with
+  // newline-as-break matches how trackers treat single newlines.
+  const md = new Marked({
+    gfm: true,
+    breaks: true,
+    renderer: {
+      // The renderer CSP (`img-src 'self' data:`) blocks remote images, so an
+      // `<img>` would render as a broken glyph. Emit a labelled link instead —
+      // the main process routes the click to the OS browser (`will-navigate`).
+      image({ href, text }): string {
+        const label = text?.trim() ? text : 'image'
+        return `<a href="${href}">🖼 ${label}</a>`
+      },
+    },
+  })
+</script>
+
+<script lang="ts">
   // The one markdown renderer for the app: task descriptions/comments, PR bodies,
-  // notes preview, changelog, license. Parsing is async (marked may return a
-  // promise) and generation-guarded so a slower parse of an older source can never
-  // overwrite a newer one. Output is DOMPurify-sanitized; link clicks need no local
-  // handling — the main process blocks top-level navigation (`will-navigate`) and
-  // routes safe external URLs to the OS browser.
+  // changelog, license. Parsing is async (marked may return a promise) and
+  // generation-guarded so a slower parse of an older source can never overwrite a
+  // newer one. Output is DOMPurify-sanitized; link clicks need no local handling —
+  // the main process blocks top-level navigation (`will-navigate`) and routes safe
+  // external URLs to the OS browser.
   let { source = '', class: cls = '' }: { source?: string; class?: string } = $props()
 
   let html = $state('')
@@ -20,11 +39,13 @@
       html = ''
       return
     }
-    // GFM with newline-as-break matches how trackers (GitHub, YouTrack, Jira
-    // comments) treat single newlines in descriptions and comments.
-    Promise.resolve(marked.parse(raw, { gfm: true, breaks: true })).then((parsed) => {
+    Promise.resolve(md.parse(raw)).then((parsed) => {
       if (gen !== parseGen) return
-      html = DOMPurify.sanitize(parsed)
+      // Style tags/attributes are forbidden on top of the default profile: the CSP
+      // allows inline styles, and DOMPurify's defaults would let a <style> block in
+      // tracker/PR content restyle app chrome (UI redress) — selectors are not
+      // scoped to this component.
+      html = DOMPurify.sanitize(parsed, { FORBID_TAGS: ['style'], FORBID_ATTR: ['style'] })
     })
   })
 </script>
@@ -141,6 +162,9 @@
     background: var(--color-bg-input);
     font-weight: 600;
   }
+  /* Applies only to data:-URL images from raw HTML in the source — markdown image
+     syntax renders as a link (see the renderer override) because the CSP blocks
+     remote image loads. */
   .md-content :global(img) {
     max-width: 100%;
     border-radius: 6px;

--- a/src/renderer/src/components/shared/Markdown.svelte
+++ b/src/renderer/src/components/shared/Markdown.svelte
@@ -77,6 +77,12 @@
       'input',
     ],
     ALLOWED_ATTR: ['href', 'title', 'alt', 'src', 'align', 'start', 'type', 'checked', 'disabled'],
+    // data-*/aria-* are checked BEFORE the allowlist and default to allowed —
+    // markdown output needs neither, and the app addresses DOM nodes with
+    // document-wide data-* queries (focus restore, list selection), which rendered
+    // tracker content could hijack.
+    ALLOW_DATA_ATTR: false,
+    ALLOW_ARIA_ATTR: false,
   }
 
   // Dedicated DOMPurify instance: the checkbox hook below must not leak into other

--- a/src/renderer/src/components/shared/Markdown.svelte
+++ b/src/renderer/src/components/shared/Markdown.svelte
@@ -5,6 +5,9 @@
   // Component-local Marked instance so the overrides below never leak into other
   // `marked` consumers (the notes pane has its own pipeline). GFM with
   // newline-as-break matches how trackers treat single newlines.
+  const escapeHtml = (s: string): string =>
+    s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
   const md = new Marked({
     gfm: true,
     breaks: true,
@@ -12,12 +15,20 @@
       // The renderer CSP (`img-src 'self' data:`) blocks remote images, so an
       // `<img>` would render as a broken glyph. Emit a labelled link instead —
       // the main process routes the click to the OS browser (`will-navigate`).
+      // Both interpolations are escaped: the default renderer runs href through
+      // cleanUrl(), and dropping that would let a quote in the href inject
+      // attributes into the anchor.
       image({ href, text }): string {
         const label = text?.trim() ? text : 'image'
-        return `<a href="${href}">🖼 ${label}</a>`
+        return `<a href="${escapeHtml(href)}">🖼 ${escapeHtml(label)}</a>`
       },
     },
   })
+
+  // On top of the default profile: no live CSS (the CSP allows inline styles) and
+  // no class/id — the app ships global Tailwind utilities, so an attacker-supplied
+  // class list could rebuild a full-viewport overlay out of our own tokens.
+  const SANITIZE_OPTS = { FORBID_TAGS: ['style'], FORBID_ATTR: ['style', 'class', 'id'] }
 </script>
 
 <script lang="ts">
@@ -39,14 +50,18 @@
       html = ''
       return
     }
-    Promise.resolve(md.parse(raw)).then((parsed) => {
-      if (gen !== parseGen) return
-      // Style tags/attributes are forbidden on top of the default profile: the CSP
-      // allows inline styles, and DOMPurify's defaults would let a <style> block in
-      // tracker/PR content restyle app chrome (UI redress) — selectors are not
-      // scoped to this component.
-      html = DOMPurify.sanitize(parsed, { FORBID_TAGS: ['style'], FORBID_ATTR: ['style'] })
-    })
+    // Promise.resolve().then(...) so a SYNCHRONOUS parser throw lands in the catch
+    // instead of escaping the effect; the catch falls back to the sanitized raw
+    // source rather than leaving stale HTML from a previous source on screen.
+    Promise.resolve()
+      .then(() => md.parse(raw))
+      .then((parsed) => {
+        if (gen !== parseGen) return
+        html = DOMPurify.sanitize(parsed, SANITIZE_OPTS)
+      })
+      .catch(() => {
+        if (gen === parseGen) html = DOMPurify.sanitize(raw, SANITIZE_OPTS)
+      })
   })
 </script>
 

--- a/src/renderer/src/components/shared/Markdown.svelte
+++ b/src/renderer/src/components/shared/Markdown.svelte
@@ -5,8 +5,16 @@
   // Component-local Marked instance so the overrides below never leak into other
   // `marked` consumers (the notes pane has its own pipeline). GFM with
   // newline-as-break matches how trackers treat single newlines.
-  const escapeHtml = (s: string): string =>
-    s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  // Entity-aware attribute escaper (marked's "no-encode" variant): the tokenizer
+  // hands the image alt text over ALREADY entity-escaped, so re-escaping `&`
+  // unconditionally would render `Q&amp;A` literally. Leaving existing entities
+  // alone is exactly as safe for the attribute-injection case.
+  const escapeAttr = (s: string): string =>
+    s
+      .replace(/&(?!(#\d{1,7}|#[Xx][a-fA-F0-9]{1,6}|\w+);)/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
 
   const md = new Marked({
     gfm: true,
@@ -20,7 +28,7 @@
       // attributes into the anchor.
       image({ href, text }): string {
         const label = text?.trim() ? text : 'image'
-        return `<a href="${escapeHtml(href)}">🖼 ${escapeHtml(label)}</a>`
+        return `<a href="${escapeAttr(href)}">🖼 ${escapeAttr(label)}</a>`
       },
     },
   })

--- a/src/renderer/src/components/shared/Markdown.svelte
+++ b/src/renderer/src/components/shared/Markdown.svelte
@@ -33,10 +33,64 @@
     },
   })
 
-  // On top of the default profile: no live CSS (the CSP allows inline styles) and
-  // no class/id — the app ships global Tailwind utilities, so an attacker-supplied
-  // class list could rebuild a full-viewport overlay out of our own tokens.
-  const SANITIZE_OPTS = { FORBID_TAGS: ['style'], FORBID_ATTR: ['style', 'class', 'id'] }
+  // Markdown-specific allowlist instead of DOMPurify's broad HTML profile:
+  // tracker/PR content is untrusted, and the default profile keeps enough HTML
+  // (dialog/form/button/input, SVG, presentational attributes) to build convincing
+  // fake UI inside a privileged window. Only text structure, code, tables, links,
+  // data:-URL images, and GFM task-list checkboxes survive. No style/class/id —
+  // global Tailwind utilities would make attacker-supplied classes a full-viewport
+  // overlay primitive.
+  const SANITIZE_OPTS = {
+    ALLOWED_TAGS: [
+      'a',
+      'p',
+      'br',
+      'hr',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'ul',
+      'ol',
+      'li',
+      'blockquote',
+      'pre',
+      'code',
+      'em',
+      'strong',
+      'b',
+      'i',
+      'u',
+      'del',
+      's',
+      'sup',
+      'sub',
+      'table',
+      'thead',
+      'tbody',
+      'tr',
+      'th',
+      'td',
+      'img',
+      'input',
+    ],
+    ALLOWED_ATTR: ['href', 'title', 'alt', 'src', 'align', 'start', 'type', 'checked', 'disabled'],
+  }
+
+  // Dedicated DOMPurify instance: the checkbox hook below must not leak into other
+  // DOMPurify consumers (the notes pipeline uses the shared default instance).
+  const purify = DOMPurify(window)
+  purify.addHook('uponSanitizeElement', (node) => {
+    // `input` is allowed solely for GFM task-list checkboxes — force every
+    // surviving input into that shape so raw HTML cannot render text/password
+    // fields inside the app.
+    if (node.nodeName === 'INPUT' && node instanceof HTMLInputElement) {
+      node.setAttribute('type', 'checkbox')
+      node.setAttribute('disabled', '')
+    }
+  })
 </script>
 
 <script lang="ts">
@@ -65,10 +119,10 @@
       .then(() => md.parse(raw))
       .then((parsed) => {
         if (gen !== parseGen) return
-        html = DOMPurify.sanitize(parsed, SANITIZE_OPTS)
+        html = purify.sanitize(parsed, SANITIZE_OPTS)
       })
       .catch(() => {
-        if (gen === parseGen) html = DOMPurify.sanitize(raw, SANITIZE_OPTS)
+        if (gen === parseGen) html = purify.sanitize(raw, SANITIZE_OPTS)
       })
   })
 </script>

--- a/src/renderer/src/components/taskTracker/AttachmentLightbox.svelte
+++ b/src/renderer/src/components/taskTracker/AttachmentLightbox.svelte
@@ -35,7 +35,12 @@
     previouslyFocused = document.activeElement as HTMLElement | null
     containerEl?.focus()
   })
-  onDestroy(() => previouslyFocused?.focus?.())
+  // Fallback restore only when the opener is still in the DOM — a lazily loaded
+  // preview may have replaced it, in which case the owner (TaskPanel) restores
+  // focus to the current trigger by attachment id.
+  onDestroy(() => {
+    if (previouslyFocused?.isConnected) previouslyFocused.focus?.()
+  })
 
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === 'Escape') {
@@ -50,10 +55,14 @@
       const first = focusable[0]
       const last = focusable[focusable.length - 1]
       const active = document.activeElement as HTMLElement | null
-      if (e.shiftKey && (active === first || !containerEl.contains(active))) {
+      // The container itself is focused on mount and sits OUTSIDE the button
+      // cycle — `containerEl.contains(containerEl)` is true, so it must be
+      // checked explicitly or the first Shift+Tab escapes into the underlay.
+      const outsideCycle = active === containerEl || !containerEl.contains(active)
+      if (e.shiftKey && (active === first || outsideCycle)) {
         e.preventDefault()
         last.focus()
-      } else if (!e.shiftKey && active === last) {
+      } else if (!e.shiftKey && (active === last || outsideCycle)) {
         e.preventDefault()
         first.focus()
       }

--- a/src/renderer/src/components/taskTracker/AttachmentLightbox.svelte
+++ b/src/renderer/src/components/taskTracker/AttachmentLightbox.svelte
@@ -11,6 +11,7 @@
     dataUrl,
     loading = false,
     saving = false,
+    error = '',
     onSave,
     onOpenExternal,
     onClose,
@@ -19,6 +20,9 @@
     dataUrl: string | null
     loading?: boolean
     saving?: boolean
+    /** Preview fetch failure — distinct from "not previewable" so the user knows
+     *  something broke and can retry via Save…/tracker. */
+    error?: string
     onSave: () => void
     onOpenExternal: () => void
     onClose: () => void
@@ -104,13 +108,21 @@
         <X size={14} />
       </button>
     </header>
-    <div class="flex-1 min-h-0 flex items-center justify-center p-3 overflow-auto">
+    <!-- aria-live: announce the loading → loaded/failed transition to screen readers. -->
+    <div
+      class="flex-1 min-h-0 flex items-center justify-center p-3 overflow-auto"
+      aria-live="polite"
+    >
       {#if dataUrl}
         <img src={dataUrl} alt={name} class="max-w-full max-h-[78vh] object-contain rounded-md" />
       {:else if loading}
         <div class="flex items-center gap-2 px-10 py-14 text-sm text-text-muted">
           <LoaderCircle size={15} class="animate-spin-slow motion-reduce:animate-none" />
           <span>Loading image…</span>
+        </div>
+      {:else if error}
+        <div class="px-10 py-14 text-sm text-danger-text">
+          Couldn’t load the preview: {error} — try “Save…” or open the tracker.
         </div>
       {:else}
         <div class="px-10 py-14 text-sm text-text-muted">

--- a/src/renderer/src/components/taskTracker/AttachmentLightbox.svelte
+++ b/src/renderer/src/components/taskTracker/AttachmentLightbox.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte'
+  import { Download, ExternalLink, LoaderCircle, X } from '@lucide/svelte'
+
+  // In-app viewer for task attachments: images render directly (data URL proxied
+  // through the authenticated tracker connection), everything else gets a save
+  // prompt. Both paths expose "save to disk" — opening the tracker in the browser
+  // is a secondary escape hatch, not the primary flow anymore.
+  let {
+    name,
+    dataUrl,
+    loading = false,
+    saving = false,
+    onSave,
+    onOpenExternal,
+    onClose,
+  }: {
+    name: string
+    dataUrl: string | null
+    loading?: boolean
+    saving?: boolean
+    onSave: () => void
+    onOpenExternal: () => void
+    onClose: () => void
+  } = $props()
+
+  let containerEl: HTMLDivElement | undefined = $state()
+  let previouslyFocused: HTMLElement | null = null
+
+  onMount(() => {
+    previouslyFocused = document.activeElement as HTMLElement | null
+    containerEl?.focus()
+  })
+  onDestroy(() => previouslyFocused?.focus?.())
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      e.stopPropagation()
+      onClose()
+      return
+    }
+    if (e.key === 'Tab' && containerEl) {
+      const focusable = containerEl.querySelectorAll<HTMLElement>('button:not([disabled])')
+      if (focusable.length === 0) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const active = document.activeElement as HTMLElement | null
+      if (e.shiftKey && (active === first || !containerEl.contains(active))) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="fixed inset-0 z-overlay flex items-center justify-center bg-scrim"
+  onkeydown={handleKeydown}
+  onmousedown={onClose}
+>
+  <div
+    bind:this={containerEl}
+    class="outline-none max-w-[90vw] max-h-[90vh] flex flex-col rounded-xl bg-bg-overlay border border-border shadow-modal overflow-hidden"
+    role="dialog"
+    aria-modal="true"
+    aria-label={name}
+    tabindex="-1"
+    onmousedown={(e) => e.stopPropagation()}
+  >
+    <header class="flex items-center gap-2 px-3 py-2 border-b border-border-subtle">
+      <span class="flex-1 min-w-0 text-sm text-text truncate" title={name}>{name}</span>
+      <button
+        class="inline-flex items-center gap-1.5 px-2 py-1 rounded-md border-0 bg-accent-bg text-accent-text text-xs font-inherit enabled:cursor-pointer enabled:hover:bg-accent-bg-hover disabled:opacity-50"
+        onclick={onSave}
+        disabled={saving}
+        title="Save this attachment to disk"
+      >
+        {#if saving}
+          <LoaderCircle size={12} class="animate-spin-slow motion-reduce:animate-none" />
+        {:else}
+          <Download size={12} />
+        {/if}
+        Save…
+      </button>
+      <button
+        class="inline-flex items-center justify-center size-6 p-0 rounded-md border-0 bg-transparent text-text-faint cursor-pointer hover:text-text hover:bg-hover"
+        onclick={onOpenExternal}
+        title="Open in tracker"
+        aria-label="Open in tracker"
+      >
+        <ExternalLink size={13} />
+      </button>
+      <button
+        class="inline-flex items-center justify-center size-6 p-0 rounded-md border-0 bg-transparent text-text-faint cursor-pointer hover:text-text hover:bg-hover"
+        onclick={onClose}
+        title="Close"
+        aria-label="Close"
+      >
+        <X size={14} />
+      </button>
+    </header>
+    <div class="flex-1 min-h-0 flex items-center justify-center p-3 overflow-auto">
+      {#if dataUrl}
+        <img src={dataUrl} alt={name} class="max-w-full max-h-[78vh] object-contain rounded-md" />
+      {:else if loading}
+        <div class="flex items-center gap-2 px-10 py-14 text-sm text-text-muted">
+          <LoaderCircle size={15} class="animate-spin-slow motion-reduce:animate-none" />
+          <span>Loading image…</span>
+        </div>
+      {:else}
+        <div class="px-10 py-14 text-sm text-text-muted">
+          No preview available — use “Save…” to download the file.
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/src/renderer/src/components/taskTracker/TaskPanel.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPanel.svelte
@@ -86,26 +86,33 @@
   // --- Attachment lightbox: view in-app, save to disk, tracker as escape hatch ---
   let lightboxAttachment = $state<Attachment | null>(null)
   let lightboxLoading = $state(false)
+  let lightboxError = $state('')
   let savingAttachment = $state(false)
 
   function openLightbox(a: Attachment): void {
     lightboxAttachment = a
+    lightboxError = ''
     const isImage = (a.mimeType ?? '').startsWith('image/')
-    if (isImage && !attachmentPreviews[a.id] && panel?.taskKey) {
-      lightboxLoading = true
-      const key = panel.taskKey
-      window.api
-        .trackerConfigAttachmentPreview(worktreePath, key, a.id, panelTrackerId)
-        .then((dataUrl) => {
-          if (dataUrl && lightboxAttachment?.id === a.id) {
-            attachmentPreviews = { ...attachmentPreviews, [a.id]: dataUrl }
-          }
-        })
-        .catch(() => {})
-        .finally(() => {
-          if (lightboxAttachment?.id === a.id) lightboxLoading = false
-        })
-    }
+    const key = panel?.taskKey
+    // Computed unconditionally — raising it only inside the branch leaked a stale
+    // `true` across attachments when a fetch was aborted by closing the lightbox.
+    const needsFetch = isImage && !attachmentPreviews[a.id] && !!key
+    lightboxLoading = needsFetch
+    if (!needsFetch || !key) return
+    window.api
+      .trackerConfigAttachmentPreview(worktreePath, key, a.id, panelTrackerId)
+      .then((dataUrl) => {
+        if (dataUrl && lightboxAttachment?.id === a.id) {
+          attachmentPreviews = { ...attachmentPreviews, [a.id]: dataUrl }
+        }
+      })
+      .catch((e) => {
+        // Distinct from "not previewable": the user should know the load broke.
+        if (lightboxAttachment?.id === a.id) lightboxError = ipcErrorMessage(e)
+      })
+      .finally(() => {
+        if (lightboxAttachment?.id === a.id) lightboxLoading = false
+      })
   }
 
   async function saveLightboxAttachment(): Promise<void> {
@@ -1011,6 +1018,7 @@
     dataUrl={attachmentPreviews[lightboxAttachment.id] ?? null}
     loading={lightboxLoading}
     saving={savingAttachment}
+    error={lightboxError}
     onSave={saveLightboxAttachment}
     onOpenExternal={() => lightboxAttachment && window.api.openExternal(lightboxAttachment.url)}
     onClose={() => (lightboxAttachment = null)}

--- a/src/renderer/src/components/taskTracker/TaskPanel.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPanel.svelte
@@ -30,6 +30,8 @@
   import { formatDateTime } from '../../lib/formatDate'
   import { getAiSessions, focusSessionByPtyId } from '../../lib/stores/tabs.svelte'
   import CustomSelect from '../shared/CustomSelect.svelte'
+  import Markdown from '../shared/Markdown.svelte'
+  import AttachmentLightbox from './AttachmentLightbox.svelte'
 
   // Task management panel for the worktree's backing task: change status (workflow-aware where the
   // tracker can introspect requirements — Jira; otherwise server errors are surfaced verbatim) and
@@ -80,6 +82,51 @@
   // The tracker that OWNS the panel task — with several trackers configured, defaulting to the
   // first one could read or mutate a same-key issue in the wrong external system.
   let panelTrackerId = $derived(panel?.connectionId || undefined)
+
+  // --- Attachment lightbox: view in-app, save to disk, tracker as escape hatch ---
+  let lightboxAttachment = $state<Attachment | null>(null)
+  let lightboxLoading = $state(false)
+  let savingAttachment = $state(false)
+
+  function openLightbox(a: Attachment): void {
+    lightboxAttachment = a
+    const isImage = (a.mimeType ?? '').startsWith('image/')
+    if (isImage && !attachmentPreviews[a.id] && panel?.taskKey) {
+      lightboxLoading = true
+      const key = panel.taskKey
+      window.api
+        .trackerConfigAttachmentPreview(worktreePath, key, a.id, panelTrackerId)
+        .then((dataUrl) => {
+          if (dataUrl && lightboxAttachment?.id === a.id) {
+            attachmentPreviews = { ...attachmentPreviews, [a.id]: dataUrl }
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          if (lightboxAttachment?.id === a.id) lightboxLoading = false
+        })
+    }
+  }
+
+  async function saveLightboxAttachment(): Promise<void> {
+    const a = lightboxAttachment
+    const key = panel?.taskKey
+    if (!a || !key || savingAttachment) return
+    savingAttachment = true
+    try {
+      const savedPath = await window.api.trackerConfigAttachmentSave(
+        worktreePath,
+        key,
+        a.id,
+        panelTrackerId,
+      )
+      if (savedPath) addToast(`Saved ${a.name} to ${savedPath}`)
+    } catch (e) {
+      addToast(`Could not save attachment: ${ipcErrorMessage(e)}`)
+    } finally {
+      savingAttachment = false
+    }
+  }
   let panelTasks = $derived(getPanelTasks())
   // Task resolution runs at the end of worktree hydration — until it lands for THIS worktree, the
   // store still holds the previous worktree's tasks. Show a loader instead of stale data.
@@ -695,12 +742,12 @@
       {#if task?.description}
         {#key task.description}
           <!-- Native resize handle: starts at content height (capped), then the user drags. -->
-          <p
+          <div
             use:initDescriptionHeight
-            class="m-0 mt-1 px-1.5 py-1 text-xs text-text-muted leading-snug whitespace-pre-wrap resize-y overflow-y-auto min-h-10 max-h-[70vh] rounded-md border border-transparent hover:border-border-subtle"
+            class="m-0 mt-1 px-1.5 py-1 text-xs text-text-muted leading-snug resize-y overflow-y-auto min-h-10 max-h-[70vh] rounded-md border border-transparent hover:border-border-subtle"
           >
-            {task.description}
-          </p>
+            <Markdown source={task.description} />
+          </div>
         {/key}
       {:else if !task && loading}
         <div class="flex items-center gap-1.5 mt-1 text-xs text-text-faint">
@@ -718,8 +765,8 @@
               {#if attachmentPreviews[a.id]}
                 <button
                   class="p-0 border-0 bg-transparent cursor-pointer rounded-md overflow-hidden"
-                  onclick={() => window.api.openExternal(a.url)}
-                  title={`${a.name} — open in tracker`}
+                  onclick={() => openLightbox(a)}
+                  title={`${a.name} — view`}
                 >
                   <img
                     src={attachmentPreviews[a.id]}
@@ -730,11 +777,11 @@
               {:else}
                 <button
                   class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md border border-border-subtle bg-active text-2xs text-text-secondary font-inherit cursor-pointer hover:border-accent-muted hover:text-accent-text"
-                  onclick={() => window.api.openExternal(a.url)}
-                  title={`${a.name} — open in tracker`}
+                  onclick={() => openLightbox(a)}
+                  title={`${a.name} — view / save`}
                 >
                   {#if (a.mimeType ?? '').startsWith('image/')}
-                    <LoaderCircle size={10} class="animate-spin" />
+                    <LoaderCircle size={10} class="animate-spin-slow motion-reduce:animate-none" />
                   {/if}
                   {a.name}
                 </button>
@@ -927,7 +974,7 @@
                 <Bot size={12} />
               </button>
             </div>
-            <p class="m-0 text-xs text-text leading-snug whitespace-pre-wrap">{comment.body}</p>
+            <Markdown source={comment.body} class="text-xs text-text leading-snug" />
             {#if composeTarget?.kind === 'comment' && composeTarget.id === comment.id}
               <div class="mt-1.5">
                 {@render composeBox()}
@@ -956,4 +1003,16 @@
       </div>
     {/if}
   </div>
+{/if}
+
+{#if lightboxAttachment}
+  <AttachmentLightbox
+    name={lightboxAttachment.name}
+    dataUrl={attachmentPreviews[lightboxAttachment.id] ?? null}
+    loading={lightboxLoading}
+    saving={savingAttachment}
+    onSave={saveLightboxAttachment}
+    onOpenExternal={() => lightboxAttachment && window.api.openExternal(lightboxAttachment.url)}
+    onClose={() => (lightboxAttachment = null)}
+  />
 {/if}

--- a/src/renderer/src/components/taskTracker/TaskPanel.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPanel.svelte
@@ -9,6 +9,7 @@
     Bot,
     ImagePlus,
     Image as ImageIcon,
+    AlertCircle,
     X,
   } from '@lucide/svelte'
   import { statusChipClass } from '../../lib/taskTracker/statusChip'
@@ -248,6 +249,11 @@
       attachments = []
       attachmentPreviews = {}
       thumbnailStates = {}
+      // The lightbox belongs to the task being cleared — leaving it open would
+      // address the NEW task's key with the OLD attachment id.
+      lightboxAttachment = null
+      lightboxLoading = false
+      lightboxError = ''
       void refresh(key)
     } else if (!key) {
       loadedForKey = ''
@@ -257,6 +263,9 @@
       attachments = []
       attachmentPreviews = {}
       thumbnailStates = {}
+      lightboxAttachment = null
+      lightboxLoading = false
+      lightboxError = ''
     }
   })
 
@@ -288,7 +297,6 @@
         comments = []
         attachments = []
         attachmentPreviews = {}
-        thumbnailStates = {}
         thumbnailStates = {}
         return
       }
@@ -334,6 +342,7 @@
         url: a.url,
       }))
       attachmentPreviews = {}
+      thumbnailStates = {}
       // Thumbnails for image attachments (bounded — huge tasks shouldn't fire dozens of
       // authenticated downloads). Loading state is tracked per id: images beyond the
       // prefetch limit and failed fetches must render as plain files, not as an
@@ -821,10 +830,14 @@
                   class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md border border-border-subtle bg-active text-2xs text-text-secondary font-inherit cursor-pointer hover:border-accent-muted hover:text-accent-text"
                   data-attachment-trigger={a.id}
                   onclick={() => openLightbox(a)}
-                  title={`${a.name} — view / save`}
+                  title={thumbnailStates[a.id] === 'failed'
+                    ? `${a.name} — thumbnail failed to load; view / save`
+                    : `${a.name} — view / save`}
                 >
                   {#if thumbnailStates[a.id] === 'loading'}
                     <LoaderCircle size={10} class="animate-spin-slow motion-reduce:animate-none" />
+                  {:else if thumbnailStates[a.id] === 'failed'}
+                    <AlertCircle size={10} class="text-warning-text" />
                   {:else if (a.mimeType ?? '').startsWith('image/')}
                     <ImageIcon size={10} />
                   {/if}

--- a/src/renderer/src/components/taskTracker/TaskPanel.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPanel.svelte
@@ -822,28 +822,30 @@
           </span>
           <div class="flex flex-wrap items-start gap-1.5">
             {#each attachments as a (a.id)}
-              {#if attachmentPreviews[a.id]}
-                <button
-                  class="p-0 border-0 bg-transparent cursor-pointer rounded-md overflow-hidden"
-                  data-attachment-trigger={a.id}
-                  onclick={() => openLightbox(a)}
-                  title={`${a.name} — view`}
-                >
+              <!-- ONE persistent trigger element per attachment: an independently
+                   resolving thumbnail prefetch must swap this button's CONTENT,
+                   not the node itself — replacing a focused element (e.g. right
+                   after the lightbox restored focus here) drops keyboard focus
+                   back to the document. -->
+              <button
+                class={attachmentPreviews[a.id]
+                  ? 'p-0 border-0 bg-transparent cursor-pointer rounded-md overflow-hidden'
+                  : 'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md border border-border-subtle bg-active text-2xs text-text-secondary font-inherit cursor-pointer hover:border-accent-muted hover:text-accent-text'}
+                data-attachment-trigger={a.id}
+                onclick={() => openLightbox(a)}
+                title={attachmentPreviews[a.id]
+                  ? `${a.name} — view`
+                  : thumbnailStates[a.id] === 'failed'
+                    ? `${a.name} — thumbnail failed to load; view / save`
+                    : `${a.name} — view / save`}
+              >
+                {#if attachmentPreviews[a.id]}
                   <img
                     src={attachmentPreviews[a.id]}
                     alt={a.name}
                     class="h-16 max-w-44 object-contain rounded-md border border-border-subtle bg-bg-input hover:border-accent-muted"
                   />
-                </button>
-              {:else}
-                <button
-                  class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md border border-border-subtle bg-active text-2xs text-text-secondary font-inherit cursor-pointer hover:border-accent-muted hover:text-accent-text"
-                  data-attachment-trigger={a.id}
-                  onclick={() => openLightbox(a)}
-                  title={thumbnailStates[a.id] === 'failed'
-                    ? `${a.name} — thumbnail failed to load; view / save`
-                    : `${a.name} — view / save`}
-                >
+                {:else}
                   {#if thumbnailStates[a.id] === 'loading'}
                     <LoaderCircle size={10} class="animate-spin-slow motion-reduce:animate-none" />
                   {:else if thumbnailStates[a.id] === 'failed'}
@@ -852,8 +854,8 @@
                     <ImageIcon size={10} />
                   {/if}
                   {a.name}
-                </button>
-              {/if}
+                {/if}
+              </button>
             {/each}
           </div>
         </div>

--- a/src/renderer/src/components/taskTracker/TaskPanel.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPanel.svelte
@@ -8,6 +8,7 @@
     LoaderCircle,
     Bot,
     ImagePlus,
+    Image as ImageIcon,
     X,
   } from '@lucide/svelte'
   import { statusChipClass } from '../../lib/taskTracker/statusChip'
@@ -117,6 +118,21 @@
       })
   }
 
+  function closeLightbox(): void {
+    const id = lightboxAttachment?.id
+    lightboxAttachment = null
+    // Restore focus by attachment id: a lazily loaded preview replaces the chip
+    // button with the thumbnail button, so the element focused at open time may be
+    // a detached node by now.
+    if (id) {
+      requestAnimationFrame(() => {
+        document
+          .querySelector<HTMLElement>(`[data-attachment-trigger="${CSS.escape(id)}"]`)
+          ?.focus()
+      })
+    }
+  }
+
   async function saveLightboxAttachment(): Promise<void> {
     const a = lightboxAttachment
     const key = panel?.taskKey
@@ -160,6 +176,9 @@
   let attachments = $state<Attachment[]>([])
   // Attachment id → data: URL (CSP allows img-src data:, not blob:/file:). Loaded lazily.
   let attachmentPreviews = $state<Record<string, string>>({})
+  // Per-attachment thumbnail fetch state: absent = no request ran (beyond the
+  // prefetch limit), 'loading' = in flight, 'failed' = request errored.
+  let thumbnailStates = $state<Record<string, 'loading' | 'failed'>>({})
   let loading = $state(false)
   let loadError = $state('')
   // The tracker answered but doesn't know this key — the task was deleted (or became invisible).
@@ -228,6 +247,7 @@
       comments = []
       attachments = []
       attachmentPreviews = {}
+      thumbnailStates = {}
       void refresh(key)
     } else if (!key) {
       loadedForKey = ''
@@ -236,6 +256,7 @@
       comments = []
       attachments = []
       attachmentPreviews = {}
+      thumbnailStates = {}
     }
   })
 
@@ -267,6 +288,8 @@
         comments = []
         attachments = []
         attachmentPreviews = {}
+        thumbnailStates = {}
+        thumbnailStates = {}
         return
       }
       const [trans, comm, atts] = await Promise.all([
@@ -312,16 +335,25 @@
       }))
       attachmentPreviews = {}
       // Thumbnails for image attachments (bounded — huge tasks shouldn't fire dozens of
-      // authenticated downloads).
+      // authenticated downloads). Loading state is tracked per id: images beyond the
+      // prefetch limit and failed fetches must render as plain files, not as an
+      // eternal spinner for a request that isn't running.
       for (const a of attachments
         .filter((a) => (a.mimeType ?? '').startsWith('image/'))
         .slice(0, 6)) {
+        thumbnailStates = { ...thumbnailStates, [a.id]: 'loading' }
         void window.api
           .trackerConfigAttachmentPreview(worktreePath, taskKey, a.id, panelTrackerId)
           .then((dataUrl) => {
-            if (seq === refreshSeq) attachmentPreviews = { ...attachmentPreviews, [a.id]: dataUrl }
+            if (seq !== refreshSeq) return
+            attachmentPreviews = { ...attachmentPreviews, [a.id]: dataUrl }
+            const rest = { ...thumbnailStates }
+            delete rest[a.id]
+            thumbnailStates = rest
           })
-          .catch(() => {})
+          .catch(() => {
+            if (seq === refreshSeq) thumbnailStates = { ...thumbnailStates, [a.id]: 'failed' }
+          })
       }
     } catch (e) {
       if (seq !== refreshSeq) return
@@ -774,6 +806,7 @@
               {#if attachmentPreviews[a.id]}
                 <button
                   class="p-0 border-0 bg-transparent cursor-pointer rounded-md overflow-hidden"
+                  data-attachment-trigger={a.id}
                   onclick={() => openLightbox(a)}
                   title={`${a.name} — view`}
                 >
@@ -786,11 +819,14 @@
               {:else}
                 <button
                   class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md border border-border-subtle bg-active text-2xs text-text-secondary font-inherit cursor-pointer hover:border-accent-muted hover:text-accent-text"
+                  data-attachment-trigger={a.id}
                   onclick={() => openLightbox(a)}
                   title={`${a.name} — view / save`}
                 >
-                  {#if (a.mimeType ?? '').startsWith('image/')}
+                  {#if thumbnailStates[a.id] === 'loading'}
                     <LoaderCircle size={10} class="animate-spin-slow motion-reduce:animate-none" />
+                  {:else if (a.mimeType ?? '').startsWith('image/')}
+                    <ImageIcon size={10} />
                   {/if}
                   {a.name}
                 </button>
@@ -1023,6 +1059,6 @@
     error={lightboxError}
     onSave={saveLightboxAttachment}
     onOpenExternal={() => lightboxAttachment && window.api.openExternal(lightboxAttachment.url)}
-    onClose={() => (lightboxAttachment = null)}
+    onClose={closeLightbox}
   />
 {/if}

--- a/src/renderer/src/components/taskTracker/TaskPanel.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPanel.svelte
@@ -87,7 +87,9 @@
   let lightboxAttachment = $state<Attachment | null>(null)
   let lightboxLoading = $state(false)
   let lightboxError = $state('')
-  let savingAttachment = $state(false)
+  // Keyed by attachment id — the post-dialog download is not window-modal, so a
+  // single flag would lock attachment B's Save behind A's still-running download.
+  let savingAttachmentId = $state<string | null>(null)
 
   function openLightbox(a: Attachment): void {
     lightboxAttachment = a
@@ -118,8 +120,8 @@
   async function saveLightboxAttachment(): Promise<void> {
     const a = lightboxAttachment
     const key = panel?.taskKey
-    if (!a || !key || savingAttachment) return
-    savingAttachment = true
+    if (!a || !key || savingAttachmentId === a.id) return
+    savingAttachmentId = a.id
     try {
       const savedPath = await window.api.trackerConfigAttachmentSave(
         worktreePath,
@@ -131,7 +133,7 @@
     } catch (e) {
       addToast(`Could not save attachment: ${ipcErrorMessage(e)}`)
     } finally {
-      savingAttachment = false
+      if (savingAttachmentId === a.id) savingAttachmentId = null
     }
   }
   let panelTasks = $derived(getPanelTasks())
@@ -1017,7 +1019,7 @@
     name={lightboxAttachment.name}
     dataUrl={attachmentPreviews[lightboxAttachment.id] ?? null}
     loading={lightboxLoading}
-    saving={savingAttachment}
+    saving={savingAttachmentId === lightboxAttachment.id}
     error={lightboxError}
     onSave={saveLightboxAttachment}
     onOpenExternal={() => lightboxAttachment && window.api.openExternal(lightboxAttachment.url)}

--- a/src/renderer/src/components/taskTracker/TaskPanel.svelte
+++ b/src/renderer/src/components/taskTracker/TaskPanel.svelte
@@ -92,10 +92,17 @@
   // Keyed by attachment id — the post-dialog download is not window-modal, so a
   // single flag would lock attachment B's Save behind A's still-running download.
   let savingAttachmentId = $state<string | null>(null)
+  // Monotonic token for preview requests: the attachment id alone is not a
+  // request-generation guard (close + reopen of the SAME attachment, or an id
+  // reused across tasks/providers, would let a stale request's catch/finally
+  // clobber the newer request's state). Bumped on every open, close, and panel
+  // reset — handlers only apply when their captured token is still current.
+  let previewSeq = 0
 
   function openLightbox(a: Attachment): void {
     lightboxAttachment = a
     lightboxError = ''
+    const token = ++previewSeq
     const isImage = (a.mimeType ?? '').startsWith('image/')
     const key = panel?.taskKey
     // Computed unconditionally — raising it only inside the branch leaked a stale
@@ -106,21 +113,22 @@
     window.api
       .trackerConfigAttachmentPreview(worktreePath, key, a.id, panelTrackerId)
       .then((dataUrl) => {
-        if (dataUrl && lightboxAttachment?.id === a.id) {
+        if (dataUrl && token === previewSeq) {
           attachmentPreviews = { ...attachmentPreviews, [a.id]: dataUrl }
         }
       })
       .catch((e) => {
         // Distinct from "not previewable": the user should know the load broke.
-        if (lightboxAttachment?.id === a.id) lightboxError = ipcErrorMessage(e)
+        if (token === previewSeq) lightboxError = ipcErrorMessage(e)
       })
       .finally(() => {
-        if (lightboxAttachment?.id === a.id) lightboxLoading = false
+        if (token === previewSeq) lightboxLoading = false
       })
   }
 
   function closeLightbox(): void {
     const id = lightboxAttachment?.id
+    previewSeq++
     lightboxAttachment = null
     // Restore focus by attachment id: a lazily loaded preview replaces the chip
     // button with the thumbnail button, so the element focused at open time may be
@@ -251,6 +259,7 @@
       thumbnailStates = {}
       // The lightbox belongs to the task being cleared — leaving it open would
       // address the NEW task's key with the OLD attachment id.
+      previewSeq++
       lightboxAttachment = null
       lightboxLoading = false
       lightboxError = ''
@@ -263,6 +272,7 @@
       attachments = []
       attachmentPreviews = {}
       thumbnailStates = {}
+      previewSeq++
       lightboxAttachment = null
       lightboxLoading = false
       lightboxError = ''


### PR DESCRIPTION
## What

Two UX fixes reported from live usage:

- **Markdown rendered everywhere through one component.** New `shared/Markdown.svelte` — sanitized (marked + DOMPurify, GFM with newline-as-break) with self-contained typography (headings, lists, code, tables, blockquotes, task-list checkboxes) scaled by the consumer's text-size class. Converted call sites:
  - task description and comments in the Task panel (previously raw `whitespace-pre-wrap` text),
  - PR body in the PR details modal (same),
  - changelog entries and the About license (previously per-dialog `marked` + `DOMPurify` pipelines — now deduplicated).
  The notes pane keeps its contenteditable preview — it is an editor with its own input/paste handling, not a display surface. Link clicks stay safe with no local handling: the main process blocks top-level navigation and routes safe external URLs to the OS browser.
- **Task attachments open in-app instead of the external browser.** Clicking an attachment opens a focus-trapped lightbox (Esc/backdrop close): images render directly from the authenticated proxy (fetched on demand when the thumbnail preview has not loaded yet), non-images show a save hint. **Save…** to disk is the primary action; open-in-tracker is demoted to an icon.
- New `taskTracker:attachmentSave` IPC mirrors the hardened `attachmentPreview` addressing: the renderer supplies only task key + attachment id, provider metadata decides URL and filename; the native save dialog is shown before any download and the suggested filename is sanitized of path-like characters.

## Why

Task descriptions, comments, and PR bodies displayed raw markdown markup; three dialogs each had their own parse pipeline. Attachments could only be opened in an external browser with no way to save them from Canopy.

## How to test

1. `npm run dev`, open a worktree linked to a tracker task with a markdown description/comments → both render formatted (headers, lists, code).
2. GIT section → View PR → the description renders as markdown.
3. Task panel → click an image attachment → in-app lightbox; **Save…** writes the file where you choose; the external-link icon still opens the tracker. Click a non-image attachment → same dialog with the save hint.
4. Help → About and the post-update changelog still render correctly (now through the shared component).
5. `npm test` (105 tests), `npm run build`, `npm run lint`.

## Checklist

- [x] No secrets, tokens, or credentials logged or stored in plaintext
- [ ] Non-core feature is behind a feature flag (off by default) — n/a, UI fix of existing features
- [x] Cross-platform: no hardcoded OS-specific labels, paths, or shell commands
- [x] Keyboard accessible (lightbox: focus trap, Escape, labelled buttons)
- [x] IPC follows `feature:action` naming and uses `invoke`/`handle`
- [x] Renderer code does not import Node.js modules directly
- [x] Feature docs in `docs/` updated (`docs/integrations/task-tracker.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)